### PR TITLE
fix: resolve auto-equip boosters infinite shop loop

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.1
+// @version      7.35.2
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -23127,6 +23127,9 @@ function handlePageSpecific(ctx) {
                     Booster.collectBoostersFromMarket = callItOnce(Booster.collectBoostersFromMarket);
                     setTimeout(Booster.collectBoostersFromMarket, 200);
                 }
+                if (!Booster.hasBoosterDataFromMarket()) {
+                    setTimeout(() => Shop.updateShop(), 300);
+                }
                 break;
             case ConfigHelper.getHHScriptVars("pagesIDHome"):
                 setTimeout(Season.displayRemainingTime, 500);
@@ -23509,7 +23512,7 @@ const MAX_REMIND_COUNT = 3;
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION = "7.35.1";
+const FEATURE_POPUP_VERSION = "7.35.2";
 /**
  * Title shown in the popup header.
  */

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.2 — Fix auto-equip boosters loop
+
+Fixed a bug where auto-equip boosters could enter an infinite loop navigating to the shop page repeatedly without caching booster inventory data.
+
 ### v7.35.1 — New troll "Rex & Kate" added for Trans Pornstar Harem
 
 ### v7.35.0 — Optimized Equipment Selection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.1",
+  "version": "7.35.2",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/AutoLoopPageHandlers.ts
+++ b/src/Service/AutoLoopPageHandlers.ts
@@ -192,6 +192,9 @@ export async function handlePageSpecific(ctx: AutoLoopContext): Promise<void> {
                 Booster.collectBoostersFromMarket = callItOnce(Booster.collectBoostersFromMarket);
                 setTimeout(Booster.collectBoostersFromMarket,200);
             }
+            if(!Booster.hasBoosterDataFromMarket()) {
+                setTimeout(() => Shop.updateShop(),300);
+            }
             break;
         case ConfigHelper.getHHScriptVars("pagesIDHome"):
             setTimeout(Season.displayRemainingTime,500);

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -35,7 +35,7 @@ const MAX_REMIND_COUNT = 3;
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION: string = "7.35.1";
+const FEATURE_POPUP_VERSION: string = "7.35.2";
 
 /**
  * Title shown in the popup header.


### PR DESCRIPTION
## Summary
- Fixed infinite loop where `autoEquipBoosters` repeatedly navigated to the shop page without caching booster inventory data
- Root cause: `collectBoostersFromMarket()` only cached equipped slots (`boosterStatus`), but `autoEquipBoosters` checks `boosterIdMap` and `haveBooster` (player inventory), which are only populated by `Shop.updateShop()`
- Added `Shop.updateShop()` call in the shop page handler when booster inventory data is missing

Fixes #1562

## Test plan
- [ ] Enable auto-equip boosters with all booster slots active
- [ ] Clear session storage to simulate fresh start
- [ ] Verify the script navigates to shop once, caches data, and proceeds normally without looping
- [ ] Verify normal booster equip flow still works correctly