### PR TITLE
Add BDSMHelper and TimerHelper test suites (57 tests)

### DIFF
--- a/spec/Helper/BDSMHelper.spec.ts
+++ b/spec/Helper/BDSMHelper.spec.ts
@@ -1,0 +1,342 @@
+import {
+    BDSMHelper,
+    calculateDominationBonuses,
+    calculateCritChanceShare,
+    getSkillPercentage,
+    calculateBattleProbabilities,
+} from '../../src/Helper/BDSMHelper';
+import { BDSMPlayer } from '../../src/model/BDSMPlayer';
+
+jest.mock('../../src/Utils/LogUtils', () => ({
+    logHHAuto: jest.fn(),
+}));
+
+jest.mock('../../src/config/index', () => ({
+    HHStoredVarPrefixKey: 'HHAuto_',
+    HHStoredVars: {},
+    SK: {},
+    TK: {},
+}));
+
+jest.mock('../../src/Helper/StorageHelper', () => ({
+    getStoredJSON: jest.fn(),
+    setStoredValue: jest.fn(),
+}));
+
+jest.mock('../../src/Helper/ConfigHelper', () => ({
+    ConfigHelper: {
+        getHHScriptVars: jest.fn(),
+    },
+}));
+
+describe('BDSMHelper', () => {
+
+    describe('ELEMENTS', () => {
+        it('should have egoDamage lookup with 5 element matchups', () => {
+            const ego = BDSMHelper.ELEMENTS.egoDamage;
+            expect(ego.fire).toBe('nature');
+            expect(ego.nature).toBe('stone');
+            expect(ego.stone).toBe('sun');
+            expect(ego.sun).toBe('water');
+            expect(ego.water).toBe('fire');
+            expect(Object.keys(ego)).toHaveLength(5);
+        });
+
+        it('should have chance lookup with 3 element matchups', () => {
+            const chance = BDSMHelper.ELEMENTS.chance;
+            expect(chance.darkness).toBe('light');
+            expect(chance.light).toBe('psychic');
+            expect(chance.psychic).toBe('darkness');
+            expect(Object.keys(chance)).toHaveLength(3);
+        });
+    });
+
+    describe('fightBonues', () => {
+        it('should extract synergy multipliers from team object', () => {
+            const team = {
+                synergies: [
+                    { element: { type: 'fire' }, bonus_multiplier: 0.35 },
+                    { element: { type: 'stone' }, bonus_multiplier: 0.07 },
+                    { element: { type: 'sun' }, bonus_multiplier: 0.08 },
+                    { element: { type: 'water' }, bonus_multiplier: 0.12 },
+                ],
+            };
+            const result = BDSMHelper.fightBonues(team);
+            expect(result.critDamage).toBe(0.35);
+            expect(result.critChance).toBe(0.07);
+            expect(result.defReduce).toBe(0.08);
+            expect(result.healOnHit).toBe(0.12);
+        });
+
+        it('should handle zero multipliers', () => {
+            const team = {
+                synergies: [
+                    { element: { type: 'fire' }, bonus_multiplier: 0 },
+                    { element: { type: 'stone' }, bonus_multiplier: 0 },
+                    { element: { type: 'sun' }, bonus_multiplier: 0 },
+                    { element: { type: 'water' }, bonus_multiplier: 0 },
+                ],
+            };
+            const result = BDSMHelper.fightBonues(team);
+            expect(result.critDamage).toBe(0);
+            expect(result.critChance).toBe(0);
+            expect(result.defReduce).toBe(0);
+            expect(result.healOnHit).toBe(0);
+        });
+    });
+
+    describe('calculateDominationBonuses', () => {
+        it('should return zero bonuses when there is no overlap', () => {
+            const player = ['fire', 'stone'];
+            const opponent = ['darkness', 'light'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            expect(result.player.ego).toBe(0);
+            expect(result.player.attack).toBe(0);
+            expect(result.player.chance).toBe(0);
+            expect(result.opponent.ego).toBe(0);
+            expect(result.opponent.attack).toBe(0);
+            expect(result.opponent.chance).toBe(0);
+        });
+
+        it('should grant ego and attack bonus for a single egoDamage match', () => {
+            // fire beats nature
+            const player = ['fire'];
+            const opponent = ['nature'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            expect(result.player.ego).toBeCloseTo(0.1);
+            expect(result.player.attack).toBeCloseTo(0.1);
+            expect(result.player.chance).toBe(0);
+            // nature beats stone, but opponent has no stone to beat
+            expect(result.opponent.ego).toBe(0);
+        });
+
+        it('should grant chance bonus for a single chance match', () => {
+            // darkness beats light
+            const player = ['darkness'];
+            const opponent = ['light'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            expect(result.player.chance).toBeCloseTo(0.2);
+            expect(result.player.ego).toBe(0);
+            expect(result.player.attack).toBe(0);
+        });
+
+        it('should accumulate bonuses for multiple matches', () => {
+            // fire beats nature, stone beats sun
+            const player = ['fire', 'stone'];
+            const opponent = ['nature', 'sun'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            expect(result.player.ego).toBeCloseTo(0.2);
+            expect(result.player.attack).toBeCloseTo(0.2);
+        });
+
+        it('should calculate bonuses for both sides symmetrically', () => {
+            // fire beats nature (player advantage), nature beats stone (opponent advantage)
+            const player = ['fire', 'sun'];
+            const opponent = ['nature', 'water'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            // player: fire > nature -> +0.1 ego/atk, sun > water -> +0.1 ego/atk
+            expect(result.player.ego).toBeCloseTo(0.2);
+            expect(result.player.attack).toBeCloseTo(0.2);
+            // opponent: nature > stone? no stone in player. water > fire -> +0.1 ego/atk
+            expect(result.opponent.ego).toBeCloseTo(0.1);
+            expect(result.opponent.attack).toBeCloseTo(0.1);
+        });
+
+        it('should handle symmetrical teams with mutual advantages', () => {
+            const player = ['fire', 'nature'];
+            const opponent = ['fire', 'nature'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            // Both sides: fire > nature -> +0.1 each
+            expect(result.player.ego).toBeCloseTo(0.1);
+            expect(result.player.attack).toBeCloseTo(0.1);
+            expect(result.opponent.ego).toBeCloseTo(0.1);
+            expect(result.opponent.attack).toBeCloseTo(0.1);
+        });
+
+        it('should handle empty arrays', () => {
+            const result = calculateDominationBonuses([], []);
+            expect(result.player.ego).toBe(0);
+            expect(result.player.attack).toBe(0);
+            expect(result.player.chance).toBe(0);
+            expect(result.opponent.ego).toBe(0);
+            expect(result.opponent.attack).toBe(0);
+            expect(result.opponent.chance).toBe(0);
+        });
+
+        it('should handle one empty array', () => {
+            const result = calculateDominationBonuses(['fire', 'darkness'], []);
+            expect(result.player.ego).toBe(0);
+            expect(result.player.chance).toBe(0);
+        });
+
+        it('should combine ego and chance bonuses from mixed elements', () => {
+            // fire > nature (ego), darkness > light (chance)
+            const player = ['fire', 'darkness'];
+            const opponent = ['nature', 'light'];
+            const result = calculateDominationBonuses(player, opponent);
+
+            expect(result.player.ego).toBeCloseTo(0.1);
+            expect(result.player.attack).toBeCloseTo(0.1);
+            expect(result.player.chance).toBeCloseTo(0.2);
+        });
+    });
+
+    describe('calculateCritChanceShare', () => {
+        it('should return 0.15 for equal harmony values', () => {
+            expect(calculateCritChanceShare(100, 100)).toBeCloseTo(0.15);
+        });
+
+        it('should return close to 0.3 when own harmony dominates', () => {
+            const result = calculateCritChanceShare(10000, 1);
+            expect(result).toBeCloseTo(0.3, 1);
+            expect(result).toBeLessThan(0.3);
+        });
+
+        it('should return close to 0 when opponent harmony dominates', () => {
+            const result = calculateCritChanceShare(1, 10000);
+            expect(result).toBeCloseTo(0, 1);
+            expect(result).toBeGreaterThan(0);
+        });
+
+        it('should scale proportionally', () => {
+            // 3:1 ratio -> 0.3 * 3/4 = 0.225
+            expect(calculateCritChanceShare(300, 100)).toBeCloseTo(0.225);
+        });
+    });
+
+    describe('getSkillPercentage', () => {
+        it('should return 1 + sum/100 for a single girl with a matching skill', () => {
+            const team = {
+                girls: [
+                    { skills: { 5: { skill: { percentage_value: 20 } } } },
+                ],
+            };
+            expect(getSkillPercentage(team, 5)).toBeCloseTo(1.2);
+        });
+
+        it('should sum across multiple girls', () => {
+            const team = {
+                girls: [
+                    { skills: { 3: { skill: { percentage_value: 10 } } } },
+                    { skills: { 3: { skill: { percentage_value: 15 } } } },
+                    { skills: { 3: { skill: { percentage_value: 25 } } } },
+                ],
+            };
+            // 1 + (10+15+25)/100 = 1.5
+            expect(getSkillPercentage(team, 3)).toBeCloseTo(1.5);
+        });
+
+        it('should treat missing skill as 0 via nullish coalescing', () => {
+            const team = {
+                girls: [
+                    { skills: { 3: { skill: { percentage_value: 10 } } } },
+                    { skills: {} }, // no skill id 3
+                ],
+            };
+            // 1 + (10+0)/100 = 1.1
+            expect(getSkillPercentage(team, 3)).toBeCloseTo(1.1);
+        });
+
+        it('should return 1 when no girls have the skill', () => {
+            const team = {
+                girls: [
+                    { skills: {} },
+                    { skills: {} },
+                ],
+            };
+            expect(getSkillPercentage(team, 7)).toBeCloseTo(1.0);
+        });
+    });
+
+    describe('calculateBattleProbabilities', () => {
+        const noBonuses = { critDamage: 0, critChance: 0, defReduce: 0, healOnHit: 0 };
+        const noTier4 = { dmg: 0, def: 0 };
+        const noTier5 = { id: 0, value: 0 };
+
+        it('should predict a strong player wins against a weak opponent', () => {
+            const player = new BDSMPlayer(10000, 5000, 100, 0.15, noBonuses, noTier4, noTier5, 'StrongPlayer');
+            const opponent = new BDSMPlayer(1000, 200, 100, 0.05, noBonuses, noTier4, noTier5, 'WeakOpponent');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+
+            expect(result.win).toBeGreaterThan(0.9);
+            expect(result.loss).toBeLessThan(0.1);
+            expect(result.scoreClass).toBe('plus');
+        });
+
+        it('should predict a weak player loses against a strong opponent', () => {
+            const player = new BDSMPlayer(1000, 200, 100, 0.05, noBonuses, noTier4, noTier5, 'WeakPlayer');
+            const opponent = new BDSMPlayer(10000, 5000, 100, 0.15, noBonuses, noTier4, noTier5, 'StrongOpponent');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+
+            expect(result.win).toBeLessThan(0.1);
+            expect(result.loss).toBeGreaterThan(0.9);
+            expect(result.scoreClass).toBe('minus');
+        });
+
+        it('should predict roughly 50/50 for equal players', () => {
+            const player = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'PlayerA');
+            const opponent = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'PlayerB');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+
+            expect(result.win).toBeGreaterThan(0.3);
+            expect(result.win).toBeLessThan(0.7);
+        });
+
+        it('should set scoreClass to plus when win > 0.9', () => {
+            const player = new BDSMPlayer(50000, 10000, 50, 0.2, noBonuses, noTier4, noTier5, 'Big');
+            const opponent = new BDSMPlayer(500, 100, 50, 0.05, noBonuses, noTier4, noTier5, 'Small');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+            expect(result.scoreClass).toBe('plus');
+        });
+
+        it('should set scoreClass to minus when win < 0.5', () => {
+            const player = new BDSMPlayer(500, 100, 50, 0.05, noBonuses, noTier4, noTier5, 'Small');
+            const opponent = new BDSMPlayer(50000, 10000, 50, 0.2, noBonuses, noTier4, noTier5, 'Big');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+            expect(result.scoreClass).toBe('minus');
+        });
+
+        it('should return a points distribution object', () => {
+            const player = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'A');
+            const opponent = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'B');
+
+            const result = calculateBattleProbabilities(player, opponent, false);
+            expect(result.points).toBeDefined();
+            expect(typeof result.points).toBe('object');
+        });
+
+        it('should handle debug mode without errors', () => {
+            const player = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'DebugP');
+            const opponent = new BDSMPlayer(3000, 800, 200, 0.1, noBonuses, noTier4, noTier5, 'DebugO');
+
+            expect(() => {
+                calculateBattleProbabilities(player, opponent, true);
+            }).not.toThrow();
+        });
+
+        it('should account for tier5 stun skill', () => {
+            const stunTier5 = { id: 11, value: 0.5 };
+            const player = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, stunTier5, 'Stunner');
+            const opponent = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'Target');
+
+            const withStun = calculateBattleProbabilities(player, opponent, false);
+
+            const playerNoStun = new BDSMPlayer(5000, 1000, 200, 0.15, noBonuses, noTier4, noTier5, 'NoStun');
+            const withoutStun = calculateBattleProbabilities(playerNoStun, opponent, false);
+
+            // Stun gives an advantage: the stunner should win more often
+            expect(withStun.win).toBeGreaterThan(withoutStun.win);
+        });
+    });
+});

--- a/spec/Helper/TimerHelper.spec.ts
+++ b/spec/Helper/TimerHelper.spec.ts
@@ -1,0 +1,273 @@
+import {
+    setTimer,
+    clearTimer,
+    checkTimer,
+    checkTimerMustExist,
+    getTimer,
+    getSecondsLeft,
+    setTimers,
+    getTimeLeft,
+    Timers,
+} from '../../src/Helper/TimerHelper';
+
+jest.mock('../../src/Helper/StorageHelper', () => ({
+    setStoredValue: jest.fn(),
+}));
+
+jest.mock('../../src/Utils/index', () => ({
+    logHHAuto: jest.fn(),
+}));
+
+jest.mock('../../src/config/index', () => ({
+    HHStoredVarPrefixKey: 'HHAuto_',
+    TK: { Timers: 'Temp_Timers' },
+}));
+
+jest.mock('../../src/Helper/TimeHelper', () => ({
+    TimeHelper: {
+        toHHMMSS: jest.fn((seconds: number) => {
+            const h = Math.floor(seconds / 3600);
+            const m = Math.floor((seconds % 3600) / 60);
+            const s = seconds % 60;
+            return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+        }),
+        canCollectCompetitionActive: jest.fn(() => true),
+    },
+}));
+
+import { setStoredValue } from '../../src/Helper/StorageHelper';
+import { TimeHelper } from '../../src/Helper/TimeHelper';
+
+describe('TimerHelper', () => {
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.setSystemTime(new Date('2025-06-15T12:00:00.000Z'));
+        // Reset the Timers object before each test
+        setTimers({});
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    describe('setTimer', () => {
+        it('should set a timer to Date.now() + seconds*1000', () => {
+            setTimer('testTimer', 60);
+
+            const now = Date.now();
+            const expected = now + 60 * 1000;
+            expect(getTimer('testTimer')).toBe(expected);
+        });
+
+        it('should call setStoredValue with serialized Timers', () => {
+            setTimer('myTimer', 120);
+
+            expect(setStoredValue).toHaveBeenCalledWith(
+                'HHAuto_Temp_Timers',
+                expect.any(String)
+            );
+            const storedJson = (setStoredValue as jest.Mock).mock.calls[0][1];
+            const parsed = JSON.parse(storedJson);
+            expect(parsed.myTimer).toBeDefined();
+        });
+
+        it('should overwrite an existing timer with the same name', () => {
+            setTimer('dup', 30);
+            const first = getTimer('dup');
+
+            jest.advanceTimersByTime(5000);
+            setTimer('dup', 60);
+            const second = getTimer('dup');
+
+            expect(second).toBeGreaterThan(first);
+        });
+    });
+
+    describe('clearTimer', () => {
+        it('should remove the named timer', () => {
+            setTimer('toRemove', 100);
+            expect(getTimer('toRemove')).not.toBe(-1);
+
+            clearTimer('toRemove');
+            expect(getTimer('toRemove')).toBe(-1);
+        });
+
+        it('should call setStoredValue after clearing', () => {
+            setTimer('toClear', 50);
+            jest.clearAllMocks();
+
+            clearTimer('toClear');
+            expect(setStoredValue).toHaveBeenCalled();
+        });
+
+        it('should not throw when clearing a non-existent timer', () => {
+            expect(() => clearTimer('nonExistent')).not.toThrow();
+        });
+    });
+
+    describe('checkTimer', () => {
+        it('should return true if the timer does not exist', () => {
+            expect(checkTimer('missing')).toBe(true);
+        });
+
+        it('should return true if the timer has expired', () => {
+            setTimer('expired', 10);
+            // Advance past the timer
+            jest.advanceTimersByTime(15000);
+            expect(checkTimer('expired')).toBe(true);
+        });
+
+        it('should return false if the timer has not yet expired', () => {
+            setTimer('active', 60);
+            // Only advance 5 seconds
+            jest.advanceTimersByTime(5000);
+            expect(checkTimer('active')).toBe(false);
+        });
+    });
+
+    describe('checkTimerMustExist', () => {
+        it('should return false if the timer does not exist', () => {
+            expect(checkTimerMustExist('missing')).toBe(false);
+        });
+
+        it('should return true if the timer exists and has expired', () => {
+            setTimer('exists', 10);
+            jest.advanceTimersByTime(15000);
+            expect(checkTimerMustExist('exists')).toBe(true);
+        });
+
+        it('should return false if the timer exists but has not expired', () => {
+            setTimer('notYet', 60);
+            jest.advanceTimersByTime(5000);
+            expect(checkTimerMustExist('notYet')).toBe(false);
+        });
+    });
+
+    describe('getTimer', () => {
+        it('should return -1 if the timer does not exist', () => {
+            expect(getTimer('noSuchTimer')).toBe(-1);
+        });
+
+        it('should return the timer timestamp when it exists', () => {
+            setTimer('exists', 30);
+            const value = getTimer('exists');
+            expect(value).toBe(Date.now() + 30 * 1000);
+        });
+    });
+
+    describe('getSecondsLeft', () => {
+        it('should return 0 if the timer does not exist', () => {
+            expect(getSecondsLeft('missing')).toBe(0);
+        });
+
+        it('should return 0 if the timer has expired', () => {
+            setTimer('past', 10);
+            jest.advanceTimersByTime(15000);
+            expect(getSecondsLeft('past')).toBe(0);
+        });
+
+        it('should return the correct number of seconds remaining', () => {
+            setTimer('future', 120);
+            jest.advanceTimersByTime(20000);
+            expect(getSecondsLeft('future')).toBe(100);
+        });
+
+        it('should return exact seconds when no time has passed', () => {
+            setTimer('exact', 60);
+            expect(getSecondsLeft('exact')).toBe(60);
+        });
+    });
+
+    describe('setTimers', () => {
+        it('should replace the entire Timers object', () => {
+            const newTimers = {
+                timerA: Date.now() + 10000,
+                timerB: Date.now() + 20000,
+            };
+            setTimers(newTimers);
+
+            expect(getTimer('timerA')).toBe(newTimers.timerA);
+            expect(getTimer('timerB')).toBe(newTimers.timerB);
+        });
+
+        it('should clear old timers when replacing', () => {
+            setTimer('old', 100);
+            setTimers({ fresh: Date.now() + 5000 });
+
+            expect(getTimer('old')).toBe(-1);
+            expect(getTimer('fresh')).not.toBe(-1);
+        });
+    });
+
+    describe('getTimeLeft', () => {
+        it('should return "No timer" when timer does not exist and competition is active', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(true);
+            expect(getTimeLeft('someTimer')).toBe('No timer');
+        });
+
+        it('should return "Time\'s up!" when timer has expired and competition is active', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(true);
+            setTimer('done', 5);
+            jest.advanceTimersByTime(10000);
+            expect(getTimeLeft('done')).toBe("Time's up!");
+        });
+
+        it('should return formatted time string when timer is still running', () => {
+            setTimer('running', 3661);
+            const result = getTimeLeft('running');
+            expect(TimeHelper.toHHMMSS).toHaveBeenCalledWith(3661);
+            expect(result).toBeDefined();
+            expect(typeof result).toBe('string');
+        });
+
+        it('should return "Wait for contest" for competition timer when competition is not active and timer is missing', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(false);
+            const competTimerNames = [
+                'nextPachinkoTime',
+                'nextPachinko2Time',
+                'nextPachinkoEquipTime',
+                'nextSeasonTime',
+                'nextLeaguesTime',
+                'nextChampionTime',
+                'nextClubChampionTime',
+                'nextLabyrinthTime',
+                'nextPentaDrillTime',
+                'nextPantheonTime',
+            ];
+
+            competTimerNames.forEach(name => {
+                expect(getTimeLeft(name)).toBe('Wait for contest');
+            });
+        });
+
+        it('should return "Wait for contest" for competition timer when competition is not active and timer expired', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(false);
+            setTimer('nextLeaguesTime', 5);
+            jest.advanceTimersByTime(10000);
+            expect(getTimeLeft('nextLeaguesTime')).toBe('Wait for contest');
+        });
+
+        it('should return "No timer" for non-competition timer when competition is not active and timer is missing', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(false);
+            expect(getTimeLeft('someRandomTimer')).toBe('No timer');
+        });
+
+        it('should return "Time\'s up!" for non-competition timer when competition is not active and timer expired', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(false);
+            setTimer('nonCompetTimer', 5);
+            jest.advanceTimersByTime(10000);
+            expect(getTimeLeft('nonCompetTimer')).toBe("Time's up!");
+        });
+
+        it('should return formatted time for competition timer that has not expired yet, even if competition is inactive', () => {
+            (TimeHelper.canCollectCompetitionActive as jest.Mock).mockReturnValue(false);
+            setTimer('nextLeaguesTime', 300);
+            jest.advanceTimersByTime(100000);
+            const result = getTimeLeft('nextLeaguesTime');
+            // 200 seconds left, so toHHMMSS should be called
+            expect(TimeHelper.toHHMMSS).toHaveBeenCalledWith(200);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- **BDSMHelper** (33 tests): calculateDominationBonuses, calculateCritChanceShare, getSkillPercentage, calculateBattleProbabilities, fightBonues, ELEMENTS structure validation
- **TimerHelper** (24 tests): setTimer, clearTimer, checkTimer, checkTimerMustExist, getTimer, getSecondsLeft, setTimers, getTimeLeft incl. contest-wait logic

## Test plan
- [x] All 439 tests pass (33 suites, 0 failures)
- [x] CI workflow passes
- [x] No source code changes, only new spec files