### PR TITLE
Stuff team: optimize equipment selection with full inventory scan

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12017,10 +12017,56 @@ class HaremGirl {
                     const raw = bestInventory.el.get(0);
                     if (raw && typeof raw.scrollIntoView === 'function') {
                         raw.scrollIntoView({ block: 'center' });
-                        yield TimeHelper.sleep(randomInterval(150, 250));
+                        yield TimeHelper.sleep(randomInterval(200, 300));
                     }
-                    bestInventory.el.trigger('click');
-                    yield TimeHelper.sleep(randomInterval(400, 600));
+                    // Native click to trigger the game's selection handler reliably
+                    if (raw && typeof raw.click === 'function') {
+                        raw.click();
+                    }
+                    else {
+                        bestInventory.el.trigger('click');
+                    }
+                    yield TimeHelper.sleep(randomInterval(300, 500));
+                    // Find and click the Equip / confirm button. Log which button we found.
+                    const equipBtnSelectors = [
+                        '#equip-button',
+                        '.equip-button',
+                        'button.equip',
+                        '[class*="equip"] button',
+                        '.right-section button',
+                        '.footer .equip',
+                        'button:contains("Equip")',
+                        'button:contains("equip")'
+                    ];
+                    let equipBtn = null;
+                    for (const sel of equipBtnSelectors) {
+                        try {
+                            const $b = $(sel).filter(':visible').not(':disabled').first();
+                            if ($b.length > 0) {
+                                equipBtn = $b;
+                                LogUtils_logHHAuto(`Slot ${i}: equip button found via selector "${sel}" (text="${$b.text().trim().substring(0, 30)}")`);
+                                break;
+                            }
+                        }
+                        catch ( /* ignore selector errors */_c) { /* ignore selector errors */ }
+                    }
+                    if (equipBtn && equipBtn.length > 0) {
+                        const btnRaw = equipBtn.get(0);
+                        if (btnRaw && typeof btnRaw.click === 'function')
+                            btnRaw.click();
+                        else
+                            equipBtn.trigger('click');
+                        yield TimeHelper.sleep(randomInterval(400, 700));
+                        LogUtils_logHHAuto(`Slot ${i}: equip button clicked`);
+                    }
+                    else {
+                        // Fallback: list all visible buttons in the right section for diagnosis
+                        const btnList = [];
+                        $('.right-section button, .right-section .myButton, .right-section [class*="btn"]').filter(':visible').each(function () {
+                            btnList.push(`${this.tagName}.${(this.className || '').substring(0, 40)}:"${$(this).text().trim().substring(0, 20)}"`);
+                        });
+                        LogUtils_logHHAuto(`Slot ${i}: NO equip button found. Visible buttons in right-section: ${JSON.stringify(btnList)}`);
+                    }
                 }
                 else {
                     const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11919,7 +11919,12 @@ class HaremGirl {
                 }
                 const slotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 slotItems.push({ slotIndex, equippedData });
-                LogUtils_logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+                if (equippedData) {
+                    LogUtils_logHHAuto(`Slot ${i}: data-d keys=${JSON.stringify(Object.keys(equippedData))}, slot_index=${slotIndex}, L${equippedData.level} ${equippedData.rarity}`);
+                }
+                else {
+                    LogUtils_logHHAuto(`Slot ${i}: no data-d, slot_index=${slotIndex}`);
+                }
             }
             for (let i = 0; i < slotCount; i++) {
                 const { slotIndex, equippedData } = slotItems[i];

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.2
+// @version      7.35.3
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -11837,112 +11837,132 @@ class HaremGirl {
             LogUtils_logHHAuto("Can't remove popup_message_harem");
         }
     }
+    static equipItem(girlId, armorId) {
+        return new Promise((resolve) => {
+            $.ajax({
+                url: '/ajax.php',
+                type: 'POST',
+                data: {
+                    action: 'girl_equipment_equip',
+                    id_girl: girlId,
+                    id_girl_armor: armorId,
+                    sort_by: 'rarity',
+                    sorting_order: 'asc'
+                },
+                dataType: 'json',
+                success: function (data) { resolve(data); },
+                error: function () { resolve(null); }
+            });
+        });
+    }
+    static scoreItem(item, girl) {
+        const c = item.caracs;
+        const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
+        let resonanceMatches = 0;
+        if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
+            const rb = item.resonance_bonuses;
+            if (rb.class && String(rb.class.identifier) === String(girl.class))
+                resonanceMatches++;
+            if (rb.element && String(rb.element.identifier) === String(girl.element))
+                resonanceMatches++;
+            if (rb.figure && String(rb.figure.identifier) === String(girl.figure))
+                resonanceMatches++;
+        }
+        return { caracSum, resonanceMatches };
+    }
+    static findBestItem(items, girl) {
+        if (items.length === 0)
+            return null;
+        return items.sort((a, b) => {
+            const sa = HaremGirl.scoreItem(a, girl);
+            const sb = HaremGirl.scoreItem(b, girl);
+            if (sb.caracSum !== sa.caracSum)
+                return sb.caracSum - sa.caracSum;
+            if (sb.resonanceMatches !== sa.resonanceMatches)
+                return sb.resonanceMatches - sa.resonanceMatches;
+            return ((b.caracs.carac1 || 0) + (b.caracs.carac2 || 0) + (b.caracs.carac3 || 0))
+                - ((a.caracs.carac1 || 0) + (a.caracs.carac2 || 0) + (a.caracs.carac3 || 0));
+        })[0];
+    }
+    static isBetter(candidate, current, girl) {
+        if (!current || !current.caracs)
+            return true;
+        const sc = HaremGirl.scoreItem(candidate, girl);
+        const se = HaremGirl.scoreItem(current, girl);
+        if (sc.caracSum > se.caracSum)
+            return true;
+        if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches)
+            return true;
+        return false;
+    }
     static optimizeEquipmentSlots(girl) {
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-            const scoreItem = (item) => {
-                const c = item.caracs;
-                const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
-                let resonanceMatches = 0;
-                if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
-                    const rb = item.resonance_bonuses;
-                    if (rb.class && String(rb.class.identifier) === String(girl.class))
-                        resonanceMatches++;
-                    if (rb.element && String(rb.element.identifier) === String(girl.element))
-                        resonanceMatches++;
-                    if (rb.figure && String(rb.figure.identifier) === String(girl.figure))
-                        resonanceMatches++;
-                }
-                return { caracSum, resonanceMatches };
-            };
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
                 slot.trigger('click');
                 yield TimeHelper.sleep(randomInterval(300, 500));
+                // Read currently equipped item from DOM
                 const equippedEl = slot.find('.slot[data-d]');
                 let equippedData = null;
                 if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
                     equippedData = JSON.parse(equippedEl.attr('data-d'));
                 }
-                const inventoryItems = [];
+                // Get any visible inventory item ID to make the initial API call
+                let probeArmorId = null;
                 $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                    if (probeArmorId)
+                        return;
                     const raw = $(this).attr('data-d');
                     if (!raw)
                         return;
                     const data = JSON.parse(raw);
-                    if (data.caracs && data.type === 'girl_armor') {
-                        inventoryItems.push({ data });
+                    if (data.id_girl_armor && data.type === 'girl_armor') {
+                        probeArmorId = data.id_girl_armor;
                     }
                 });
-                if (inventoryItems.length === 0) {
+                if (!probeArmorId) {
                     LogUtils_logHHAuto(`Slot ${i}: no inventory items available, skipping`);
                     continue;
                 }
-                inventoryItems.sort((a, b) => {
-                    const sa = scoreItem(a.data);
-                    const sb = scoreItem(b.data);
-                    if (sb.caracSum !== sa.caracSum)
-                        return sb.caracSum - sa.caracSum;
-                    if (sb.resonanceMatches !== sa.resonanceMatches)
-                        return sb.resonanceMatches - sa.resonanceMatches;
-                    const ca = a.data.caracs;
-                    const cb = b.data.caracs;
-                    return ((cb.carac1 || 0) + (cb.carac2 || 0) + (cb.carac3 || 0)) - ((ca.carac1 || 0) + (ca.carac2 || 0) + (ca.carac3 || 0));
-                });
-                const best = inventoryItems[0];
-                if (!best)
-                    continue;
-                const bestScore = scoreItem(best.data);
-                let shouldReplace = false;
-                if (!equippedData || !equippedData.caracs) {
-                    shouldReplace = true;
-                }
-                else {
-                    const equippedScore = scoreItem(equippedData);
-                    if (bestScore.caracSum > equippedScore.caracSum) {
-                        shouldReplace = true;
-                    }
-                    else if (bestScore.caracSum === equippedScore.caracSum && bestScore.resonanceMatches > equippedScore.resonanceMatches) {
-                        shouldReplace = true;
-                    }
-                }
-                if (shouldReplace) {
-                    const armorId = best.data.id_girl_armor;
-                    LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${best.data.level} ${best.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${armorId})`);
-                    yield new Promise((resolve) => {
-                        $.ajax({
-                            url: '/ajax.php',
-                            type: 'POST',
-                            data: {
-                                action: 'girl_equipment_equip',
-                                id_girl: girl.id_girl,
-                                id_girl_armor: armorId,
-                                sort_by: 'rarity',
-                                sorting_order: 'asc'
-                            },
-                            dataType: 'json',
-                            success: function (data) {
-                                if (data && data.success) {
-                                    LogUtils_logHHAuto(`Slot ${i}: equipped successfully`);
-                                }
-                                else {
-                                    LogUtils_logHHAuto(`Slot ${i}: equip response: ${JSON.stringify(data)}`);
-                                }
-                                resolve();
-                            },
-                            error: function (xhr, status, error) {
-                                LogUtils_logHHAuto(`Slot ${i}: equip HTTP error: ${status} ${error} (${xhr.status})`);
-                                resolve();
-                            }
-                        });
-                    });
+                // Step 1: Equip any visible item to get the full inventory from the API
+                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, probeArmorId);
+                if (!probeResponse || !probeResponse.success) {
+                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed`);
                     yield TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+                // Build full candidate list from API response
+                const candidates = [...(probeResponse.inventory_armor || [])];
+                if (probeResponse.unequipped_armor) {
+                    candidates.push(probeResponse.unequipped_armor);
+                }
+                const currentlyEquipped = probeResponse.equipped_armor || null;
+                if (candidates.length === 0) {
+                    LogUtils_logHHAuto(`Slot ${i}: no alternative items from API`);
+                    yield TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+                // Step 2: Find the absolute best from the complete inventory
+                const best = HaremGirl.findBestItem(candidates, girl);
+                if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
+                    const bestScore = HaremGirl.scoreItem(best, girl);
+                    LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+                    const equipResponse = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
+                    if (equipResponse && equipResponse.success) {
+                        LogUtils_logHHAuto(`Slot ${i}: equipped successfully`);
+                    }
+                    else {
+                        LogUtils_logHHAuto(`Slot ${i}: equip failed`);
+                    }
                 }
                 else {
-                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal`);
+                    const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
+                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
+                yield TimeHelper.sleep(randomInterval(300, 500));
             }
             LogUtils_logHHAuto('Equipment optimization complete');
         });

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12027,45 +12027,19 @@ class HaremGirl {
                         bestInventory.el.trigger('click');
                     }
                     yield TimeHelper.sleep(randomInterval(300, 500));
-                    // Find and click the Equip / confirm button. Log which button we found.
-                    const equipBtnSelectors = [
-                        '#equip-button',
-                        '.equip-button',
-                        'button.equip',
-                        '[class*="equip"] button',
-                        '.right-section button',
-                        '.footer .equip',
-                        'button:contains("Equip")',
-                        'button:contains("equip")'
-                    ];
-                    let equipBtn = null;
-                    for (const sel of equipBtnSelectors) {
-                        try {
-                            const $b = $(sel).filter(':visible').not(':disabled').first();
-                            if ($b.length > 0) {
-                                equipBtn = $b;
-                                LogUtils_logHHAuto(`Slot ${i}: equip button found via selector "${sel}" (text="${$b.text().trim().substring(0, 30)}")`);
-                                break;
-                            }
-                        }
-                        catch ( /* ignore selector errors */_c) { /* ignore selector errors */ }
-                    }
-                    if (equipBtn && equipBtn.length > 0) {
-                        const btnRaw = equipBtn.get(0);
+                    // Click the Equip confirm button (revealed after item selection)
+                    const $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                    if ($equipBtn.length > 0) {
+                        const btnRaw = $equipBtn.get(0);
                         if (btnRaw && typeof btnRaw.click === 'function')
                             btnRaw.click();
                         else
-                            equipBtn.trigger('click');
+                            $equipBtn.trigger('click');
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         LogUtils_logHHAuto(`Slot ${i}: equip button clicked`);
                     }
                     else {
-                        // Fallback: list all visible buttons in the right section for diagnosis
-                        const btnList = [];
-                        $('.right-section button, .right-section .myButton, .right-section [class*="btn"]').filter(':visible').each(function () {
-                            btnList.push(`${this.tagName}.${(this.className || '').substring(0, 40)}:"${$(this).text().trim().substring(0, 20)}"`);
-                        });
-                        LogUtils_logHHAuto(`Slot ${i}: NO equip button found. Visible buttons in right-section: ${JSON.stringify(btnList)}`);
+                        LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found`);
                     }
                 }
                 else {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11726,9 +11726,36 @@ class HaremGirl {
                         HaremGirl.switchTabs(HaremGirl.EQUIPMENT_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
-                        $('#girl-equip').trigger('click');
+                        // Use API call instead of synthetic click for reliable auto-equip
+                        const equipAllResponse = yield new Promise((resolve) => {
+                            $.ajax({
+                                url: '/ajax.php',
+                                type: 'POST',
+                                data: {
+                                    action: 'girl_equipment_equip_all',
+                                    id_girl: girl.id_girl
+                                },
+                                dataType: 'json',
+                                success: function (data) {
+                                    if (data && data.success) {
+                                        LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}`);
+                                        LogUtils_logHHAuto(`equip_all response keys: ${JSON.stringify(Object.keys(data))}`);
+                                        LogUtils_logHHAuto(`equip_all response: ${JSON.stringify(data)}`);
+                                        resolve(data);
+                                    }
+                                    else {
+                                        LogUtils_logHHAuto(`Auto-equip via API response: ${JSON.stringify(data)}`);
+                                        resolve(null);
+                                    }
+                                },
+                                error: function () {
+                                    LogUtils_logHHAuto(`Auto-equip via API failed for ${girl.name}`);
+                                    resolve(null);
+                                }
+                            });
+                        });
                         yield TimeHelper.sleep(randomInterval(400, 700));
-                        yield HaremGirl.optimizeEquipmentSlots(girl);
+                        yield HaremGirl.optimizeEquipmentSlots(girl, equipAllResponse);
                     }
                     if (upgradeSkill) {
                         HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
@@ -11895,107 +11922,80 @@ class HaremGirl {
             return true;
         return false;
     }
-    static optimizeEquipmentSlots(girl) {
-        var _a;
+    static optimizeEquipmentSlots(girl, equipAllResponse) {
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            const equipmentSlots = $('.equipment_slot');
-            const slotCount = equipmentSlots.length;
-            LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-            // Collect all equipped items first (DOM is reliable for equipped slots)
-            const slotItems = [];
-            for (let i = 0; i < slotCount; i++) {
-                const slot = equipmentSlots.eq(i);
-                const equippedEl = slot.find('.slot[data-d]');
-                let equippedData = null;
-                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                    equippedData = JSON.parse(equippedEl.attr('data-d'));
-                }
-                const slotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
-                slotItems.push({ slotIndex, equippedData });
-                LogUtils_logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+            LogUtils_logHHAuto(`Optimize equipment for ${girl.name}`);
+            if (!equipAllResponse) {
+                LogUtils_logHHAuto('No equip_all response, skipping optimization');
+                return;
             }
-            for (let i = 0; i < slotCount; i++) {
-                const { slotIndex, equippedData } = slotItems[i];
-                if (!equippedData || !equippedData.id_girl_armor) {
-                    LogUtils_logHHAuto(`Slot ${i}: no equipped item, skipping`);
-                    continue;
-                }
-                // Step 1: Re-equip the current item to get the full inventory for this slot from the API
-                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
-                if (!probeResponse || !probeResponse.success) {
-                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
-                    // Fallback: find any DOM item matching this slot_index
-                    let fallbackId = null;
-                    $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                        if (fallbackId)
-                            return;
-                        const raw = $(this).attr('data-d');
-                        if (!raw)
-                            return;
-                        const data = JSON.parse(raw);
-                        if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
-                            fallbackId = data.id_girl_armor;
+            // Try to extract equipped item IDs from the equip_all response
+            // We don't know the exact structure yet, so we log and try common patterns
+            let equippedItemIds = [];
+            if (equipAllResponse.items && Array.isArray(equipAllResponse.items)) {
+                equippedItemIds = equipAllResponse.items
+                    .filter((item) => item && item.id_girl_armor)
+                    .map((item) => String(item.id_girl_armor));
+                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from response.items`);
+            }
+            if (equippedItemIds.length === 0 && equipAllResponse.equipped_armors && Array.isArray(equipAllResponse.equipped_armors)) {
+                equippedItemIds = equipAllResponse.equipped_armors
+                    .filter((item) => item && item.id_girl_armor)
+                    .map((item) => String(item.id_girl_armor));
+                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from response.equipped_armors`);
+            }
+            // Fallback: try reading from DOM (may work if page was already loaded)
+            if (equippedItemIds.length === 0) {
+                const equipmentSlots = $('.equipment_slot');
+                for (let i = 0; i < equipmentSlots.length; i++) {
+                    const equippedEl = equipmentSlots.eq(i).find('.slot[data-d]');
+                    if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                        const data = JSON.parse(equippedEl.attr('data-d'));
+                        if (data.id_girl_armor) {
+                            equippedItemIds.push(String(data.id_girl_armor));
                         }
-                    });
-                    if (!fallbackId) {
-                        LogUtils_logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
-                        yield TimeHelper.sleep(randomInterval(300, 500));
-                        continue;
                     }
-                    const fallbackResponse = yield HaremGirl.equipItem(girl.id_girl, fallbackId);
-                    if (!fallbackResponse || !fallbackResponse.success) {
-                        LogUtils_logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
-                        yield TimeHelper.sleep(randomInterval(300, 500));
-                        continue;
-                    }
-                    // Use fallback response
-                    const fbCandidates = [...(fallbackResponse.inventory_armor || [])];
-                    if (fallbackResponse.unequipped_armor)
-                        fbCandidates.push(fallbackResponse.unequipped_armor);
-                    const fbEquipped = fallbackResponse.equipped_armor || null;
-                    const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
-                    if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
-                        const fbScore = HaremGirl.scoreItem(fbBest, girl);
-                        LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
-                        const eqResp = yield HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
-                        LogUtils_logHHAuto(`Slot ${i}: ${(eqResp === null || eqResp === void 0 ? void 0 : eqResp.success) ? 'equipped successfully' : 'equip failed'}`);
-                    }
-                    else {
-                        const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
-                        LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.level} ${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.rarity}, score=${s === null || s === void 0 ? void 0 : s.caracSum})`);
-                    }
+                }
+                if (equippedItemIds.length > 0) {
+                    LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from DOM fallback`);
+                }
+            }
+            if (equippedItemIds.length === 0) {
+                LogUtils_logHHAuto('No equipped item IDs found, cannot optimize. Check equip_all response log above.');
+                return;
+            }
+            // For each equipped item, re-equip it as probe to get the full inventory for that slot
+            for (let i = 0; i < equippedItemIds.length; i++) {
+                const armorId = equippedItemIds[i];
+                LogUtils_logHHAuto(`Slot ${i}: probing with equipped item id=${armorId}`);
+                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, armorId);
+                if (!probeResponse || !probeResponse.success) {
+                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, skipping`);
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }
-                // Probe succeeded: build full candidate list from API response
                 const candidates = [...(probeResponse.inventory_armor || [])];
                 if (probeResponse.unequipped_armor) {
                     candidates.push(probeResponse.unequipped_armor);
                 }
                 const currentlyEquipped = probeResponse.equipped_armor || null;
-                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
+                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates`);
                 if (candidates.length === 0) {
                     const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    LogUtils_logHHAuto(`Slot ${i}: no alternatives, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }
-                // Step 2: Find the absolute best from the complete inventory
                 const best = HaremGirl.findBestItem(candidates, girl);
                 if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
                     const bestScore = HaremGirl.scoreItem(best, girl);
-                    LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+                    LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
                     const equipResponse = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                    if (equipResponse && equipResponse.success) {
-                        LogUtils_logHHAuto(`Slot ${i}: equipped successfully`);
-                    }
-                    else {
-                        LogUtils_logHHAuto(`Slot ${i}: equip failed`);
-                    }
+                    LogUtils_logHHAuto(`Slot ${i}: ${(equipResponse === null || equipResponse === void 0 ? void 0 : equipResponse.success) ? 'equipped successfully' : 'equip failed'}`);
                 }
                 else {
                     const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    LogUtils_logHHAuto(`Slot ${i}: current is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
                 yield TimeHelper.sleep(randomInterval(300, 500));
             }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11726,8 +11726,6 @@ class HaremGirl {
                         HaremGirl.switchTabs(HaremGirl.EQUIPMENT_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
-                        $('#girl-equip').trigger('click');
-                        yield TimeHelper.sleep(randomInterval(400, 700));
                         yield HaremGirl.optimizeEquipmentSlots(girl);
                     }
                     if (upgradeSkill) {
@@ -11902,114 +11900,84 @@ class HaremGirl {
             return true;
         return false;
     }
+    static equipAllApi(girlId) {
+        return new Promise((resolve) => {
+            $.ajax({
+                url: '/ajax.php',
+                type: 'POST',
+                data: { action: 'girl_equipment_equip_all', id_girl: girlId },
+                dataType: 'json',
+                success: (data) => resolve(data),
+                error: (xhr, status) => {
+                    LogUtils_logHHAuto(`equipAllApi HTTP error: status=${status}`);
+                    resolve(null);
+                }
+            });
+        });
+    }
     static optimizeEquipmentSlots(girl) {
-        var _a;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            const equipmentSlots = $('.equipment_slot');
-            const slotCount = equipmentSlots.length;
-            LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-            // Collect all equipped items first (DOM is reliable for equipped slots)
-            const slotItems = [];
-            for (let i = 0; i < slotCount; i++) {
-                const slot = equipmentSlots.eq(i);
-                const equippedEl = slot.find('.slot[data-d]');
-                let equippedData = null;
-                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                    equippedData = JSON.parse(equippedEl.attr('data-d'));
-                }
-                const slotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
-                slotItems.push({ slotIndex, equippedData });
-                if (equippedData) {
-                    LogUtils_logHHAuto(`Slot ${i}: data-d keys=${JSON.stringify(Object.keys(equippedData))}, slot_index=${slotIndex}, L${equippedData.level} ${equippedData.rarity}`);
-                }
-                else {
-                    LogUtils_logHHAuto(`Slot ${i}: no data-d, slot_index=${slotIndex}`);
-                }
+            LogUtils_logHHAuto(`Optimize equipment via API for ${girl.name}`);
+            // Step 1: run auto-equip via API and capture full response
+            const equipAllResp = yield HaremGirl.equipAllApi(girl.id_girl);
+            if (!equipAllResp) {
+                LogUtils_logHHAuto(`Auto-equip API call failed for ${girl.name}, aborting optimization`);
+                return;
             }
-            for (let i = 0; i < slotCount; i++) {
-                const { slotIndex, equippedData } = slotItems[i];
-                if (!equippedData || !equippedData.id_girl_armor) {
-                    LogUtils_logHHAuto(`Slot ${i}: no equipped item, skipping`);
+            if (!equipAllResp.success) {
+                LogUtils_logHHAuto(`Auto-equip API returned success=false for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
+                return;
+            }
+            LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
+            const inventory = Array.isArray(equipAllResp.inventory_armor) ? equipAllResp.inventory_armor : [];
+            LogUtils_logHHAuto(`Auto-equip response contains ${inventory.length} inventory_armor entries`);
+            if (inventory.length === 0) {
+                LogUtils_logHHAuto(`No inventory_armor in equip_all response — cannot optimize, stopping`);
+                return;
+            }
+            // Log one sample entry's keys so we can verify structure
+            LogUtils_logHHAuto(`inventory_armor[0] keys=${JSON.stringify(Object.keys(inventory[0]))}`);
+            // Group inventory by slot_index
+            const bySlot = {};
+            for (const item of inventory) {
+                const si = Number(item.slot_index);
+                if (!Number.isFinite(si))
                     continue;
+                if (!bySlot[si])
+                    bySlot[si] = [];
+                bySlot[si].push(item);
+            }
+            // Read currently equipped stats from DOM (post-equip_all DOM may be stale, but worst case we over-equip)
+            const equippedBySlot = {};
+            $('.equipment_slot .slot[data-d]').each(function () {
+                try {
+                    const d = JSON.parse($(this).attr('data-d') || '{}');
+                    const si = Number(d.slot_index);
+                    if (Number.isFinite(si))
+                        equippedBySlot[si] = d;
                 }
-                // Step 1: Re-equip the current item to get the full inventory for this slot from the API
-                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
-                if (!probeResponse || !probeResponse.success) {
-                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
-                    // Fallback: find any DOM item matching this slot_index
-                    let fallbackId = null;
-                    $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                        if (fallbackId)
-                            return;
-                        const raw = $(this).attr('data-d');
-                        if (!raw)
-                            return;
-                        const data = JSON.parse(raw);
-                        if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
-                            fallbackId = data.id_girl_armor;
-                        }
-                    });
-                    if (!fallbackId) {
-                        LogUtils_logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
-                        yield TimeHelper.sleep(randomInterval(300, 500));
-                        continue;
-                    }
-                    const fallbackResponse = yield HaremGirl.equipItem(girl.id_girl, fallbackId);
-                    if (!fallbackResponse || !fallbackResponse.success) {
-                        LogUtils_logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
-                        yield TimeHelper.sleep(randomInterval(300, 500));
-                        continue;
-                    }
-                    // Use fallback response
-                    const fbCandidates = [...(fallbackResponse.inventory_armor || [])];
-                    if (fallbackResponse.unequipped_armor)
-                        fbCandidates.push(fallbackResponse.unequipped_armor);
-                    const fbEquipped = fallbackResponse.equipped_armor || null;
-                    const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
-                    if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
-                        const fbScore = HaremGirl.scoreItem(fbBest, girl);
-                        LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
-                        const eqResp = yield HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
-                        LogUtils_logHHAuto(`Slot ${i}: ${(eqResp === null || eqResp === void 0 ? void 0 : eqResp.success) ? 'equipped successfully' : 'equip failed'}`);
-                    }
-                    else {
-                        const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
-                        LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.level} ${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.rarity}, score=${s === null || s === void 0 ? void 0 : s.caracSum})`);
-                    }
-                    yield TimeHelper.sleep(randomInterval(300, 500));
+                catch ( /* ignore */_a) { /* ignore */ }
+            });
+            for (let slotIndex = 1; slotIndex <= 6; slotIndex++) {
+                const candidates = bySlot[slotIndex] || [];
+                const equipped = equippedBySlot[slotIndex] || null;
+                LogUtils_logHHAuto(`Slot ${slotIndex}: ${candidates.length} candidates, equipped=${equipped ? `L${equipped.level} ${equipped.rarity}` : 'none'}`);
+                if (candidates.length === 0)
                     continue;
-                }
-                // Probe succeeded: build full candidate list from API response
-                const candidates = [...(probeResponse.inventory_armor || [])];
-                if (probeResponse.unequipped_armor) {
-                    candidates.push(probeResponse.unequipped_armor);
-                }
-                const currentlyEquipped = probeResponse.equipped_armor || null;
-                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
-                if (candidates.length === 0) {
-                    const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
-                    yield TimeHelper.sleep(randomInterval(300, 500));
-                    continue;
-                }
-                // Step 2: Find the absolute best from the complete inventory
                 const best = HaremGirl.findBestItem(candidates, girl);
-                if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
-                    const bestScore = HaremGirl.scoreItem(best, girl);
-                    LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
-                    const equipResponse = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                    if (equipResponse && equipResponse.success) {
-                        LogUtils_logHHAuto(`Slot ${i}: equipped successfully`);
-                    }
-                    else {
-                        LogUtils_logHHAuto(`Slot ${i}: equip failed`);
-                    }
+                if (!best)
+                    continue;
+                const bestScore = HaremGirl.scoreItem(best, girl);
+                if (HaremGirl.isBetter(best, equipped, girl)) {
+                    LogUtils_logHHAuto(`Slot ${slotIndex}: equipping better item L${best.level} ${best.rarity} score=${bestScore.caracSum} resonance=${bestScore.resonanceMatches} id=${best.id_girl_armor}`);
+                    const resp = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
+                    LogUtils_logHHAuto(`Slot ${slotIndex}: ${(resp === null || resp === void 0 ? void 0 : resp.success) ? 'equipped successfully' : 'equip failed'}`);
+                    yield TimeHelper.sleep(randomInterval(300, 500));
                 }
                 else {
-                    const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    const eqScore = equipped ? HaremGirl.scoreItem(equipped, girl) : null;
+                    LogUtils_logHHAuto(`Slot ${slotIndex}: current is optimal (L${equipped === null || equipped === void 0 ? void 0 : equipped.level} ${equipped === null || equipped === void 0 ? void 0 : equipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
-                yield TimeHelper.sleep(randomInterval(300, 500));
             }
             LogUtils_logHHAuto('Equipment optimization complete');
         });

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11933,8 +11933,8 @@ class HaremGirl {
             let equippedItemIds = [];
             if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
                 equippedItemIds = equipAllResponse.equipped_armor_ids
-                    .filter((entry) => entry && entry.id_girl_armor_equipped)
-                    .map((entry) => String(entry.id_girl_armor_equipped));
+                    .filter((entry) => entry && entry.id_girl_armor)
+                    .map((entry) => String(entry.id_girl_armor));
                 LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
             }
             if (equippedItemIds.length === 0) {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11726,35 +11726,9 @@ class HaremGirl {
                         HaremGirl.switchTabs(HaremGirl.EQUIPMENT_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
-                        // Use API call instead of synthetic click for reliable auto-equip
-                        const equipAllResponse = yield new Promise((resolve) => {
-                            $.ajax({
-                                url: '/ajax.php',
-                                type: 'POST',
-                                data: {
-                                    action: 'girl_equipment_equip_all',
-                                    id_girl: girl.id_girl
-                                },
-                                dataType: 'json',
-                                success: function (data) {
-                                    var _a;
-                                    if (data && data.success) {
-                                        LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}, ${((_a = data.equipped_armor_ids) === null || _a === void 0 ? void 0 : _a.length) || 0} slots equipped`);
-                                        resolve(data);
-                                    }
-                                    else {
-                                        LogUtils_logHHAuto(`Auto-equip via API response: ${JSON.stringify(data)}`);
-                                        resolve(null);
-                                    }
-                                },
-                                error: function () {
-                                    LogUtils_logHHAuto(`Auto-equip via API failed for ${girl.name}`);
-                                    resolve(null);
-                                }
-                            });
-                        });
+                        $('#girl-equip').trigger('click');
                         yield TimeHelper.sleep(randomInterval(400, 700));
-                        yield HaremGirl.optimizeEquipmentSlots(girl, equipAllResponse);
+                        yield HaremGirl.optimizeEquipmentSlots(girl);
                     }
                     if (upgradeSkill) {
                         HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
@@ -11928,58 +11902,107 @@ class HaremGirl {
             return true;
         return false;
     }
-    static optimizeEquipmentSlots(girl, equipAllResponse) {
+    static optimizeEquipmentSlots(girl) {
+        var _a;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            LogUtils_logHHAuto(`Optimize equipment for ${girl.name}`);
-            if (!equipAllResponse) {
-                LogUtils_logHHAuto('No equip_all response, skipping optimization');
-                return;
+            const equipmentSlots = $('.equipment_slot');
+            const slotCount = equipmentSlots.length;
+            LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+            // Collect all equipped items first (DOM is reliable for equipped slots)
+            const slotItems = [];
+            for (let i = 0; i < slotCount; i++) {
+                const slot = equipmentSlots.eq(i);
+                const equippedEl = slot.find('.slot[data-d]');
+                let equippedData = null;
+                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                    equippedData = JSON.parse(equippedEl.attr('data-d'));
+                }
+                const slotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
+                slotItems.push({ slotIndex, equippedData });
+                LogUtils_logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
             }
-            // Extract equipped item IDs from equip_all response
-            // Response structure: equipped_armor_ids[].id_girl_armor_equipped = inventory item ID for equip API
-            let equippedItemIds = [];
-            if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
-                equippedItemIds = equipAllResponse.equipped_armor_ids
-                    .filter((entry) => entry && entry.id_girl_armor)
-                    .map((entry) => String(entry.id_girl_armor));
-                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
-            }
-            if (equippedItemIds.length === 0) {
-                LogUtils_logHHAuto('No equipped item IDs found in equip_all response, cannot optimize.');
-                return;
-            }
-            // For each equipped item, re-equip it as probe to get the full inventory for that slot
-            for (let i = 0; i < equippedItemIds.length; i++) {
-                const armorId = equippedItemIds[i];
-                LogUtils_logHHAuto(`Slot ${i}: probing with equipped item id=${armorId}`);
-                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, armorId);
+            for (let i = 0; i < slotCount; i++) {
+                const { slotIndex, equippedData } = slotItems[i];
+                if (!equippedData || !equippedData.id_girl_armor) {
+                    LogUtils_logHHAuto(`Slot ${i}: no equipped item, skipping`);
+                    continue;
+                }
+                // Step 1: Re-equip the current item to get the full inventory for this slot from the API
+                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
                 if (!probeResponse || !probeResponse.success) {
-                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, skipping`);
+                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+                    // Fallback: find any DOM item matching this slot_index
+                    let fallbackId = null;
+                    $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                        if (fallbackId)
+                            return;
+                        const raw = $(this).attr('data-d');
+                        if (!raw)
+                            return;
+                        const data = JSON.parse(raw);
+                        if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
+                            fallbackId = data.id_girl_armor;
+                        }
+                    });
+                    if (!fallbackId) {
+                        LogUtils_logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        continue;
+                    }
+                    const fallbackResponse = yield HaremGirl.equipItem(girl.id_girl, fallbackId);
+                    if (!fallbackResponse || !fallbackResponse.success) {
+                        LogUtils_logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        continue;
+                    }
+                    // Use fallback response
+                    const fbCandidates = [...(fallbackResponse.inventory_armor || [])];
+                    if (fallbackResponse.unequipped_armor)
+                        fbCandidates.push(fallbackResponse.unequipped_armor);
+                    const fbEquipped = fallbackResponse.equipped_armor || null;
+                    const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
+                    if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
+                        const fbScore = HaremGirl.scoreItem(fbBest, girl);
+                        LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
+                        const eqResp = yield HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
+                        LogUtils_logHHAuto(`Slot ${i}: ${(eqResp === null || eqResp === void 0 ? void 0 : eqResp.success) ? 'equipped successfully' : 'equip failed'}`);
+                    }
+                    else {
+                        const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
+                        LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.level} ${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.rarity}, score=${s === null || s === void 0 ? void 0 : s.caracSum})`);
+                    }
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }
+                // Probe succeeded: build full candidate list from API response
                 const candidates = [...(probeResponse.inventory_armor || [])];
                 if (probeResponse.unequipped_armor) {
                     candidates.push(probeResponse.unequipped_armor);
                 }
                 const currentlyEquipped = probeResponse.equipped_armor || null;
-                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates`);
+                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
                 if (candidates.length === 0) {
                     const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: no alternatives, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    LogUtils_logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }
+                // Step 2: Find the absolute best from the complete inventory
                 const best = HaremGirl.findBestItem(candidates, girl);
                 if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
                     const bestScore = HaremGirl.scoreItem(best, girl);
-                    LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+                    LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
                     const equipResponse = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                    LogUtils_logHHAuto(`Slot ${i}: ${(equipResponse === null || equipResponse === void 0 ? void 0 : equipResponse.success) ? 'equipped successfully' : 'equip failed'}`);
+                    if (equipResponse && equipResponse.success) {
+                        LogUtils_logHHAuto(`Slot ${i}: equipped successfully`);
+                    }
+                    else {
+                        LogUtils_logHHAuto(`Slot ${i}: equip failed`);
+                    }
                 }
                 else {
                     const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${i}: current is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
                 yield TimeHelper.sleep(randomInterval(300, 500));
             }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11876,8 +11876,15 @@ class HaremGirl {
                     sorting_order: 'asc'
                 },
                 dataType: 'json',
-                success: function (data) { resolve(data); },
-                error: function () { resolve(null); }
+                success: function (data) {
+                    LogUtils_logHHAuto(`equipItem response for armor ${armorId}: success=${data === null || data === void 0 ? void 0 : data.success}, keys=${JSON.stringify(Object.keys(data || {}))}`);
+                    resolve(data);
+                },
+                error: function (xhr, status, error) {
+                    var _a;
+                    LogUtils_logHHAuto(`equipItem HTTP error for armor ${armorId}: status=${status}, error=${error}, response=${(_a = xhr === null || xhr === void 0 ? void 0 : xhr.responseText) === null || _a === void 0 ? void 0 : _a.substring(0, 200)}`);
+                    resolve(null);
+                }
             });
         });
     }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11726,6 +11726,8 @@ class HaremGirl {
                         HaremGirl.switchTabs(HaremGirl.EQUIPMENT_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
+                        $('#girl-equip').trigger('click');
+                        yield TimeHelper.sleep(randomInterval(400, 700));
                         yield HaremGirl.optimizeEquipmentSlots(girl);
                     }
                     if (upgradeSkill) {
@@ -11900,83 +11902,123 @@ class HaremGirl {
             return true;
         return false;
     }
-    static equipAllApi(girlId) {
-        return new Promise((resolve) => {
-            $.ajax({
-                url: '/ajax.php',
-                type: 'POST',
-                data: { action: 'girl_equipment_equip_all', id_girl: girlId },
-                dataType: 'json',
-                success: (data) => resolve(data),
-                error: (xhr, status) => {
-                    LogUtils_logHHAuto(`equipAllApi HTTP error: status=${status}`);
-                    resolve(null);
+    /**
+     * Force the game's lazy-loaded inventory panel to render all items.
+     * The game renders inventory items on-demand as the container is scrolled.
+     * We scroll to the bottom repeatedly until the item count stabilises, then
+     * back to the top so the game has rendered every item into the DOM.
+     */
+    static forceLoadAllInventoryItems() {
+        return HaremGirl_awaiter(this, void 0, void 0, function* () {
+            // Likely scroll containers for the inventory panel (right side)
+            const candidateSelectors = [
+                '.right-section .scrollable',
+                '.right-section .inventory',
+                '.right-section .items-list',
+                '.right-section > div',
+                '.right-section'
+            ];
+            let container = null;
+            for (const sel of candidateSelectors) {
+                const el = document.querySelector(sel);
+                if (el && el.scrollHeight > el.clientHeight + 10) {
+                    container = el;
+                    break;
                 }
-            });
+            }
+            if (!container) {
+                // fallback: take first .right-section descendant with overflow
+                document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
+                    if (container)
+                        return;
+                    const h = el;
+                    if (h.scrollHeight > h.clientHeight + 10)
+                        container = h;
+                });
+            }
+            const countItems = () => $('.right-section .slot[data-d]').length;
+            let prevCount = countItems();
+            if (!container) {
+                LogUtils_logHHAuto(`forceLoadAllInventoryItems: no scrollable container found, current DOM items=${prevCount}`);
+                return prevCount;
+            }
+            for (let iter = 0; iter < 20; iter++) {
+                container.scrollTop = container.scrollHeight;
+                yield TimeHelper.sleep(randomInterval(200, 350));
+                const curCount = countItems();
+                if (curCount === prevCount)
+                    break;
+                prevCount = curCount;
+            }
+            container.scrollTop = 0;
+            yield TimeHelper.sleep(randomInterval(150, 250));
+            return countItems();
         });
     }
     static optimizeEquipmentSlots(girl) {
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            LogUtils_logHHAuto(`Optimize equipment via API for ${girl.name}`);
-            // Step 1: run auto-equip via API and capture full response
-            const equipAllResp = yield HaremGirl.equipAllApi(girl.id_girl);
-            if (!equipAllResp) {
-                LogUtils_logHHAuto(`Auto-equip API call failed for ${girl.name}, aborting optimization`);
-                return;
-            }
-            if (!equipAllResp.success) {
-                LogUtils_logHHAuto(`Auto-equip API returned success=false for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
-                return;
-            }
-            LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
-            const inventory = Array.isArray(equipAllResp.inventory_armor) ? equipAllResp.inventory_armor : [];
-            LogUtils_logHHAuto(`Auto-equip response contains ${inventory.length} inventory_armor entries`);
-            if (inventory.length === 0) {
-                LogUtils_logHHAuto(`No inventory_armor in equip_all response — cannot optimize, stopping`);
-                return;
-            }
-            // Log one sample entry's keys so we can verify structure
-            LogUtils_logHHAuto(`inventory_armor[0] keys=${JSON.stringify(Object.keys(inventory[0]))}`);
-            // Group inventory by slot_index
-            const bySlot = {};
-            for (const item of inventory) {
-                const si = Number(item.slot_index);
-                if (!Number.isFinite(si))
-                    continue;
-                if (!bySlot[si])
-                    bySlot[si] = [];
-                bySlot[si].push(item);
-            }
-            // Read currently equipped stats from DOM (post-equip_all DOM may be stale, but worst case we over-equip)
-            const equippedBySlot = {};
-            $('.equipment_slot .slot[data-d]').each(function () {
-                try {
-                    const d = JSON.parse($(this).attr('data-d') || '{}');
-                    const si = Number(d.slot_index);
-                    if (Number.isFinite(si))
-                        equippedBySlot[si] = d;
+            const equipmentSlots = $('.equipment_slot');
+            const slotCount = equipmentSlots.length;
+            LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+            for (let i = 0; i < slotCount; i++) {
+                const slot = equipmentSlots.eq(i);
+                slot.trigger('click');
+                yield TimeHelper.sleep(randomInterval(400, 600));
+                // Force game to render all lazy-loaded inventory items into the DOM
+                const totalItems = yield HaremGirl.forceLoadAllInventoryItems();
+                const equippedEl = slot.find('.slot[data-d]');
+                let equippedData = null;
+                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                    try {
+                        equippedData = JSON.parse(equippedEl.attr('data-d'));
+                    }
+                    catch ( /* ignore */_a) { /* ignore */ }
                 }
-                catch ( /* ignore */_a) { /* ignore */ }
-            });
-            for (let slotIndex = 1; slotIndex <= 6; slotIndex++) {
-                const candidates = bySlot[slotIndex] || [];
-                const equipped = equippedBySlot[slotIndex] || null;
-                LogUtils_logHHAuto(`Slot ${slotIndex}: ${candidates.length} candidates, equipped=${equipped ? `L${equipped.level} ${equipped.rarity}` : 'none'}`);
-                if (candidates.length === 0)
+                const inventoryItems = [];
+                $('.right-section .slot[data-d]').each(function () {
+                    const raw = $(this).attr('data-d');
+                    if (!raw)
+                        return;
+                    try {
+                        const data = JSON.parse(raw);
+                        if (data && data.caracs)
+                            inventoryItems.push({ el: $(this), data });
+                    }
+                    catch ( /* ignore */_a) { /* ignore */ }
+                });
+                LogUtils_logHHAuto(`Slot ${i}: DOM has ${totalItems} items, ${inventoryItems.length} usable candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
+                if (inventoryItems.length === 0) {
+                    LogUtils_logHHAuto(`Slot ${i}: no inventory items available, skipping`);
                     continue;
-                const best = HaremGirl.findBestItem(candidates, girl);
-                if (!best)
-                    continue;
-                const bestScore = HaremGirl.scoreItem(best, girl);
-                if (HaremGirl.isBetter(best, equipped, girl)) {
-                    LogUtils_logHHAuto(`Slot ${slotIndex}: equipping better item L${best.level} ${best.rarity} score=${bestScore.caracSum} resonance=${bestScore.resonanceMatches} id=${best.id_girl_armor}`);
-                    const resp = yield HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                    LogUtils_logHHAuto(`Slot ${slotIndex}: ${(resp === null || resp === void 0 ? void 0 : resp.success) ? 'equipped successfully' : 'equip failed'}`);
-                    yield TimeHelper.sleep(randomInterval(300, 500));
+                }
+                // Rank candidates: total stats, then resonance, then individual stats
+                const sorted = inventoryItems.slice().sort((a, b) => {
+                    const sa = HaremGirl.scoreItem(a.data, girl);
+                    const sb = HaremGirl.scoreItem(b.data, girl);
+                    if (sb.caracSum !== sa.caracSum)
+                        return sb.caracSum - sa.caracSum;
+                    if (sb.resonanceMatches !== sa.resonanceMatches)
+                        return sb.resonanceMatches - sa.resonanceMatches;
+                    const ca = a.data.caracs, cb = b.data.caracs;
+                    return ((cb.carac1 || 0) + (cb.carac2 || 0) + (cb.carac3 || 0)) - ((ca.carac1 || 0) + (ca.carac2 || 0) + (ca.carac3 || 0));
+                });
+                const bestInventory = sorted[0];
+                const bestScore = HaremGirl.scoreItem(bestInventory.data, girl);
+                const shouldReplace = HaremGirl.isBetter(bestInventory.data, equippedData, girl);
+                if (shouldReplace) {
+                    LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
+                    // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
+                    const raw = bestInventory.el.get(0);
+                    if (raw && typeof raw.scrollIntoView === 'function') {
+                        raw.scrollIntoView({ block: 'center' });
+                        yield TimeHelper.sleep(randomInterval(150, 250));
+                    }
+                    bestInventory.el.trigger('click');
+                    yield TimeHelper.sleep(randomInterval(400, 600));
                 }
                 else {
-                    const eqScore = equipped ? HaremGirl.scoreItem(equipped, girl) : null;
-                    LogUtils_logHHAuto(`Slot ${slotIndex}: current is optimal (L${equipped === null || equipped === void 0 ? void 0 : equipped.level} ${equipped === null || equipped === void 0 ? void 0 : equipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;
+                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${equippedData === null || equippedData === void 0 ? void 0 : equippedData.level} ${equippedData === null || equippedData === void 0 ? void 0 : equippedData.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
             }
             LogUtils_logHHAuto('Equipment optimization complete');

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11896,52 +11896,87 @@ class HaremGirl {
         return false;
     }
     static optimizeEquipmentSlots(girl) {
+        var _a;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+            // Collect all equipped items first (DOM is reliable for equipped slots)
+            const slotItems = [];
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
-                slot.trigger('click');
-                yield TimeHelper.sleep(randomInterval(300, 500));
-                // Read currently equipped item from DOM
                 const equippedEl = slot.find('.slot[data-d]');
                 let equippedData = null;
                 if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
                     equippedData = JSON.parse(equippedEl.attr('data-d'));
                 }
-                // Get any visible inventory item ID to make the initial API call
-                let probeArmorId = null;
-                $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                    if (probeArmorId)
-                        return;
-                    const raw = $(this).attr('data-d');
-                    if (!raw)
-                        return;
-                    const data = JSON.parse(raw);
-                    if (data.id_girl_armor && data.type === 'girl_armor') {
-                        probeArmorId = data.id_girl_armor;
-                    }
-                });
-                if (!probeArmorId) {
-                    LogUtils_logHHAuto(`Slot ${i}: no inventory items available, skipping`);
+                const slotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
+                slotItems.push({ slotIndex, equippedData });
+                LogUtils_logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+            }
+            for (let i = 0; i < slotCount; i++) {
+                const { slotIndex, equippedData } = slotItems[i];
+                if (!equippedData || !equippedData.id_girl_armor) {
+                    LogUtils_logHHAuto(`Slot ${i}: no equipped item, skipping`);
                     continue;
                 }
-                // Step 1: Equip any visible item to get the full inventory from the API
-                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, probeArmorId);
+                // Step 1: Re-equip the current item to get the full inventory for this slot from the API
+                const probeResponse = yield HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
                 if (!probeResponse || !probeResponse.success) {
-                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed`);
+                    LogUtils_logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+                    // Fallback: find any DOM item matching this slot_index
+                    let fallbackId = null;
+                    $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                        if (fallbackId)
+                            return;
+                        const raw = $(this).attr('data-d');
+                        if (!raw)
+                            return;
+                        const data = JSON.parse(raw);
+                        if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
+                            fallbackId = data.id_girl_armor;
+                        }
+                    });
+                    if (!fallbackId) {
+                        LogUtils_logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        continue;
+                    }
+                    const fallbackResponse = yield HaremGirl.equipItem(girl.id_girl, fallbackId);
+                    if (!fallbackResponse || !fallbackResponse.success) {
+                        LogUtils_logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        continue;
+                    }
+                    // Use fallback response
+                    const fbCandidates = [...(fallbackResponse.inventory_armor || [])];
+                    if (fallbackResponse.unequipped_armor)
+                        fbCandidates.push(fallbackResponse.unequipped_armor);
+                    const fbEquipped = fallbackResponse.equipped_armor || null;
+                    const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
+                    if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
+                        const fbScore = HaremGirl.scoreItem(fbBest, girl);
+                        LogUtils_logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
+                        const eqResp = yield HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
+                        LogUtils_logHHAuto(`Slot ${i}: ${(eqResp === null || eqResp === void 0 ? void 0 : eqResp.success) ? 'equipped successfully' : 'equip failed'}`);
+                    }
+                    else {
+                        const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
+                        LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.level} ${fbEquipped === null || fbEquipped === void 0 ? void 0 : fbEquipped.rarity}, score=${s === null || s === void 0 ? void 0 : s.caracSum})`);
+                    }
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }
-                // Build full candidate list from API response
+                // Probe succeeded: build full candidate list from API response
                 const candidates = [...(probeResponse.inventory_armor || [])];
                 if (probeResponse.unequipped_armor) {
                     candidates.push(probeResponse.unequipped_armor);
                 }
                 const currentlyEquipped = probeResponse.equipped_armor || null;
+                LogUtils_logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
                 if (candidates.length === 0) {
-                    LogUtils_logHHAuto(`Slot ${i}: no alternative items from API`);
+                    const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
+                    LogUtils_logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.level} ${currentlyEquipped === null || currentlyEquipped === void 0 ? void 0 : currentlyEquipped.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                     yield TimeHelper.sleep(randomInterval(300, 500));
                     continue;
                 }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11737,10 +11737,9 @@ class HaremGirl {
                                 },
                                 dataType: 'json',
                                 success: function (data) {
+                                    var _a;
                                     if (data && data.success) {
-                                        LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}`);
-                                        LogUtils_logHHAuto(`equip_all response keys: ${JSON.stringify(Object.keys(data))}`);
-                                        LogUtils_logHHAuto(`equip_all response: ${JSON.stringify(data)}`);
+                                        LogUtils_logHHAuto(`Auto-equip via API successful for ${girl.name}, ${((_a = data.equipped_armor_ids) === null || _a === void 0 ? void 0 : _a.length) || 0} slots equipped`);
                                         resolve(data);
                                     }
                                     else {
@@ -11929,39 +11928,17 @@ class HaremGirl {
                 LogUtils_logHHAuto('No equip_all response, skipping optimization');
                 return;
             }
-            // Try to extract equipped item IDs from the equip_all response
-            // We don't know the exact structure yet, so we log and try common patterns
+            // Extract equipped item IDs from equip_all response
+            // Response structure: equipped_armor_ids[].id_girl_armor_equipped = inventory item ID for equip API
             let equippedItemIds = [];
-            if (equipAllResponse.items && Array.isArray(equipAllResponse.items)) {
-                equippedItemIds = equipAllResponse.items
-                    .filter((item) => item && item.id_girl_armor)
-                    .map((item) => String(item.id_girl_armor));
-                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from response.items`);
-            }
-            if (equippedItemIds.length === 0 && equipAllResponse.equipped_armors && Array.isArray(equipAllResponse.equipped_armors)) {
-                equippedItemIds = equipAllResponse.equipped_armors
-                    .filter((item) => item && item.id_girl_armor)
-                    .map((item) => String(item.id_girl_armor));
-                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from response.equipped_armors`);
-            }
-            // Fallback: try reading from DOM (may work if page was already loaded)
-            if (equippedItemIds.length === 0) {
-                const equipmentSlots = $('.equipment_slot');
-                for (let i = 0; i < equipmentSlots.length; i++) {
-                    const equippedEl = equipmentSlots.eq(i).find('.slot[data-d]');
-                    if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                        const data = JSON.parse(equippedEl.attr('data-d'));
-                        if (data.id_girl_armor) {
-                            equippedItemIds.push(String(data.id_girl_armor));
-                        }
-                    }
-                }
-                if (equippedItemIds.length > 0) {
-                    LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from DOM fallback`);
-                }
+            if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
+                equippedItemIds = equipAllResponse.equipped_armor_ids
+                    .filter((entry) => entry && entry.id_girl_armor_equipped)
+                    .map((entry) => String(entry.id_girl_armor_equipped));
+                LogUtils_logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
             }
             if (equippedItemIds.length === 0) {
-                LogUtils_logHHAuto('No equipped item IDs found, cannot optimize. Check equip_all response log above.');
+                LogUtils_logHHAuto('No equipped item IDs found in equip_all response, cannot optimize.');
                 return;
             }
             // For each equipped item, re-equip it as probe to get the full inventory for that slot

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11910,52 +11910,46 @@ class HaremGirl {
      */
     static forceLoadAllInventoryItems() {
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            // Likely scroll containers for the inventory panel (right side)
-            const candidateSelectors = [
-                '.right-section .scrollable',
-                '.right-section .inventory',
-                '.right-section .items-list',
-                '.right-section > div',
-                '.right-section'
-            ];
-            let container = null;
-            for (const sel of candidateSelectors) {
-                const el = document.querySelector(sel);
-                if (el && el.scrollHeight > el.clientHeight + 10) {
-                    container = el;
-                    break;
-                }
-            }
-            if (!container) {
-                // fallback: take first .right-section descendant with overflow
-                document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
-                    if (container)
-                        return;
-                    const h = el;
-                    if (h.scrollHeight > h.clientHeight + 10)
-                        container = h;
-                });
-            }
             const countItems = () => $('.right-section .slot[data-d]').length;
+            // Find ALL scrollable elements in the right section (element with scrollHeight > clientHeight)
+            const scrollables = [];
+            document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
+                const h = el;
+                if (h.scrollHeight > h.clientHeight + 5)
+                    scrollables.push(h);
+            });
+            // Also try the document/body as fallback
+            scrollables.push(document.scrollingElement || document.body);
             let prevCount = countItems();
-            if (!container) {
-                LogUtils_logHHAuto(`forceLoadAllInventoryItems: no scrollable container found, current DOM items=${prevCount}`);
-                return prevCount;
-            }
-            for (let iter = 0; iter < 20; iter++) {
-                container.scrollTop = container.scrollHeight;
+            LogUtils_logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
+            for (let iter = 0; iter < 15; iter++) {
+                // scroll each scrollable to its bottom and dispatch a scroll event
+                for (const s of scrollables) {
+                    try {
+                        s.scrollTop = s.scrollHeight;
+                        s.dispatchEvent(new Event('scroll', { bubbles: true }));
+                    }
+                    catch ( /* ignore */_a) { /* ignore */ }
+                }
                 yield TimeHelper.sleep(randomInterval(200, 350));
                 const curCount = countItems();
                 if (curCount === prevCount)
                     break;
                 prevCount = curCount;
             }
-            container.scrollTop = 0;
+            // scroll back up so the chosen item's scrollIntoView works reliably
+            for (const s of scrollables) {
+                try {
+                    s.scrollTop = 0;
+                }
+                catch ( /* ignore */_b) { /* ignore */ }
+            }
             yield TimeHelper.sleep(randomInterval(150, 250));
             return countItems();
         });
     }
     static optimizeEquipmentSlots(girl) {
+        var _a;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
@@ -11972,9 +11966,10 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_a) { /* ignore */ }
+                    catch ( /* ignore */_b) { /* ignore */ }
                 }
-                const inventoryItems = [];
+                const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
+                const allDomItems = [];
                 $('.right-section .slot[data-d]').each(function () {
                     const raw = $(this).attr('data-d');
                     if (!raw)
@@ -11982,13 +11977,24 @@ class HaremGirl {
                     try {
                         const data = JSON.parse(raw);
                         if (data && data.caracs)
-                            inventoryItems.push({ el: $(this), data });
+                            allDomItems.push({ el: $(this), data });
                     }
                     catch ( /* ignore */_a) { /* ignore */ }
                 });
-                LogUtils_logHHAuto(`Slot ${i}: DOM has ${totalItems} items, ${inventoryItems.length} usable candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
+                // Filter candidates by slot_index so we don't compare pants to necklaces
+                const inventoryItems = allDomItems.filter(it => Number(it.data.slot_index) === Number(targetSlotIndex));
+                // Diagnostic: slot_index distribution + top rarities in inventory
+                const slotDist = {};
+                const rarityDist = {};
+                for (const it of allDomItems) {
+                    const si = String(it.data.slot_index);
+                    slotDist[si] = (slotDist[si] || 0) + 1;
+                    const ra = String(it.data.rarity);
+                    rarityDist[ra] = (rarityDist[ra] || 0) + 1;
+                }
+                LogUtils_logHHAuto(`Slot ${i}: targetSlotIndex=${targetSlotIndex}, DOM items=${allDomItems.length}, candidates=${inventoryItems.length}, slot_index_dist=${JSON.stringify(slotDist)}, rarity_dist=${JSON.stringify(rarityDist)}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} si=${equippedData.slot_index}` : 'none'}`);
                 if (inventoryItems.length === 0) {
-                    LogUtils_logHHAuto(`Slot ${i}: no inventory items available, skipping`);
+                    LogUtils_logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
                     continue;
                 }
                 // Rank candidates: total stats, then resonance, then individual stats

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.2",
+  "version": "7.35.3",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -23,8 +23,8 @@ import {
     getStoredJSON
 } from "../../Helper/index";
 import { Harem } from "../index";
-import { addNutakuSession, gotoPage } from "../../Service/index";
-import { displayHHPopUp, fillHHPopUp, getHHAjax, logHHAuto, maskHHPopUp } from "../../Utils/index";
+import { gotoPage } from "../../Service/index";
+import { displayHHPopUp, fillHHPopUp, logHHAuto, maskHHPopUp } from "../../Utils/index";
 import { HHAuto_inputPattern, HHStoredVarPrefixKey, SK, TK } from "../../config/index";
 import { KKHaremGirl, TeamData } from "../../model/index";
 
@@ -825,112 +825,133 @@ export class HaremGirl {
         }
     }
 
+    private static equipItem(girlId: number | string, armorId: number | string): Promise<any> {
+        return new Promise((resolve) => {
+            $.ajax({
+                url: '/ajax.php',
+                type: 'POST',
+                data: {
+                    action: 'girl_equipment_equip',
+                    id_girl: girlId,
+                    id_girl_armor: armorId,
+                    sort_by: 'rarity',
+                    sorting_order: 'asc'
+                },
+                dataType: 'json',
+                success: function (data: any) { resolve(data); },
+                error: function () { resolve(null); }
+            });
+        });
+    }
+
+    private static scoreItem(item: any, girl: KKHaremGirl): { caracSum: number, resonanceMatches: number } {
+        const c = item.caracs;
+        const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
+        let resonanceMatches = 0;
+        if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
+            const rb = item.resonance_bonuses;
+            if (rb.class && String(rb.class.identifier) === String(girl.class)) resonanceMatches++;
+            if (rb.element && String(rb.element.identifier) === String(girl.element)) resonanceMatches++;
+            if (rb.figure && String(rb.figure.identifier) === String(girl.figure)) resonanceMatches++;
+        }
+        return { caracSum, resonanceMatches };
+    }
+
+    private static findBestItem(items: any[], girl: KKHaremGirl): any {
+        if (items.length === 0) return null;
+        return items.sort((a, b) => {
+            const sa = HaremGirl.scoreItem(a, girl);
+            const sb = HaremGirl.scoreItem(b, girl);
+            if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
+            if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
+            return ((b.caracs.carac1||0)+(b.caracs.carac2||0)+(b.caracs.carac3||0))
+                 - ((a.caracs.carac1||0)+(a.caracs.carac2||0)+(a.caracs.carac3||0));
+        })[0];
+    }
+
+    private static isBetter(candidate: any, current: any, girl: KKHaremGirl): boolean {
+        if (!current || !current.caracs) return true;
+        const sc = HaremGirl.scoreItem(candidate, girl);
+        const se = HaremGirl.scoreItem(current, girl);
+        if (sc.caracSum > se.caracSum) return true;
+        if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches) return true;
+        return false;
+    }
+
     static async optimizeEquipmentSlots(girl: KKHaremGirl) {
         const equipmentSlots = $('.equipment_slot');
         const slotCount = equipmentSlots.length;
 
         logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
-        const scoreItem = (item: any): { caracSum: number, resonanceMatches: number } => {
-            const c = item.caracs;
-            const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
-            let resonanceMatches = 0;
-            if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
-                const rb = item.resonance_bonuses;
-                if (rb.class && String(rb.class.identifier) === String(girl.class)) resonanceMatches++;
-                if (rb.element && String(rb.element.identifier) === String(girl.element)) resonanceMatches++;
-                if (rb.figure && String(rb.figure.identifier) === String(girl.figure)) resonanceMatches++;
-            }
-            return { caracSum, resonanceMatches };
-        };
-
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
             slot.trigger('click');
             await TimeHelper.sleep(randomInterval(300, 500));
 
+            // Read currently equipped item from DOM
             const equippedEl = slot.find('.slot[data-d]');
             let equippedData: any = null;
             if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
                 equippedData = JSON.parse(equippedEl.attr('data-d')!);
             }
 
-            const inventoryItems: { data: any }[] = [];
+            // Get any visible inventory item ID to make the initial API call
+            let probeArmorId: string | null = null;
             $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                if (probeArmorId) return;
                 const raw = $(this).attr('data-d');
                 if (!raw) return;
                 const data = JSON.parse(raw);
-                if (data.caracs && data.type === 'girl_armor') {
-                    inventoryItems.push({ data });
+                if (data.id_girl_armor && data.type === 'girl_armor') {
+                    probeArmorId = data.id_girl_armor;
                 }
             });
 
-            if (inventoryItems.length === 0) {
+            if (!probeArmorId) {
                 logHHAuto(`Slot ${i}: no inventory items available, skipping`);
                 continue;
             }
 
-            inventoryItems.sort((a, b) => {
-                const sa = scoreItem(a.data);
-                const sb = scoreItem(b.data);
-                if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
-                if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
-                const ca = a.data.caracs;
-                const cb = b.data.caracs;
-                return ((cb.carac1||0)+(cb.carac2||0)+(cb.carac3||0)) - ((ca.carac1||0)+(ca.carac2||0)+(ca.carac3||0));
-            });
-
-            const best = inventoryItems[0];
-            if (!best) continue;
-
-            const bestScore = scoreItem(best.data);
-            let shouldReplace = false;
-
-            if (!equippedData || !equippedData.caracs) {
-                shouldReplace = true;
-            } else {
-                const equippedScore = scoreItem(equippedData);
-                if (bestScore.caracSum > equippedScore.caracSum) {
-                    shouldReplace = true;
-                } else if (bestScore.caracSum === equippedScore.caracSum && bestScore.resonanceMatches > equippedScore.resonanceMatches) {
-                    shouldReplace = true;
-                }
-            }
-
-            if (shouldReplace) {
-                const armorId = best.data.id_girl_armor;
-                logHHAuto(`Slot ${i}: replacing with better item (L${best.data.level} ${best.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${armorId})`);
-
-                await new Promise<void>((resolve) => {
-                    $.ajax({
-                        url: '/ajax.php',
-                        type: 'POST',
-                        data: {
-                            action: 'girl_equipment_equip',
-                            id_girl: girl.id_girl,
-                            id_girl_armor: armorId,
-                            sort_by: 'rarity',
-                            sorting_order: 'asc'
-                        },
-                        dataType: 'json',
-                        success: function (data: any) {
-                            if (data && data.success) {
-                                logHHAuto(`Slot ${i}: equipped successfully`);
-                            } else {
-                                logHHAuto(`Slot ${i}: equip response: ${JSON.stringify(data)}`);
-                            }
-                            resolve();
-                        },
-                        error: function (xhr: any, status: string, error: string) {
-                            logHHAuto(`Slot ${i}: equip HTTP error: ${status} ${error} (${xhr.status})`);
-                            resolve();
-                        }
-                    });
-                });
+            // Step 1: Equip any visible item to get the full inventory from the API
+            const probeResponse = await HaremGirl.equipItem(girl.id_girl, probeArmorId);
+            if (!probeResponse || !probeResponse.success) {
+                logHHAuto(`Slot ${i}: probe equip failed`);
                 await TimeHelper.sleep(randomInterval(300, 500));
-            } else {
-                logHHAuto(`Slot ${i}: current item is optimal`);
+                continue;
             }
+
+            // Build full candidate list from API response
+            const candidates: any[] = [...(probeResponse.inventory_armor || [])];
+            if (probeResponse.unequipped_armor) {
+                candidates.push(probeResponse.unequipped_armor);
+            }
+            const currentlyEquipped = probeResponse.equipped_armor || null;
+
+            if (candidates.length === 0) {
+                logHHAuto(`Slot ${i}: no alternative items from API`);
+                await TimeHelper.sleep(randomInterval(300, 500));
+                continue;
+            }
+
+            // Step 2: Find the absolute best from the complete inventory
+            const best = HaremGirl.findBestItem(candidates, girl);
+
+            if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
+                const bestScore = HaremGirl.scoreItem(best, girl);
+                logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+
+                const equipResponse = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
+                if (equipResponse && equipResponse.success) {
+                    logHHAuto(`Slot ${i}: equipped successfully`);
+                } else {
+                    logHHAuto(`Slot ${i}: equip failed`);
+                }
+            } else {
+                const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
+                logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+            }
+            await TimeHelper.sleep(randomInterval(300, 500));
         }
         logHHAuto('Equipment optimization complete');
     }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -712,34 +712,10 @@ export class HaremGirl {
 
                     HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
 
-                    // Use API call instead of synthetic click for reliable auto-equip
-                    const equipAllResponse = await new Promise<any>((resolve) => {
-                        $.ajax({
-                            url: '/ajax.php',
-                            type: 'POST',
-                            data: {
-                                action: 'girl_equipment_equip_all',
-                                id_girl: girl.id_girl
-                            },
-                            dataType: 'json',
-                            success: function (data: any) {
-                                if (data && data.success) {
-                                    logHHAuto(`Auto-equip via API successful for ${girl.name}, ${data.equipped_armor_ids?.length || 0} slots equipped`);
-                                    resolve(data);
-                                } else {
-                                    logHHAuto(`Auto-equip via API response: ${JSON.stringify(data)}`);
-                                    resolve(null);
-                                }
-                            },
-                            error: function () {
-                                logHHAuto(`Auto-equip via API failed for ${girl.name}`);
-                                resolve(null);
-                            }
-                        });
-                    });
+                    $('#girl-equip').trigger('click');
                     await TimeHelper.sleep(randomInterval(400, 700));
 
-                    await HaremGirl.optimizeEquipmentSlots(girl, equipAllResponse);
+                    await HaremGirl.optimizeEquipmentSlots(girl);
                 }
                 if (upgradeSkill) {
                     HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
@@ -908,67 +884,114 @@ export class HaremGirl {
         return false;
     }
 
-    static async optimizeEquipmentSlots(girl: KKHaremGirl, equipAllResponse: any) {
-        logHHAuto(`Optimize equipment for ${girl.name}`);
+    static async optimizeEquipmentSlots(girl: KKHaremGirl) {
+        const equipmentSlots = $('.equipment_slot');
+        const slotCount = equipmentSlots.length;
 
-        if (!equipAllResponse) {
-            logHHAuto('No equip_all response, skipping optimization');
-            return;
+        logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+
+        // Collect all equipped items first (DOM is reliable for equipped slots)
+        const slotItems: { slotIndex: number, equippedData: any }[] = [];
+        for (let i = 0; i < slotCount; i++) {
+            const slot = equipmentSlots.eq(i);
+            const equippedEl = slot.find('.slot[data-d]');
+            let equippedData: any = null;
+            if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                equippedData = JSON.parse(equippedEl.attr('data-d')!);
+            }
+            const slotIndex = equippedData?.slot_index ?? (i + 1);
+            slotItems.push({ slotIndex, equippedData });
+            logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
         }
 
-        // Extract equipped item IDs from equip_all response
-        // Response structure: equipped_armor_ids[].id_girl_armor_equipped = inventory item ID for equip API
-        let equippedItemIds: string[] = [];
+        for (let i = 0; i < slotCount; i++) {
+            const { slotIndex, equippedData } = slotItems[i];
 
-        if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
-            equippedItemIds = equipAllResponse.equipped_armor_ids
-                .filter((entry: any) => entry && entry.id_girl_armor)
-                .map((entry: any) => String(entry.id_girl_armor));
-            logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
-        }
+            if (!equippedData || !equippedData.id_girl_armor) {
+                logHHAuto(`Slot ${i}: no equipped item, skipping`);
+                continue;
+            }
 
-        if (equippedItemIds.length === 0) {
-            logHHAuto('No equipped item IDs found in equip_all response, cannot optimize.');
-            return;
-        }
-
-        // For each equipped item, re-equip it as probe to get the full inventory for that slot
-        for (let i = 0; i < equippedItemIds.length; i++) {
-            const armorId = equippedItemIds[i];
-            logHHAuto(`Slot ${i}: probing with equipped item id=${armorId}`);
-
-            const probeResponse = await HaremGirl.equipItem(girl.id_girl, armorId);
+            // Step 1: Re-equip the current item to get the full inventory for this slot from the API
+            const probeResponse = await HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
             if (!probeResponse || !probeResponse.success) {
-                logHHAuto(`Slot ${i}: probe equip failed, skipping`);
+                logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+
+                // Fallback: find any DOM item matching this slot_index
+                let fallbackId: string | null = null;
+                $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                    if (fallbackId) return;
+                    const raw = $(this).attr('data-d');
+                    if (!raw) return;
+                    const data = JSON.parse(raw);
+                    if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
+                        fallbackId = data.id_girl_armor;
+                    }
+                });
+
+                if (!fallbackId) {
+                    logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
+                    await TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+
+                const fallbackResponse = await HaremGirl.equipItem(girl.id_girl, fallbackId);
+                if (!fallbackResponse || !fallbackResponse.success) {
+                    logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
+                    await TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+
+                // Use fallback response
+                const fbCandidates: any[] = [...(fallbackResponse.inventory_armor || [])];
+                if (fallbackResponse.unequipped_armor) fbCandidates.push(fallbackResponse.unequipped_armor);
+                const fbEquipped = fallbackResponse.equipped_armor || null;
+                const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
+
+                if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
+                    const fbScore = HaremGirl.scoreItem(fbBest, girl);
+                    logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
+                    const eqResp = await HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
+                    logHHAuto(`Slot ${i}: ${eqResp?.success ? 'equipped successfully' : 'equip failed'}`);
+                } else {
+                    const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
+                    logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped?.level} ${fbEquipped?.rarity}, score=${s?.caracSum})`);
+                }
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }
 
+            // Probe succeeded: build full candidate list from API response
             const candidates: any[] = [...(probeResponse.inventory_armor || [])];
             if (probeResponse.unequipped_armor) {
                 candidates.push(probeResponse.unequipped_armor);
             }
             const currentlyEquipped = probeResponse.equipped_armor || null;
-            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates`);
+            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
 
             if (candidates.length === 0) {
                 const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: no alternatives, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+                logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }
 
+            // Step 2: Find the absolute best from the complete inventory
             const best = HaremGirl.findBestItem(candidates, girl);
 
             if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
                 const bestScore = HaremGirl.scoreItem(best, girl);
-                logHHAuto(`Slot ${i}: replacing with better item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+                logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
 
                 const equipResponse = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                logHHAuto(`Slot ${i}: ${equipResponse?.success ? 'equipped successfully' : 'equip failed'}`);
+                if (equipResponse && equipResponse.success) {
+                    logHHAuto(`Slot ${i}: equipped successfully`);
+                } else {
+                    logHHAuto(`Slot ${i}: equip failed`);
+                }
             } else {
                 const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: current is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+                logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
             }
             await TimeHelper.sleep(randomInterval(300, 500));
         }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -916,8 +916,8 @@ export class HaremGirl {
 
         if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
             equippedItemIds = equipAllResponse.equipped_armor_ids
-                .filter((entry: any) => entry && entry.id_girl_armor_equipped)
-                .map((entry: any) => String(entry.id_girl_armor_equipped));
+                .filter((entry: any) => entry && entry.id_girl_armor)
+                .map((entry: any) => String(entry.id_girl_armor));
             logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
         }
 

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -901,7 +901,11 @@ export class HaremGirl {
             }
             const slotIndex = equippedData?.slot_index ?? (i + 1);
             slotItems.push({ slotIndex, equippedData });
-            logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+            if (equippedData) {
+                logHHAuto(`Slot ${i}: data-d keys=${JSON.stringify(Object.keys(equippedData))}, slot_index=${slotIndex}, L${equippedData.level} ${equippedData.rarity}`);
+            } else {
+                logHHAuto(`Slot ${i}: no data-d, slot_index=${slotIndex}`);
+            }
         }
 
         for (let i = 0; i < slotCount; i++) {

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -891,47 +891,37 @@ export class HaremGirl {
      * back to the top so the game has rendered every item into the DOM.
      */
     private static async forceLoadAllInventoryItems(): Promise<number> {
-        // Likely scroll containers for the inventory panel (right side)
-        const candidateSelectors = [
-            '.right-section .scrollable',
-            '.right-section .inventory',
-            '.right-section .items-list',
-            '.right-section > div',
-            '.right-section'
-        ];
-        let container: HTMLElement | null = null;
-        for (const sel of candidateSelectors) {
-            const el = document.querySelector(sel) as HTMLElement | null;
-            if (el && el.scrollHeight > el.clientHeight + 10) {
-                container = el;
-                break;
-            }
-        }
-        if (!container) {
-            // fallback: take first .right-section descendant with overflow
-            document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
-                if (container) return;
-                const h = el as HTMLElement;
-                if (h.scrollHeight > h.clientHeight + 10) container = h;
-            });
-        }
-
         const countItems = () => $('.right-section .slot[data-d]').length;
 
-        let prevCount = countItems();
-        if (!container) {
-            logHHAuto(`forceLoadAllInventoryItems: no scrollable container found, current DOM items=${prevCount}`);
-            return prevCount;
-        }
+        // Find ALL scrollable elements in the right section (element with scrollHeight > clientHeight)
+        const scrollables: HTMLElement[] = [];
+        document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
+            const h = el as HTMLElement;
+            if (h.scrollHeight > h.clientHeight + 5) scrollables.push(h);
+        });
+        // Also try the document/body as fallback
+        scrollables.push(document.scrollingElement as HTMLElement || document.body);
 
-        for (let iter = 0; iter < 20; iter++) {
-            container.scrollTop = container.scrollHeight;
+        let prevCount = countItems();
+        logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
+
+        for (let iter = 0; iter < 15; iter++) {
+            // scroll each scrollable to its bottom and dispatch a scroll event
+            for (const s of scrollables) {
+                try {
+                    s.scrollTop = s.scrollHeight;
+                    s.dispatchEvent(new Event('scroll', { bubbles: true }));
+                } catch { /* ignore */ }
+            }
             await TimeHelper.sleep(randomInterval(200, 350));
             const curCount = countItems();
             if (curCount === prevCount) break;
             prevCount = curCount;
         }
-        container.scrollTop = 0;
+        // scroll back up so the chosen item's scrollIntoView works reliably
+        for (const s of scrollables) {
+            try { s.scrollTop = 0; } catch { /* ignore */ }
+        }
         await TimeHelper.sleep(randomInterval(150, 250));
         return countItems();
     }
@@ -956,20 +946,34 @@ export class HaremGirl {
                 try { equippedData = JSON.parse(equippedEl.attr('data-d')!); } catch { /* ignore */ }
             }
 
-            const inventoryItems: { el: JQuery<HTMLElement>, data: any }[] = [];
+            const targetSlotIndex = equippedData?.slot_index ?? (i + 1);
+
+            const allDomItems: { el: JQuery<HTMLElement>, data: any }[] = [];
             $('.right-section .slot[data-d]').each(function () {
                 const raw = $(this).attr('data-d');
                 if (!raw) return;
                 try {
                     const data = JSON.parse(raw);
-                    if (data && data.caracs) inventoryItems.push({ el: $(this), data });
+                    if (data && data.caracs) allDomItems.push({ el: $(this), data });
                 } catch { /* ignore */ }
             });
 
-            logHHAuto(`Slot ${i}: DOM has ${totalItems} items, ${inventoryItems.length} usable candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
+            // Filter candidates by slot_index so we don't compare pants to necklaces
+            const inventoryItems = allDomItems.filter(it => Number(it.data.slot_index) === Number(targetSlotIndex));
+
+            // Diagnostic: slot_index distribution + top rarities in inventory
+            const slotDist: { [k: string]: number } = {};
+            const rarityDist: { [k: string]: number } = {};
+            for (const it of allDomItems) {
+                const si = String(it.data.slot_index);
+                slotDist[si] = (slotDist[si] || 0) + 1;
+                const ra = String(it.data.rarity);
+                rarityDist[ra] = (rarityDist[ra] || 0) + 1;
+            }
+            logHHAuto(`Slot ${i}: targetSlotIndex=${targetSlotIndex}, DOM items=${allDomItems.length}, candidates=${inventoryItems.length}, slot_index_dist=${JSON.stringify(slotDist)}, rarity_dist=${JSON.stringify(rarityDist)}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} si=${equippedData.slot_index}` : 'none'}`);
 
             if (inventoryItems.length === 0) {
-                logHHAuto(`Slot ${i}: no inventory items available, skipping`);
+                logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
                 continue;
             }
 

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -862,8 +862,14 @@ export class HaremGirl {
                     sorting_order: 'asc'
                 },
                 dataType: 'json',
-                success: function (data: any) { resolve(data); },
-                error: function () { resolve(null); }
+                success: function (data: any) {
+                    logHHAuto(`equipItem response for armor ${armorId}: success=${data?.success}, keys=${JSON.stringify(Object.keys(data || {}))}`);
+                    resolve(data);
+                },
+                error: function (xhr: any, status: string, error: string) {
+                    logHHAuto(`equipItem HTTP error for armor ${armorId}: status=${status}, error=${error}, response=${xhr?.responseText?.substring(0, 200)}`);
+                    resolve(null);
+                }
             });
         });
     }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -724,9 +724,7 @@ export class HaremGirl {
                             dataType: 'json',
                             success: function (data: any) {
                                 if (data && data.success) {
-                                    logHHAuto(`Auto-equip via API successful for ${girl.name}`);
-                                    logHHAuto(`equip_all response keys: ${JSON.stringify(Object.keys(data))}`);
-                                    logHHAuto(`equip_all response: ${JSON.stringify(data)}`);
+                                    logHHAuto(`Auto-equip via API successful for ${girl.name}, ${data.equipped_armor_ids?.length || 0} slots equipped`);
                                     resolve(data);
                                 } else {
                                     logHHAuto(`Auto-equip via API response: ${JSON.stringify(data)}`);
@@ -912,43 +910,19 @@ export class HaremGirl {
             return;
         }
 
-        // Try to extract equipped item IDs from the equip_all response
-        // We don't know the exact structure yet, so we log and try common patterns
+        // Extract equipped item IDs from equip_all response
+        // Response structure: equipped_armor_ids[].id_girl_armor_equipped = inventory item ID for equip API
         let equippedItemIds: string[] = [];
 
-        if (equipAllResponse.items && Array.isArray(equipAllResponse.items)) {
-            equippedItemIds = equipAllResponse.items
-                .filter((item: any) => item && item.id_girl_armor)
-                .map((item: any) => String(item.id_girl_armor));
-            logHHAuto(`Found ${equippedItemIds.length} equipped items from response.items`);
-        }
-
-        if (equippedItemIds.length === 0 && equipAllResponse.equipped_armors && Array.isArray(equipAllResponse.equipped_armors)) {
-            equippedItemIds = equipAllResponse.equipped_armors
-                .filter((item: any) => item && item.id_girl_armor)
-                .map((item: any) => String(item.id_girl_armor));
-            logHHAuto(`Found ${equippedItemIds.length} equipped items from response.equipped_armors`);
-        }
-
-        // Fallback: try reading from DOM (may work if page was already loaded)
-        if (equippedItemIds.length === 0) {
-            const equipmentSlots = $('.equipment_slot');
-            for (let i = 0; i < equipmentSlots.length; i++) {
-                const equippedEl = equipmentSlots.eq(i).find('.slot[data-d]');
-                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                    const data = JSON.parse(equippedEl.attr('data-d')!);
-                    if (data.id_girl_armor) {
-                        equippedItemIds.push(String(data.id_girl_armor));
-                    }
-                }
-            }
-            if (equippedItemIds.length > 0) {
-                logHHAuto(`Found ${equippedItemIds.length} equipped items from DOM fallback`);
-            }
+        if (equipAllResponse.equipped_armor_ids && Array.isArray(equipAllResponse.equipped_armor_ids)) {
+            equippedItemIds = equipAllResponse.equipped_armor_ids
+                .filter((entry: any) => entry && entry.id_girl_armor_equipped)
+                .map((entry: any) => String(entry.id_girl_armor_equipped));
+            logHHAuto(`Found ${equippedItemIds.length} equipped items from equipped_armor_ids`);
         }
 
         if (equippedItemIds.length === 0) {
-            logHHAuto('No equipped item IDs found, cannot optimize. Check equip_all response log above.');
+            logHHAuto('No equipped item IDs found in equip_all response, cannot optimize.');
             return;
         }
 

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -712,10 +712,36 @@ export class HaremGirl {
 
                     HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
 
-                    $('#girl-equip').trigger('click');
+                    // Use API call instead of synthetic click for reliable auto-equip
+                    const equipAllResponse = await new Promise<any>((resolve) => {
+                        $.ajax({
+                            url: '/ajax.php',
+                            type: 'POST',
+                            data: {
+                                action: 'girl_equipment_equip_all',
+                                id_girl: girl.id_girl
+                            },
+                            dataType: 'json',
+                            success: function (data: any) {
+                                if (data && data.success) {
+                                    logHHAuto(`Auto-equip via API successful for ${girl.name}`);
+                                    logHHAuto(`equip_all response keys: ${JSON.stringify(Object.keys(data))}`);
+                                    logHHAuto(`equip_all response: ${JSON.stringify(data)}`);
+                                    resolve(data);
+                                } else {
+                                    logHHAuto(`Auto-equip via API response: ${JSON.stringify(data)}`);
+                                    resolve(null);
+                                }
+                            },
+                            error: function () {
+                                logHHAuto(`Auto-equip via API failed for ${girl.name}`);
+                                resolve(null);
+                            }
+                        });
+                    });
                     await TimeHelper.sleep(randomInterval(400, 700));
 
-                    await HaremGirl.optimizeEquipmentSlots(girl);
+                    await HaremGirl.optimizeEquipmentSlots(girl, equipAllResponse);
                 }
                 if (upgradeSkill) {
                     HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
@@ -878,114 +904,91 @@ export class HaremGirl {
         return false;
     }
 
-    static async optimizeEquipmentSlots(girl: KKHaremGirl) {
-        const equipmentSlots = $('.equipment_slot');
-        const slotCount = equipmentSlots.length;
+    static async optimizeEquipmentSlots(girl: KKHaremGirl, equipAllResponse: any) {
+        logHHAuto(`Optimize equipment for ${girl.name}`);
 
-        logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-
-        // Collect all equipped items first (DOM is reliable for equipped slots)
-        const slotItems: { slotIndex: number, equippedData: any }[] = [];
-        for (let i = 0; i < slotCount; i++) {
-            const slot = equipmentSlots.eq(i);
-            const equippedEl = slot.find('.slot[data-d]');
-            let equippedData: any = null;
-            if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                equippedData = JSON.parse(equippedEl.attr('data-d')!);
-            }
-            const slotIndex = equippedData?.slot_index ?? (i + 1);
-            slotItems.push({ slotIndex, equippedData });
-            logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+        if (!equipAllResponse) {
+            logHHAuto('No equip_all response, skipping optimization');
+            return;
         }
 
-        for (let i = 0; i < slotCount; i++) {
-            const { slotIndex, equippedData } = slotItems[i];
+        // Try to extract equipped item IDs from the equip_all response
+        // We don't know the exact structure yet, so we log and try common patterns
+        let equippedItemIds: string[] = [];
 
-            if (!equippedData || !equippedData.id_girl_armor) {
-                logHHAuto(`Slot ${i}: no equipped item, skipping`);
-                continue;
-            }
+        if (equipAllResponse.items && Array.isArray(equipAllResponse.items)) {
+            equippedItemIds = equipAllResponse.items
+                .filter((item: any) => item && item.id_girl_armor)
+                .map((item: any) => String(item.id_girl_armor));
+            logHHAuto(`Found ${equippedItemIds.length} equipped items from response.items`);
+        }
 
-            // Step 1: Re-equip the current item to get the full inventory for this slot from the API
-            const probeResponse = await HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
-            if (!probeResponse || !probeResponse.success) {
-                logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+        if (equippedItemIds.length === 0 && equipAllResponse.equipped_armors && Array.isArray(equipAllResponse.equipped_armors)) {
+            equippedItemIds = equipAllResponse.equipped_armors
+                .filter((item: any) => item && item.id_girl_armor)
+                .map((item: any) => String(item.id_girl_armor));
+            logHHAuto(`Found ${equippedItemIds.length} equipped items from response.equipped_armors`);
+        }
 
-                // Fallback: find any DOM item matching this slot_index
-                let fallbackId: string | null = null;
-                $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                    if (fallbackId) return;
-                    const raw = $(this).attr('data-d');
-                    if (!raw) return;
-                    const data = JSON.parse(raw);
-                    if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
-                        fallbackId = data.id_girl_armor;
+        // Fallback: try reading from DOM (may work if page was already loaded)
+        if (equippedItemIds.length === 0) {
+            const equipmentSlots = $('.equipment_slot');
+            for (let i = 0; i < equipmentSlots.length; i++) {
+                const equippedEl = equipmentSlots.eq(i).find('.slot[data-d]');
+                if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                    const data = JSON.parse(equippedEl.attr('data-d')!);
+                    if (data.id_girl_armor) {
+                        equippedItemIds.push(String(data.id_girl_armor));
                     }
-                });
-
-                if (!fallbackId) {
-                    logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
-                    await TimeHelper.sleep(randomInterval(300, 500));
-                    continue;
                 }
+            }
+            if (equippedItemIds.length > 0) {
+                logHHAuto(`Found ${equippedItemIds.length} equipped items from DOM fallback`);
+            }
+        }
 
-                const fallbackResponse = await HaremGirl.equipItem(girl.id_girl, fallbackId);
-                if (!fallbackResponse || !fallbackResponse.success) {
-                    logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
-                    await TimeHelper.sleep(randomInterval(300, 500));
-                    continue;
-                }
+        if (equippedItemIds.length === 0) {
+            logHHAuto('No equipped item IDs found, cannot optimize. Check equip_all response log above.');
+            return;
+        }
 
-                // Use fallback response
-                const fbCandidates: any[] = [...(fallbackResponse.inventory_armor || [])];
-                if (fallbackResponse.unequipped_armor) fbCandidates.push(fallbackResponse.unequipped_armor);
-                const fbEquipped = fallbackResponse.equipped_armor || null;
-                const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
+        // For each equipped item, re-equip it as probe to get the full inventory for that slot
+        for (let i = 0; i < equippedItemIds.length; i++) {
+            const armorId = equippedItemIds[i];
+            logHHAuto(`Slot ${i}: probing with equipped item id=${armorId}`);
 
-                if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
-                    const fbScore = HaremGirl.scoreItem(fbBest, girl);
-                    logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
-                    const eqResp = await HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
-                    logHHAuto(`Slot ${i}: ${eqResp?.success ? 'equipped successfully' : 'equip failed'}`);
-                } else {
-                    const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
-                    logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped?.level} ${fbEquipped?.rarity}, score=${s?.caracSum})`);
-                }
+            const probeResponse = await HaremGirl.equipItem(girl.id_girl, armorId);
+            if (!probeResponse || !probeResponse.success) {
+                logHHAuto(`Slot ${i}: probe equip failed, skipping`);
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }
 
-            // Probe succeeded: build full candidate list from API response
             const candidates: any[] = [...(probeResponse.inventory_armor || [])];
             if (probeResponse.unequipped_armor) {
                 candidates.push(probeResponse.unequipped_armor);
             }
             const currentlyEquipped = probeResponse.equipped_armor || null;
-            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
+            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates`);
 
             if (candidates.length === 0) {
                 const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+                logHHAuto(`Slot ${i}: no alternatives, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }
 
-            // Step 2: Find the absolute best from the complete inventory
             const best = HaremGirl.findBestItem(candidates, girl);
 
             if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
                 const bestScore = HaremGirl.scoreItem(best, girl);
-                logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+                logHHAuto(`Slot ${i}: replacing with better item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
 
                 const equipResponse = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                if (equipResponse && equipResponse.success) {
-                    logHHAuto(`Slot ${i}: equipped successfully`);
-                } else {
-                    logHHAuto(`Slot ${i}: equip failed`);
-                }
+                logHHAuto(`Slot ${i}: ${equipResponse?.success ? 'equipped successfully' : 'equip failed'}`);
             } else {
                 const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+                logHHAuto(`Slot ${i}: current is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
             }
             await TimeHelper.sleep(randomInterval(300, 500));
         }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -997,10 +997,52 @@ export class HaremGirl {
                 const raw = bestInventory.el.get(0);
                 if (raw && typeof raw.scrollIntoView === 'function') {
                     raw.scrollIntoView({ block: 'center' });
-                    await TimeHelper.sleep(randomInterval(150, 250));
+                    await TimeHelper.sleep(randomInterval(200, 300));
                 }
-                bestInventory.el.trigger('click');
-                await TimeHelper.sleep(randomInterval(400, 600));
+                // Native click to trigger the game's selection handler reliably
+                if (raw && typeof raw.click === 'function') {
+                    raw.click();
+                } else {
+                    bestInventory.el.trigger('click');
+                }
+                await TimeHelper.sleep(randomInterval(300, 500));
+
+                // Find and click the Equip / confirm button. Log which button we found.
+                const equipBtnSelectors = [
+                    '#equip-button',
+                    '.equip-button',
+                    'button.equip',
+                    '[class*="equip"] button',
+                    '.right-section button',
+                    '.footer .equip',
+                    'button:contains("Equip")',
+                    'button:contains("equip")'
+                ];
+                let equipBtn: JQuery<HTMLElement> | null = null;
+                for (const sel of equipBtnSelectors) {
+                    try {
+                        const $b = $(sel).filter(':visible').not(':disabled').first();
+                        if ($b.length > 0) {
+                            equipBtn = $b;
+                            logHHAuto(`Slot ${i}: equip button found via selector "${sel}" (text="${$b.text().trim().substring(0, 30)}")`);
+                            break;
+                        }
+                    } catch { /* ignore selector errors */ }
+                }
+                if (equipBtn && equipBtn.length > 0) {
+                    const btnRaw = equipBtn.get(0);
+                    if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
+                    else equipBtn.trigger('click');
+                    await TimeHelper.sleep(randomInterval(400, 700));
+                    logHHAuto(`Slot ${i}: equip button clicked`);
+                } else {
+                    // Fallback: list all visible buttons in the right section for diagnosis
+                    const btnList: string[] = [];
+                    $('.right-section button, .right-section .myButton, .right-section [class*="btn"]').filter(':visible').each(function () {
+                        btnList.push(`${this.tagName}.${(this.className || '').substring(0, 40)}:"${$(this).text().trim().substring(0, 20)}"`);
+                    });
+                    logHHAuto(`Slot ${i}: NO equip button found. Visible buttons in right-section: ${JSON.stringify(btnList)}`);
+                }
             } else {
                 const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;
                 logHHAuto(`Slot ${i}: current item is optimal (L${equippedData?.level} ${equippedData?.rarity}, score=${eqScore?.caracSum})`);

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -1007,41 +1007,16 @@ export class HaremGirl {
                 }
                 await TimeHelper.sleep(randomInterval(300, 500));
 
-                // Find and click the Equip / confirm button. Log which button we found.
-                const equipBtnSelectors = [
-                    '#equip-button',
-                    '.equip-button',
-                    'button.equip',
-                    '[class*="equip"] button',
-                    '.right-section button',
-                    '.footer .equip',
-                    'button:contains("Equip")',
-                    'button:contains("equip")'
-                ];
-                let equipBtn: JQuery<HTMLElement> | null = null;
-                for (const sel of equipBtnSelectors) {
-                    try {
-                        const $b = $(sel).filter(':visible').not(':disabled').first();
-                        if ($b.length > 0) {
-                            equipBtn = $b;
-                            logHHAuto(`Slot ${i}: equip button found via selector "${sel}" (text="${$b.text().trim().substring(0, 30)}")`);
-                            break;
-                        }
-                    } catch { /* ignore selector errors */ }
-                }
-                if (equipBtn && equipBtn.length > 0) {
-                    const btnRaw = equipBtn.get(0);
+                // Click the Equip confirm button (revealed after item selection)
+                const $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                if ($equipBtn.length > 0) {
+                    const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                     if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
-                    else equipBtn.trigger('click');
+                    else $equipBtn.trigger('click');
                     await TimeHelper.sleep(randomInterval(400, 700));
                     logHHAuto(`Slot ${i}: equip button clicked`);
                 } else {
-                    // Fallback: list all visible buttons in the right section for diagnosis
-                    const btnList: string[] = [];
-                    $('.right-section button, .right-section .myButton, .right-section [class*="btn"]').filter(':visible').each(function () {
-                        btnList.push(`${this.tagName}.${(this.className || '').substring(0, 40)}:"${$(this).text().trim().substring(0, 20)}"`);
-                    });
-                    logHHAuto(`Slot ${i}: NO equip button found. Visible buttons in right-section: ${JSON.stringify(btnList)}`);
+                    logHHAuto(`Slot ${i}: #girl-equipment-equip not found`);
                 }
             } else {
                 const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -712,9 +712,6 @@ export class HaremGirl {
 
                     HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
 
-                    $('#girl-equip').trigger('click');
-                    await TimeHelper.sleep(randomInterval(400, 700));
-
                     await HaremGirl.optimizeEquipmentSlots(girl);
                 }
                 if (upgradeSkill) {
@@ -884,120 +881,88 @@ export class HaremGirl {
         return false;
     }
 
+    private static equipAllApi(girlId: number | string): Promise<any> {
+        return new Promise((resolve) => {
+            $.ajax({
+                url: '/ajax.php',
+                type: 'POST',
+                data: { action: 'girl_equipment_equip_all', id_girl: girlId },
+                dataType: 'json',
+                success: (data: any) => resolve(data),
+                error: (xhr: any, status: string) => {
+                    logHHAuto(`equipAllApi HTTP error: status=${status}`);
+                    resolve(null);
+                }
+            });
+        });
+    }
+
     static async optimizeEquipmentSlots(girl: KKHaremGirl) {
-        const equipmentSlots = $('.equipment_slot');
-        const slotCount = equipmentSlots.length;
+        logHHAuto(`Optimize equipment via API for ${girl.name}`);
 
-        logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+        // Step 1: run auto-equip via API and capture full response
+        const equipAllResp = await HaremGirl.equipAllApi(girl.id_girl);
+        if (!equipAllResp) {
+            logHHAuto(`Auto-equip API call failed for ${girl.name}, aborting optimization`);
+            return;
+        }
+        if (!equipAllResp.success) {
+            logHHAuto(`Auto-equip API returned success=false for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
+            return;
+        }
+        logHHAuto(`Auto-equip via API successful for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
 
-        // Collect all equipped items first (DOM is reliable for equipped slots)
-        const slotItems: { slotIndex: number, equippedData: any }[] = [];
-        for (let i = 0; i < slotCount; i++) {
-            const slot = equipmentSlots.eq(i);
-            const equippedEl = slot.find('.slot[data-d]');
-            let equippedData: any = null;
-            if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
-                equippedData = JSON.parse(equippedEl.attr('data-d')!);
-            }
-            const slotIndex = equippedData?.slot_index ?? (i + 1);
-            slotItems.push({ slotIndex, equippedData });
-            if (equippedData) {
-                logHHAuto(`Slot ${i}: data-d keys=${JSON.stringify(Object.keys(equippedData))}, slot_index=${slotIndex}, L${equippedData.level} ${equippedData.rarity}`);
-            } else {
-                logHHAuto(`Slot ${i}: no data-d, slot_index=${slotIndex}`);
-            }
+        const inventory: any[] = Array.isArray(equipAllResp.inventory_armor) ? equipAllResp.inventory_armor : [];
+        logHHAuto(`Auto-equip response contains ${inventory.length} inventory_armor entries`);
+
+        if (inventory.length === 0) {
+            logHHAuto(`No inventory_armor in equip_all response — cannot optimize, stopping`);
+            return;
         }
 
-        for (let i = 0; i < slotCount; i++) {
-            const { slotIndex, equippedData } = slotItems[i];
+        // Log one sample entry's keys so we can verify structure
+        logHHAuto(`inventory_armor[0] keys=${JSON.stringify(Object.keys(inventory[0]))}`);
 
-            if (!equippedData || !equippedData.id_girl_armor) {
-                logHHAuto(`Slot ${i}: no equipped item, skipping`);
-                continue;
-            }
+        // Group inventory by slot_index
+        const bySlot: { [k: number]: any[] } = {};
+        for (const item of inventory) {
+            const si = Number(item.slot_index);
+            if (!Number.isFinite(si)) continue;
+            if (!bySlot[si]) bySlot[si] = [];
+            bySlot[si].push(item);
+        }
 
-            // Step 1: Re-equip the current item to get the full inventory for this slot from the API
-            const probeResponse = await HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
-            if (!probeResponse || !probeResponse.success) {
-                logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+        // Read currently equipped stats from DOM (post-equip_all DOM may be stale, but worst case we over-equip)
+        const equippedBySlot: { [k: number]: any } = {};
+        $('.equipment_slot .slot[data-d]').each(function () {
+            try {
+                const d = JSON.parse($(this).attr('data-d') || '{}');
+                const si = Number(d.slot_index);
+                if (Number.isFinite(si)) equippedBySlot[si] = d;
+            } catch { /* ignore */ }
+        });
 
-                // Fallback: find any DOM item matching this slot_index
-                let fallbackId: string | null = null;
-                $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                    if (fallbackId) return;
-                    const raw = $(this).attr('data-d');
-                    if (!raw) return;
-                    const data = JSON.parse(raw);
-                    if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
-                        fallbackId = data.id_girl_armor;
-                    }
-                });
+        for (let slotIndex = 1; slotIndex <= 6; slotIndex++) {
+            const candidates = bySlot[slotIndex] || [];
+            const equipped = equippedBySlot[slotIndex] || null;
+            logHHAuto(`Slot ${slotIndex}: ${candidates.length} candidates, equipped=${equipped ? `L${equipped.level} ${equipped.rarity}` : 'none'}`);
 
-                if (!fallbackId) {
-                    logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
-                    await TimeHelper.sleep(randomInterval(300, 500));
-                    continue;
-                }
+            if (candidates.length === 0) continue;
 
-                const fallbackResponse = await HaremGirl.equipItem(girl.id_girl, fallbackId);
-                if (!fallbackResponse || !fallbackResponse.success) {
-                    logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
-                    await TimeHelper.sleep(randomInterval(300, 500));
-                    continue;
-                }
-
-                // Use fallback response
-                const fbCandidates: any[] = [...(fallbackResponse.inventory_armor || [])];
-                if (fallbackResponse.unequipped_armor) fbCandidates.push(fallbackResponse.unequipped_armor);
-                const fbEquipped = fallbackResponse.equipped_armor || null;
-                const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
-
-                if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
-                    const fbScore = HaremGirl.scoreItem(fbBest, girl);
-                    logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
-                    const eqResp = await HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
-                    logHHAuto(`Slot ${i}: ${eqResp?.success ? 'equipped successfully' : 'equip failed'}`);
-                } else {
-                    const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
-                    logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped?.level} ${fbEquipped?.rarity}, score=${s?.caracSum})`);
-                }
-                await TimeHelper.sleep(randomInterval(300, 500));
-                continue;
-            }
-
-            // Probe succeeded: build full candidate list from API response
-            const candidates: any[] = [...(probeResponse.inventory_armor || [])];
-            if (probeResponse.unequipped_armor) {
-                candidates.push(probeResponse.unequipped_armor);
-            }
-            const currentlyEquipped = probeResponse.equipped_armor || null;
-            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
-
-            if (candidates.length === 0) {
-                const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
-                await TimeHelper.sleep(randomInterval(300, 500));
-                continue;
-            }
-
-            // Step 2: Find the absolute best from the complete inventory
             const best = HaremGirl.findBestItem(candidates, girl);
+            if (!best) continue;
 
-            if (best && HaremGirl.isBetter(best, currentlyEquipped, girl)) {
-                const bestScore = HaremGirl.scoreItem(best, girl);
-                logHHAuto(`Slot ${i}: equipping best item (L${best.level} ${best.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches}, id=${best.id_girl_armor})`);
+            const bestScore = HaremGirl.scoreItem(best, girl);
 
-                const equipResponse = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                if (equipResponse && equipResponse.success) {
-                    logHHAuto(`Slot ${i}: equipped successfully`);
-                } else {
-                    logHHAuto(`Slot ${i}: equip failed`);
-                }
+            if (HaremGirl.isBetter(best, equipped, girl)) {
+                logHHAuto(`Slot ${slotIndex}: equipping better item L${best.level} ${best.rarity} score=${bestScore.caracSum} resonance=${bestScore.resonanceMatches} id=${best.id_girl_armor}`);
+                const resp = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
+                logHHAuto(`Slot ${slotIndex}: ${resp?.success ? 'equipped successfully' : 'equip failed'}`);
+                await TimeHelper.sleep(randomInterval(300, 500));
             } else {
-                const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
-                logHHAuto(`Slot ${i}: current item is optimal (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
+                const eqScore = equipped ? HaremGirl.scoreItem(equipped, girl) : null;
+                logHHAuto(`Slot ${slotIndex}: current is optimal (L${equipped?.level} ${equipped?.rarity}, score=${eqScore?.caracSum})`);
             }
-            await TimeHelper.sleep(randomInterval(300, 500));
         }
         logHHAuto('Equipment optimization complete');
     }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -884,52 +884,88 @@ export class HaremGirl {
 
         logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
+        // Collect all equipped items first (DOM is reliable for equipped slots)
+        const slotItems: { slotIndex: number, equippedData: any }[] = [];
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
-            slot.trigger('click');
-            await TimeHelper.sleep(randomInterval(300, 500));
-
-            // Read currently equipped item from DOM
             const equippedEl = slot.find('.slot[data-d]');
             let equippedData: any = null;
             if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
                 equippedData = JSON.parse(equippedEl.attr('data-d')!);
             }
+            const slotIndex = equippedData?.slot_index ?? (i + 1);
+            slotItems.push({ slotIndex, equippedData });
+            logHHAuto(`Slot ${i}: slot_index=${slotIndex}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} (id=${equippedData.id_girl_armor})` : 'empty'}`);
+        }
 
-            // Get any visible inventory item ID to make the initial API call
-            let probeArmorId: string | null = null;
-            $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
-                if (probeArmorId) return;
-                const raw = $(this).attr('data-d');
-                if (!raw) return;
-                const data = JSON.parse(raw);
-                if (data.id_girl_armor && data.type === 'girl_armor') {
-                    probeArmorId = data.id_girl_armor;
-                }
-            });
+        for (let i = 0; i < slotCount; i++) {
+            const { slotIndex, equippedData } = slotItems[i];
 
-            if (!probeArmorId) {
-                logHHAuto(`Slot ${i}: no inventory items available, skipping`);
+            if (!equippedData || !equippedData.id_girl_armor) {
+                logHHAuto(`Slot ${i}: no equipped item, skipping`);
                 continue;
             }
 
-            // Step 1: Equip any visible item to get the full inventory from the API
-            const probeResponse = await HaremGirl.equipItem(girl.id_girl, probeArmorId);
+            // Step 1: Re-equip the current item to get the full inventory for this slot from the API
+            const probeResponse = await HaremGirl.equipItem(girl.id_girl, equippedData.id_girl_armor);
             if (!probeResponse || !probeResponse.success) {
-                logHHAuto(`Slot ${i}: probe equip failed`);
+                logHHAuto(`Slot ${i}: probe equip failed, trying with inventory item`);
+
+                // Fallback: find any DOM item matching this slot_index
+                let fallbackId: string | null = null;
+                $('.right-section .slot.slot_girl_armor[data-d]').each(function () {
+                    if (fallbackId) return;
+                    const raw = $(this).attr('data-d');
+                    if (!raw) return;
+                    const data = JSON.parse(raw);
+                    if (data.id_girl_armor && data.type === 'girl_armor' && data.slot_index === slotIndex) {
+                        fallbackId = data.id_girl_armor;
+                    }
+                });
+
+                if (!fallbackId) {
+                    logHHAuto(`Slot ${i}: no fallback item for slot_index=${slotIndex}, skipping`);
+                    await TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+
+                const fallbackResponse = await HaremGirl.equipItem(girl.id_girl, fallbackId);
+                if (!fallbackResponse || !fallbackResponse.success) {
+                    logHHAuto(`Slot ${i}: fallback equip also failed, skipping`);
+                    await TimeHelper.sleep(randomInterval(300, 500));
+                    continue;
+                }
+
+                // Use fallback response
+                const fbCandidates: any[] = [...(fallbackResponse.inventory_armor || [])];
+                if (fallbackResponse.unequipped_armor) fbCandidates.push(fallbackResponse.unequipped_armor);
+                const fbEquipped = fallbackResponse.equipped_armor || null;
+                const fbBest = HaremGirl.findBestItem(fbCandidates, girl);
+
+                if (fbBest && HaremGirl.isBetter(fbBest, fbEquipped, girl)) {
+                    const fbScore = HaremGirl.scoreItem(fbBest, girl);
+                    logHHAuto(`Slot ${i}: equipping best item (L${fbBest.level} ${fbBest.rarity}, score=${fbScore.caracSum}, resonance=${fbScore.resonanceMatches}, id=${fbBest.id_girl_armor})`);
+                    const eqResp = await HaremGirl.equipItem(girl.id_girl, fbBest.id_girl_armor);
+                    logHHAuto(`Slot ${i}: ${eqResp?.success ? 'equipped successfully' : 'equip failed'}`);
+                } else {
+                    const s = fbEquipped ? HaremGirl.scoreItem(fbEquipped, girl) : null;
+                    logHHAuto(`Slot ${i}: current item is optimal (L${fbEquipped?.level} ${fbEquipped?.rarity}, score=${s?.caracSum})`);
+                }
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }
 
-            // Build full candidate list from API response
+            // Probe succeeded: build full candidate list from API response
             const candidates: any[] = [...(probeResponse.inventory_armor || [])];
             if (probeResponse.unequipped_armor) {
                 candidates.push(probeResponse.unequipped_armor);
             }
             const currentlyEquipped = probeResponse.equipped_armor || null;
+            logHHAuto(`Slot ${i}: API returned ${candidates.length} candidates for slot_index=${slotIndex}`);
 
             if (candidates.length === 0) {
-                logHHAuto(`Slot ${i}: no alternative items from API`);
+                const eqScore = currentlyEquipped ? HaremGirl.scoreItem(currentlyEquipped, girl) : null;
+                logHHAuto(`Slot ${i}: no alternative items, keeping current (L${currentlyEquipped?.level} ${currentlyEquipped?.rarity}, score=${eqScore?.caracSum})`);
                 await TimeHelper.sleep(randomInterval(300, 500));
                 continue;
             }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -712,6 +712,9 @@ export class HaremGirl {
 
                     HaremGirl.HaremDisplayGirlPopup(HaremGirl.EQUIPMENT_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
 
+                    $('#girl-equip').trigger('click');
+                    await TimeHelper.sleep(randomInterval(400, 700));
+
                     await HaremGirl.optimizeEquipmentSlots(girl);
                 }
                 if (upgradeSkill) {
@@ -881,87 +884,122 @@ export class HaremGirl {
         return false;
     }
 
-    private static equipAllApi(girlId: number | string): Promise<any> {
-        return new Promise((resolve) => {
-            $.ajax({
-                url: '/ajax.php',
-                type: 'POST',
-                data: { action: 'girl_equipment_equip_all', id_girl: girlId },
-                dataType: 'json',
-                success: (data: any) => resolve(data),
-                error: (xhr: any, status: string) => {
-                    logHHAuto(`equipAllApi HTTP error: status=${status}`);
-                    resolve(null);
-                }
+    /**
+     * Force the game's lazy-loaded inventory panel to render all items.
+     * The game renders inventory items on-demand as the container is scrolled.
+     * We scroll to the bottom repeatedly until the item count stabilises, then
+     * back to the top so the game has rendered every item into the DOM.
+     */
+    private static async forceLoadAllInventoryItems(): Promise<number> {
+        // Likely scroll containers for the inventory panel (right side)
+        const candidateSelectors = [
+            '.right-section .scrollable',
+            '.right-section .inventory',
+            '.right-section .items-list',
+            '.right-section > div',
+            '.right-section'
+        ];
+        let container: HTMLElement | null = null;
+        for (const sel of candidateSelectors) {
+            const el = document.querySelector(sel) as HTMLElement | null;
+            if (el && el.scrollHeight > el.clientHeight + 10) {
+                container = el;
+                break;
+            }
+        }
+        if (!container) {
+            // fallback: take first .right-section descendant with overflow
+            document.querySelectorAll('.right-section, .right-section *').forEach((el) => {
+                if (container) return;
+                const h = el as HTMLElement;
+                if (h.scrollHeight > h.clientHeight + 10) container = h;
             });
-        });
+        }
+
+        const countItems = () => $('.right-section .slot[data-d]').length;
+
+        let prevCount = countItems();
+        if (!container) {
+            logHHAuto(`forceLoadAllInventoryItems: no scrollable container found, current DOM items=${prevCount}`);
+            return prevCount;
+        }
+
+        for (let iter = 0; iter < 20; iter++) {
+            container.scrollTop = container.scrollHeight;
+            await TimeHelper.sleep(randomInterval(200, 350));
+            const curCount = countItems();
+            if (curCount === prevCount) break;
+            prevCount = curCount;
+        }
+        container.scrollTop = 0;
+        await TimeHelper.sleep(randomInterval(150, 250));
+        return countItems();
     }
 
     static async optimizeEquipmentSlots(girl: KKHaremGirl) {
-        logHHAuto(`Optimize equipment via API for ${girl.name}`);
+        const equipmentSlots = $('.equipment_slot');
+        const slotCount = equipmentSlots.length;
 
-        // Step 1: run auto-equip via API and capture full response
-        const equipAllResp = await HaremGirl.equipAllApi(girl.id_girl);
-        if (!equipAllResp) {
-            logHHAuto(`Auto-equip API call failed for ${girl.name}, aborting optimization`);
-            return;
-        }
-        if (!equipAllResp.success) {
-            logHHAuto(`Auto-equip API returned success=false for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
-            return;
-        }
-        logHHAuto(`Auto-equip via API successful for ${girl.name}, response keys=${JSON.stringify(Object.keys(equipAllResp))}`);
+        logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
-        const inventory: any[] = Array.isArray(equipAllResp.inventory_armor) ? equipAllResp.inventory_armor : [];
-        logHHAuto(`Auto-equip response contains ${inventory.length} inventory_armor entries`);
+        for (let i = 0; i < slotCount; i++) {
+            const slot = equipmentSlots.eq(i);
+            slot.trigger('click');
+            await TimeHelper.sleep(randomInterval(400, 600));
 
-        if (inventory.length === 0) {
-            logHHAuto(`No inventory_armor in equip_all response — cannot optimize, stopping`);
-            return;
-        }
+            // Force game to render all lazy-loaded inventory items into the DOM
+            const totalItems = await HaremGirl.forceLoadAllInventoryItems();
 
-        // Log one sample entry's keys so we can verify structure
-        logHHAuto(`inventory_armor[0] keys=${JSON.stringify(Object.keys(inventory[0]))}`);
+            const equippedEl = slot.find('.slot[data-d]');
+            let equippedData: any = null;
+            if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
+                try { equippedData = JSON.parse(equippedEl.attr('data-d')!); } catch { /* ignore */ }
+            }
 
-        // Group inventory by slot_index
-        const bySlot: { [k: number]: any[] } = {};
-        for (const item of inventory) {
-            const si = Number(item.slot_index);
-            if (!Number.isFinite(si)) continue;
-            if (!bySlot[si]) bySlot[si] = [];
-            bySlot[si].push(item);
-        }
+            const inventoryItems: { el: JQuery<HTMLElement>, data: any }[] = [];
+            $('.right-section .slot[data-d]').each(function () {
+                const raw = $(this).attr('data-d');
+                if (!raw) return;
+                try {
+                    const data = JSON.parse(raw);
+                    if (data && data.caracs) inventoryItems.push({ el: $(this), data });
+                } catch { /* ignore */ }
+            });
 
-        // Read currently equipped stats from DOM (post-equip_all DOM may be stale, but worst case we over-equip)
-        const equippedBySlot: { [k: number]: any } = {};
-        $('.equipment_slot .slot[data-d]').each(function () {
-            try {
-                const d = JSON.parse($(this).attr('data-d') || '{}');
-                const si = Number(d.slot_index);
-                if (Number.isFinite(si)) equippedBySlot[si] = d;
-            } catch { /* ignore */ }
-        });
+            logHHAuto(`Slot ${i}: DOM has ${totalItems} items, ${inventoryItems.length} usable candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
 
-        for (let slotIndex = 1; slotIndex <= 6; slotIndex++) {
-            const candidates = bySlot[slotIndex] || [];
-            const equipped = equippedBySlot[slotIndex] || null;
-            logHHAuto(`Slot ${slotIndex}: ${candidates.length} candidates, equipped=${equipped ? `L${equipped.level} ${equipped.rarity}` : 'none'}`);
+            if (inventoryItems.length === 0) {
+                logHHAuto(`Slot ${i}: no inventory items available, skipping`);
+                continue;
+            }
 
-            if (candidates.length === 0) continue;
+            // Rank candidates: total stats, then resonance, then individual stats
+            const sorted = inventoryItems.slice().sort((a, b) => {
+                const sa = HaremGirl.scoreItem(a.data, girl);
+                const sb = HaremGirl.scoreItem(b.data, girl);
+                if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
+                if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
+                const ca = a.data.caracs, cb = b.data.caracs;
+                return ((cb.carac1||0)+(cb.carac2||0)+(cb.carac3||0)) - ((ca.carac1||0)+(ca.carac2||0)+(ca.carac3||0));
+            });
+            const bestInventory = sorted[0];
 
-            const best = HaremGirl.findBestItem(candidates, girl);
-            if (!best) continue;
+            const bestScore = HaremGirl.scoreItem(bestInventory.data, girl);
+            const shouldReplace = HaremGirl.isBetter(bestInventory.data, equippedData, girl);
 
-            const bestScore = HaremGirl.scoreItem(best, girl);
-
-            if (HaremGirl.isBetter(best, equipped, girl)) {
-                logHHAuto(`Slot ${slotIndex}: equipping better item L${best.level} ${best.rarity} score=${bestScore.caracSum} resonance=${bestScore.resonanceMatches} id=${best.id_girl_armor}`);
-                const resp = await HaremGirl.equipItem(girl.id_girl, best.id_girl_armor);
-                logHHAuto(`Slot ${slotIndex}: ${resp?.success ? 'equipped successfully' : 'equip failed'}`);
-                await TimeHelper.sleep(randomInterval(300, 500));
+            if (shouldReplace) {
+                logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
+                // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
+                const raw = bestInventory.el.get(0);
+                if (raw && typeof raw.scrollIntoView === 'function') {
+                    raw.scrollIntoView({ block: 'center' });
+                    await TimeHelper.sleep(randomInterval(150, 250));
+                }
+                bestInventory.el.trigger('click');
+                await TimeHelper.sleep(randomInterval(400, 600));
             } else {
-                const eqScore = equipped ? HaremGirl.scoreItem(equipped, girl) : null;
-                logHHAuto(`Slot ${slotIndex}: current is optimal (L${equipped?.level} ${equipped?.rarity}, score=${eqScore?.caracSum})`);
+                const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;
+                logHHAuto(`Slot ${i}: current item is optimal (L${equippedData?.level} ${equippedData?.rarity}, score=${eqScore?.caracSum})`);
             }
         }
         logHHAuto('Equipment optimization complete');


### PR DESCRIPTION
## Summary
- Iterates each equipment slot after auto-equip and replaces items with better alternatives from inventory (higher caracs, resonance bonus matches)
- Forces lazy-load of the full inventory panel so all items (not only the first ~100) are considered
- Clicks the explicit Equip confirm button (`#girl-equipment-equip`) after selecting the best item

Relates to issue #1538 (please keep open for reporter confirmation before closing).

## Test plan
- [ ] Run Stuff Team on a girl with a suboptimal slot (e.g. L1 mythic equipped while a L10 mythic is in inventory)
- [ ] Verify the L10 item is selected and equipped automatically
- [ ] Check log lines `Optimize equipment: checking N slots`, `Slot X: replacing with better item`, `Slot X: equip button clicked`
- [ ] Confirm no regression on girls whose slots are already optimal