### PR TITLE
Delay questing instead of disabling it

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -571,10 +571,9 @@ function gotoPage(page,inArgs,delay = -1)
             }
             else if (togoto.includes("world"))
             {
-                logHHAuto("All quests finished, turning off AutoQuest!");
-                setStoredValue("HHAuto_Setting_autoQuest", false);
-                //setStoredValue("HHAuto_Setting_autoSideQuest", false);
-                location.reload();
+                logHHAuto("All quests finished, setting timer to check back later!");
+                setTimer('nextMainQuestAttempt', 604800); // 1 week delay
+                gotoPage(getHHScriptVars("pagesIDHome"));
                 return false;
             }
             logHHAuto("Current quest page: "+togoto);
@@ -690,9 +689,9 @@ var proceedQuest = function () {
             gotoPage(quests.attr('href'));
         }
         else {
-            logHHAuto("All quests finished, turning off AutoQuest!");
-            setStoredValue("HHAuto_Setting_autoQuest", false);
-            setStoredValue("HHAuto_Setting_autoSideQuest", false);
+            logHHAuto("All quests finished, setting timer to check back later!");
+            if (checkTimer('nextMainQuestAttempt')) {setTimer('nextMainQuestAttempt', 604800);} // 1 week delay
+            setTimer('nextSideQuestAttempt', 604800); // 1 week delay
             location.reload();
         }
         return;
@@ -7331,11 +7330,14 @@ var autoLoop = function ()
             }
             else if(questRequirement === "none")
             {
-                if (Number(getHHVars('Hero.energies.quest.amount')) > Number(getStoredValue("HHAuto_Setting_autoQuestThreshold")) || Number(checkParanoiaSpendings('quest')) > 0 )
+                if (checkTimer('nextMainQuestAttempt') && checkTimer('nextSideQuestAttempt'))
                 {
-                    //logHHAuto("NONE req.");
-                    busy = true;
-                    proceedQuest();
+                    if (Number(getHHVars('Hero.energies.quest.amount')) > Number(getStoredValue("HHAuto_Setting_autoQuestThreshold")) || Number(checkParanoiaSpendings('quest')) > 0 )
+                    {
+                        //logHHAuto("NONE req.");
+                        busy = true;
+                        proceedQuest();
+                    }    
                 }
             }
             else


### PR DESCRIPTION
This change implements timers for the Main and Side quests. Instead of disabling those functions when there are no quests to perform, a timer is set for 1 week, after which the script will be able to check again to see if there are new quests.

The logic around how questing is approached feels a little convoluted, so this will likely require some testing to be sure there are no negative impacts.