### PR TITLE
fix: improve Hero retry mechanism to prevent infinite loop (#1523)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.34.4
+// @version      7.34.5
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.34.4",
+  "version": "7.34.5",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/StartService.ts
+++ b/src/Service/StartService.ts
@@ -91,6 +91,9 @@ import { disableToolTipsDisplay, enableToolTipsDisplay, manageToolTipsDisplay } 
 
 var started=false;
 var debugMenuID;
+var heroRetryTimer: ReturnType<typeof setTimeout> | null = null;
+var heroRetryCount = 0;
+const HERO_MAX_RETRIES = 15;
 
 export class StartService {
     static checkVersion()
@@ -194,12 +197,22 @@ export function start() {
 
     if (unsafeWindow.shared?.Hero === undefined)
     {
-        logHHAuto('???no Hero???');
+        heroRetryCount++;
+        if (heroRetryCount > HERO_MAX_RETRIES) {
+            logHHAuto('Hero object not available after ' + HERO_MAX_RETRIES + ' retries. Giving up. Try reloading the page.');
+            return;
+        }
+        logHHAuto('???no Hero??? (attempt ' + heroRetryCount + '/' + HERO_MAX_RETRIES + ')');
         started = false;
-        $('.hh_logo').trigger('click');
-        setTimeout(hardened_start,5000);
+        heroRetryTimer = setTimeout(hardened_start, 5000);
         return;
     }
+    // Hero available, cancel any pending retry and reset counter
+    if (heroRetryTimer !== null) {
+        clearTimeout(heroRetryTimer);
+        heroRetryTimer = null;
+    }
+    heroRetryCount = 0;
     if($("a[rel='phoenix_member_login']").length > 0)
     {    
         logHHAuto('Not logged in, please login first!');

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,4 @@ declare global {
     }
 }
 
-setTimeout(hardened_start,5000);
-
-(function () {
-    hardened_start();
-})();
+hardened_start();


### PR DESCRIPTION
## Summary
- Removes `.hh_logo` trigger click from Hero retry (caused navigation interference that prevented successful init)
- Adds retry counter with max 15 attempts instead of infinite loop
- Stores timer ID and uses `clearTimeout` on successful init to cancel stale retries
- Removes duplicate `hardened_start()` invocation (IIFE + setTimeout created 2 parallel retry chains)
- Bumps version to 7.34.5

## Root cause
When `shared.Hero` wasn't available on initial load, the retry mechanism triggered a logo click to navigate home. In Chrome 146, this click either failed silently or caused navigation that destroyed a successful init in progress. Combined with the dual invocation creating 2 parallel retry chains, this resulted in an infinite "???no Hero???" loop — preventing the config button and full initialization from ever completing.

## Test plan
- [ ] Test in Chrome 146 — config button should appear
- [ ] Test in Firefox — no regression
- [ ] Test in Edge — no regression
- [ ] Verify retry stops after 15 attempts with clear log message