### PR TITLE
Fix seasonal event collection looping

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -3962,9 +3962,19 @@ function goAndCollectSeasonalEvent()
     }
     else
     {
-        logHHAuto("Switching to SeasonalEvent screen.");
-        gotoPage(getHHScriptVars("pagesIDSeasonalEvent"));
-        return true;
+        // If we return here within the 60 second timer set below, assume something is wrong
+        if (checkTimer('trySeasonalEventPage'))
+        {
+            logHHAuto("Switching to SeasonalEvent screen.");
+            setTimer('trySeasonalEventPage', 60) 
+            gotoPage(getHHScriptVars("pagesIDSeasonalEvent"));    
+            return true;
+        } else {
+            logHHAuto("Switching to SeasonalEvent screen failed, will retry later.")
+            setTimer('nextSeasonalEventCollectTime', 86400) // 1 day
+            gotoPage(getHHScriptVars('pagesIDHome'));
+            return true;
+        }
     }
 }
 


### PR DESCRIPTION
This should stop the script from getting into a loop if a seasonal event has ended and the reward collection page is no longer available.