### PR TITLE
Prevent pachinko auto play from using epic draft orbs

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1856,7 +1856,7 @@ function modulePachinko()
                     document.getElementById("PachinkoError").innerText=getTextForUI("PachinkoNoGirls","elementText");
                 }
             }
-            let pachinkoSelectedButton= $(buttonSelector);
+            let pachinkoSelectedButton= $(buttonSelector)[0];
             let rewardQuery="div#rewards_popup button.blue_button_L";
             if ($(rewardQuery).length >0 )
             {


### PR DESCRIPTION
Right it you have draft orbs for epic pachinko, those will be used along 1-game orbs. This small change prevents that by only calling `.click()` on the first element returned by the selector