### PR TITLE
Update timers champions and league #1046

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "6.14.1",
+  "version": "6.15.0",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Helper/HHMenuHelper.js
+++ b/src/Helper/HHMenuHelper.js
@@ -566,6 +566,7 @@ export function getMenu() {
                             + hhMenuSwitch('autoClubForceStart')
                             + hhMenuInputWithImg('autoClubChampMax', HHAuto_inputPattern.autoClubChampMax, 'text-align:center; width:45px', 'pictures/design/champion_ticket.png', 'numeric')
                             + hhMenuSwitch('showClubButtonInPoa')
+                            + hhMenuSwitch('autoChampAlignTimer')
                         +`</div>`
                         +`<div class="internalOptionsRow separator">`
                             + hhMenuInput('autoChampsTeamLoop', HHAuto_inputPattern.autoChampsTeamLoop, 'text-align:center; width:25px', '', 'numeric')

--- a/src/Module/League.js
+++ b/src/Module/League.js
@@ -198,6 +198,7 @@ export class LeagueHelper {
         const league_end = LeagueHelper.getLeagueEndTime();
         if (league_end > 0 && league_end <= (60*60)) {
             // Last league hour //TODO
+            logHHAuto("Last League hour");
         }
         const energyAboveThreshold = humanLikeRun && LeagueHelper.getEnergy() > threshold || LeagueHelper.getEnergy() > Math.max(threshold, runThreshold-1);
         const paranoiaSpending = LeagueHelper.getEnergy() > 0 && Number(checkParanoiaSpendings('challenge')) > 0;
@@ -551,10 +552,12 @@ export class LeagueHelper {
                     gotoPage(getHHScriptVars("pagesIDLeaderboard"))
                 }
             }
-            //logHHAuto('ls! '+$('h4.leagues').length);
-            //$('h4.leagues').each(function(){this.click();}); // ???
 
-            if(currentPower < 1)
+            logHHAuto('parsing enemies');
+            var Data=LeagueHelper.getLeagueOpponentListData();
+            const league_end = LeagueHelper.getLeagueEndTime();
+
+            if(currentPower < 1 && Data.length > 0)
             {
                 logHHAuto("No power for leagues.");
                 //prevent paranoia to wait for league
@@ -564,14 +567,12 @@ export class LeagueHelper {
                 return;
             }
 
-            logHHAuto('parsing enemies');
-            var Data=LeagueHelper.getLeagueOpponentListData();
             if (Data.length==0)
             {
-                logHHAuto('No valid targets!');
+                logHHAuto('No valid targets! Set timer to league ends.');
                 //prevent paranoia to wait for league
                 setStoredValue(HHStoredVarPrefixKey+"Temp_paranoiaLeagueBlocked", "true");
-                setTimer('nextLeaguesTime', randomInterval(35*60, 40*60));
+                setTimer('nextLeaguesTime', randomInterval(league_end - 5*60, league_end));
             }
             else
             {
@@ -618,16 +619,15 @@ export class LeagueHelper {
                     logHHAuto("Current league above target ("+Number(getPlayerCurrentLevel)+"/"+leagueTargetValue+"), needs to demote. Score should not be higher than : "+maxDemote);
                     if ( currentScore + leagueScoreSecurityThreshold >= maxDemote )
                     {
-                        let league_end = LeagueHelper.getLeagueEndTime();
                         if (league_end <= (60*60)) {
                             logHHAuto("Can't do league as could go above demote, as last hour setting timer to 5 mins"); 
                             setTimer('nextLeaguesTime', randomInterval(5*60, 8*60));
                         } else {
                             logHHAuto("Can't do league as could go above demote, setting timer to 30 mins");
                             setTimer('nextLeaguesTime', randomInterval(30*60, 35*60));
-                            //prevent paranoia to wait for league
-                            setStoredValue(HHStoredVarPrefixKey+"Temp_paranoiaLeagueBlocked", "true");
                         }
+                        //prevent paranoia to wait for league
+                        setStoredValue(HHStoredVarPrefixKey+"Temp_paranoiaLeagueBlocked", "true");
                         gotoPage(getHHScriptVars("pagesIDHome"));
                         return;
                     }
@@ -757,4 +757,3 @@ export class LeagueHelper {
         LeagueHelper.LeagueDisplayGetOpponentPopup(numberDone,remainingTime);
     }
 }
-unsafeWindow.LeagueHelper = LeagueHelper;

--- a/src/Service/AutoLoop.js
+++ b/src/Service/AutoLoop.js
@@ -1058,6 +1058,8 @@ export function autoLoop()
             break;
         case getHHScriptVars("pagesIDClubChampion"):
             Champion.moduleSimChampions();
+            ClubChampion.resetTimerIfNeeded = callItOnce(ClubChampion.resetTimerIfNeeded);
+            ClubChampion.resetTimerIfNeeded();
             break;
         case getHHScriptVars("pagesIDQuest"):
             const haremItem = getStoredValue(HHStoredVarPrefixKey+"Temp_haremGirlActions");
@@ -1069,9 +1071,6 @@ export function autoLoop()
             break;
         case getHHScriptVars("pagesIDClub"):
             Club.run();
-            // if (!checkTimer('nextClubChampionTime') && getNextClubChampionTimer() == -1) {
-            //     updateClubChampionTimer();
-            // }
             break;
     }
 

--- a/src/config/HHStoredVars.js
+++ b/src/config/HHStoredVars.js
@@ -80,6 +80,17 @@ HHStoredVars[HHStoredVarPrefixKey+"Setting_autoChamps"] =
         clearTimer('nextChampionTime');
     }
 };
+HHStoredVars[HHStoredVarPrefixKey+"Setting_autoChampAlignTimer"] =
+    {
+    default:"false",
+    storage:"Storage()",
+    HHType:"Setting",
+    valueType:"Boolean",
+    getMenu:true,
+    setMenu:true,
+    menuType:"checked",
+    kobanUsing:false
+};
 HHStoredVars[HHStoredVarPrefixKey+"Setting_autoChampsForceStart"] =
     {
     default:"false",
@@ -174,7 +185,11 @@ HHStoredVars[HHStoredVarPrefixKey+"Setting_autoClubChamp"] =
     getMenu:true,
     setMenu:true,
     menuType:"checked",
-    kobanUsing:false
+    kobanUsing:false,
+    newValueFunction:function()
+    {
+        clearTimer('nextClubChampionTime');
+    }
 };
 HHStoredVars[HHStoredVarPrefixKey+"Setting_autoClubChampMax"] =
     {
@@ -196,7 +211,11 @@ HHStoredVars[HHStoredVarPrefixKey+"Setting_autoClubForceStart"] =
     getMenu:true,
     setMenu:true,
     menuType:"checked",
-    kobanUsing:false
+    kobanUsing:false,
+    newValueFunction:function()
+    {
+        clearTimer('nextClubChampionTime');
+    }
 };
 HHStoredVars[HHStoredVarPrefixKey+"Setting_autoContest"] =
     {
@@ -262,7 +281,11 @@ HHStoredVars[HHStoredVarPrefixKey+"Setting_autoLeagues"] =
     getMenu:true,
     setMenu:true,
     menuType:"checked",
-    kobanUsing:false
+    kobanUsing:false,
+    newValueFunction:function()
+    {
+        clearTimer('nextLeaguesTime');
+    }
 };
 HHStoredVars[HHStoredVarPrefixKey+"Setting_autoLeaguesAllowWinCurrent"] =
     {

--- a/src/i18n/en.js
+++ b/src/i18n/en.js
@@ -91,6 +91,7 @@ HHAuto_ToolTips.en.compactPowerPlace = { version: "5.24.0", elementText: "Compac
 HHAuto_ToolTips.en.autoChampsTitle = { version: "5.6.24", elementText: "Champions"};
 HHAuto_ToolTips.en.autoChamps = { version: "5.6.24", elementText: "Normal", tooltip: "if enabled : Automatically do champions (if they are started and in filter only)"};
 HHAuto_ToolTips.en.autoChampsForceStart = { version: "5.6.76", elementText: "Force start", tooltip: "if enabled : will fight filtered champions even if not started."};
+HHAuto_ToolTips.en.autoChampAlignTimer = { version: "6.15.0", elementText: "Align timers", tooltip: "if enabled : will align champion and club champion timers."};
 HHAuto_ToolTips.en.autoChampsUseEne = { version: "5.39.0", elementText: "Buy tickets", tooltip: "If enabled : use Energy to buy tickets respecting the energy quest threshold"};
 HHAuto_ToolTips.en.autoChampsFilter = { version: "5.6.24", elementText: "Filter", tooltip: "(values separated by ; 1 to 6)<br>Allow to set filter on champions to be fought"};
 HHAuto_ToolTips.en.autoChampsTeamLoop = { version: "5.21.0", elementText: "Auto team Loops", tooltip: "Number of loop to search for champion team for every button click"};


### PR DESCRIPTION
- New option to align champions timer
- Reset club timer when deactivating auto club
- Set both champion timers to 1h when no tickets
- Reset to 30s club timer on club champion page when fight button displayed set club timer to girl rest time when script goes to fight it too soon
- When no more fight available in league, set timer to league ends Reset league timer when deactivating auto league
- Fix league paranoia loop