### PR TITLE
fix: prevent contest reward collection infinite loop (#1525)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.34.3
+// @version      7.34.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -6169,8 +6169,12 @@ class Contest {
             LogUtils_logHHAuto(`Found ${contest_list.length} contest to be collected`);
             if (contest_list.length > 0) {
                 const firstContestEnded = contest_list.first();
-                LogUtils_logHHAuto(`Collected contest id : ${(_a = firstContestEnded.parents('.contest')) === null || _a === void 0 ? void 0 : _a.attr('id_contest')}.`);
+                const contestContainer = firstContestEnded.parents('.contest');
+                LogUtils_logHHAuto(`Collected contest id : ${contestContainer === null || contestContainer === void 0 ? void 0 : contestContainer.attr('id_contest')}.`);
                 firstContestEnded.trigger('click');
+                // Remove the claimed contest from the DOM so setTimers() won't
+                // see stale claim buttons and create an infinite collect loop.
+                contestContainer.remove();
                 if (contest_list.length > 1) {
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));
                     return true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.34.3",
+  "version": "7.34.4",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Contest.ts
+++ b/src/Module/Contest.ts
@@ -47,8 +47,12 @@ export class Contest {
             if ( contest_list.length > 0)
             {
                 const firstContestEnded = contest_list.first();
-                logHHAuto(`Collected contest id : ${firstContestEnded.parents('.contest')?.attr('id_contest') }.`);
+                const contestContainer = firstContestEnded.parents('.contest');
+                logHHAuto(`Collected contest id : ${contestContainer?.attr('id_contest') }.`);
                 firstContestEnded.trigger('click');
+                // Remove the claimed contest from the DOM so setTimers() won't
+                // see stale claim buttons and create an infinite collect loop.
+                contestContainer.remove();
                 if ( contest_list.length > 1 )
                 {
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));


### PR DESCRIPTION
## Summary
- After clicking a contest claim button, the DOM element was not removed before `setTimers()` re-checked for claimable contests
- Since the click is processed asynchronously, the button was still present, causing `nextContestCollectTime` to be set to 0 and triggering an endless loop that blocked the entire script
- Bumps version to 7.34.4

## Test plan
- [ ] Verify contest rewards are collected without looping
- [ ] Verify the script continues with other actions after collecting contest rewards
- [ ] Verify multiple pending contests are still collected sequentially