### PR TITLE
fix(#1562): prevent booster auto-equip loop on stale cross-browser state (v7.35.6)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -10893,6 +10893,11 @@ HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatus] =
         storage: "sessionStorage",
         HHType: "Temp"
     };
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatusLastUpdate] =
+    {
+        storage: "sessionStorage",
+        HHType: "Temp"
+    };
 HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterIdMap] =
     {
         storage: "sessionStorage",

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.5
+// @version      7.35.6
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1368,6 +1368,21 @@ class Booster {
             mythic: activeMythicSlots,
         };
         setStoredValue(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(boosterStatus));
+        setStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate, String(Date.now()));
+    }
+    /**
+     * Checks whether boosterStatus was refreshed from the market recently.
+     * Used to detect stale state when another browser/tab changed the equipped boosters.
+     * A missing timestamp is treated as stale (forces a market visit).
+     */
+    static hasFreshBoosterStatus() {
+        const lastUpdateRaw = getStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
+        if (!lastUpdateRaw)
+            return false;
+        const lastUpdate = parseInt(lastUpdateRaw, 10);
+        if (isNaN(lastUpdate))
+            return false;
+        return (Date.now() - lastUpdate) < Booster.BOOSTER_STATUS_TTL_MS;
     }
     /**
      * Checks whether booster data from a market visit is available in cache.
@@ -1520,6 +1535,14 @@ class Booster {
                 LogUtils_logHHAuto("Auto-equip: No booster data from market. Navigating to market first.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
                 return true; // Signal busy — the market visit will cache the data, next loop will equip
+            }
+            // Also refresh boosterStatus if it's stale — another browser/tab may have changed
+            // the equipped boosters. Without this, getBoostersToEquip() would use stale data
+            // and repeatedly try to equip slots that are actually already occupied server-side.
+            if (!Booster.hasFreshBoosterStatus()) {
+                LogUtils_logHHAuto("Auto-equip: boosterStatus is stale or missing. Navigating to market to refresh.");
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
+                return true; // Signal busy — market visit will refresh boosterStatus via collectBoostersFromMarket
             }
             const boostersToEquip = Booster.getBoostersToEquip();
             if (boostersToEquip.length === 0) {
@@ -1806,6 +1829,8 @@ Booster.SANDALWOOD_IDENTIFIER = "MB1";
 Booster._battleResponseReady = false;
 /** Resolver: set when waitForBattleResponse() is waiting; called by notifyBattleResponseProcessed() */
 Booster._battleResponseResolve = null;
+/** TTL for boosterStatus freshness in milliseconds (10 minutes). */
+Booster.BOOSTER_STATUS_TTL_MS = 10 * 60 * 1000;
 
 ;// CONCATENATED MODULE: ./src/Module/Bundles.ts
 // Bundles.ts -- Collects free daily and periodic bundles from the shop popup.
@@ -8425,6 +8450,7 @@ const TK = {
     charLevel: "Temp_charLevel",
     storeContents: "Temp_storeContents",
     boosterStatus: "Temp_boosterStatus",
+    boosterStatusLastUpdate: "Temp_boosterStatusLastUpdate",
     boosterIdMap: "Temp_boosterIdMap",
     // Troll
     TrollHumanLikeRun: "Temp_TrollHumanLikeRun",
@@ -21217,6 +21243,32 @@ class HeroHelper {
                 // change referer
                 const currentPath = window.location.href.replace('http://', '').replace('https://', '').replace(window.location.hostname, '');
                 window.history.replaceState(null, '', addNutakuSession('/shop.html'));
+                // Guard: ensure we resolve exactly once, even if both AJAX callback and timeout fire.
+                let settled = false;
+                let timeoutId = null;
+                const settle = (value) => {
+                    if (settled)
+                        return;
+                    settled = true;
+                    if (timeoutId !== null)
+                        clearTimeout(timeoutId);
+                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
+                    setTimeout(autoLoop, randomInterval(500, 800));
+                    resolve(value);
+                };
+                // Option C: Safety timeout in case the AJAX call never invokes either callback
+                // (seen in the wild when the referer swap collides with navigation). Without
+                // this, the promise would hang forever and the autoLoop stays paused.
+                timeoutId = setTimeout(() => {
+                    if (settled)
+                        return;
+                    LogUtils_logHHAuto('equipBooster: AJAX timeout after 15s — resolving with false and invalidating boosterStatus');
+                    // Treat a hang as "state unknown": drop the freshness stamp so the next
+                    // auto-equip cycle re-reads boosterStatus from the market.
+                    deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
+                    HeroHelper.getSandalWoodEquipFailure(true);
+                    settle(false);
+                }, 15000);
                 getHHAjax()(params, function (data) {
                     LogUtils_logHHAuto(`equipBooster: AJAX success callback, data.success=${data.success}, full response=${JSON.stringify(data)}`);
                     if (data.success) {
@@ -21224,19 +21276,22 @@ class HeroHelper {
                     }
                     else {
                         LogUtils_logHHAuto('equipBooster: Server returned success:false (may already be equipped)');
+                        // Option D: a success:false response means our local boosterStatus is
+                        // out of sync with the server (another browser/tab probably equipped
+                        // boosters while we were paused). Invalidate the freshness timestamp
+                        // so autoEquipBoosters refreshes from the market before retrying.
+                        deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                         HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                     }
-                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-                    setTimeout(autoLoop, randomInterval(500, 800));
                     LogUtils_logHHAuto(`equipBooster: resolving with ${data.success}`);
-                    resolve(data.success);
+                    settle(!!data.success);
                 }, function (err) {
                     LogUtils_logHHAuto('equipBooster: AJAX error callback - ' + err);
-                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-                    setTimeout(autoLoop, randomInterval(500, 800));
+                    // Network/server error also implies our cached state may be wrong — invalidate.
+                    deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                     HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                     LogUtils_logHHAuto('equipBooster: resolving with false');
-                    resolve(false);
+                    settle(false);
                 });
                 // change referer
                 window.history.replaceState(null, '', addNutakuSession(currentPath));

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -8206,6 +8206,15 @@ function randomInterval(min, max) {
  * Usage:
  *   import { SK } from '../config/StorageKeys';
  *   getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle)
+ *
+ * IMPORTANT: Adding an entry here is NOT enough to make the key work at
+ * runtime. StorageHelper.getStoredValue / setStoredValue / deleteStoredValue
+ * silently ignore any key that isn't registered in HHStoredVars.ts. When
+ * you add a new SK / TK entry below, you MUST also add a matching
+ * registration in config/HHStoredVars.ts with the correct storage type
+ * ("localStorage" | "sessionStorage" | "Storage()") and HHType
+ * ("Setting" | "Temp"), otherwise reads return undefined and writes are
+ * dropped without any warning.
  */
 // ── Setting_ keys (user settings) ─────────────────────────────────
 const SK = {
@@ -19909,6 +19918,14 @@ function getMenu() {
 // persisting all HHAuto settings and temporary state. Every stored
 // variable is registered in HHStoredVars (config/HHStoredVars.ts) with
 // a storage type, default value, and optional validation regex.
+//
+// IMPORTANT: getStoredValue / setStoredValue / deleteStoredValue ONLY
+// work for keys that are registered in HHStoredVars. Unregistered keys
+// are silently dropped on write and return undefined on read — no error,
+// no log, just a no-op. When adding a new SK/TK entry in StorageKeys.ts,
+// you MUST also register it in HHStoredVars.ts (with its storage type
+// "localStorage" | "sessionStorage" | "Storage()" and HHType
+// "Setting" | "Temp"), otherwise nothing will be persisted.
 //
 // Key design decisions:
 //   - Settings use localStorage (survive tab close); temp vars use

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.6 — Booster auto-equip recovers from external changes
+
+Fixes [#1565](https://github.com/Roukys/HHauto/issues/1565).
+
+If boosters were changed in another browser or tab while the script was paused, auto-equip could get stuck retrying to equip already-occupied slots or repeatedly reload the Market page. The script now recognizes the out-of-sync state, refreshes the booster info from the Market and resumes normal operation.
+
+---
+
 ### v7.35.5 — Simpler buy-combat and refined +Raid Stars
 
 Further addresses [#1565](https://github.com/Roukys/HHauto/issues/1565).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.5",
+  "version": "7.35.6",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Helper/HeroHelper.ts
+++ b/src/Helper/HeroHelper.ts
@@ -19,7 +19,7 @@ import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { KKHero } from '../model/index';
 import { ConfigHelper } from './ConfigHelper';
 import { getHHVars } from "./HHHelper";
-import { getStoredJSON, getStoredValue, setStoredValue } from "./StorageHelper";
+import { deleteStoredValue, getStoredJSON, getStoredValue, setStoredValue } from "./StorageHelper";
 import { randomInterval } from "./TimeHelper";
 
 export function getHero():KKHero
@@ -133,25 +133,54 @@ export class HeroHelper {
             // change referer
             const currentPath = window.location.href.replace('http://', '').replace('https://', '').replace(window.location.hostname, '');
             window.history.replaceState(null, '', addNutakuSession('/shop.html') as string);
+
+            // Guard: ensure we resolve exactly once, even if both AJAX callback and timeout fire.
+            let settled = false;
+            let timeoutId: ReturnType<typeof setTimeout> | null = null;
+            const settle = (value: boolean) => {
+                if (settled) return;
+                settled = true;
+                if (timeoutId !== null) clearTimeout(timeoutId);
+                setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "true");
+                setTimeout(autoLoop,randomInterval(500,800));
+                resolve(value);
+            };
+
+            // Option C: Safety timeout in case the AJAX call never invokes either callback
+            // (seen in the wild when the referer swap collides with navigation). Without
+            // this, the promise would hang forever and the autoLoop stays paused.
+            timeoutId = setTimeout(() => {
+                if (settled) return;
+                logHHAuto('equipBooster: AJAX timeout after 15s — resolving with false and invalidating boosterStatus');
+                // Treat a hang as "state unknown": drop the freshness stamp so the next
+                // auto-equip cycle re-reads boosterStatus from the market.
+                deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
+                HeroHelper.getSandalWoodEquipFailure(true);
+                settle(false);
+            }, 15000);
+
             getHHAjax()(params, function(data) {
                 logHHAuto(`equipBooster: AJAX success callback, data.success=${data.success}, full response=${JSON.stringify(data)}`);
                 if (data.success) {
                     logHHAuto('equipBooster: Booster equipped successfully');
                 } else {
                     logHHAuto('equipBooster: Server returned success:false (may already be equipped)');
+                    // Option D: a success:false response means our local boosterStatus is
+                    // out of sync with the server (another browser/tab probably equipped
+                    // boosters while we were paused). Invalidate the freshness timestamp
+                    // so autoEquipBoosters refreshes from the market before retrying.
+                    deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                     HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                 }
-                setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "true");
-                setTimeout(autoLoop,randomInterval(500,800));
                 logHHAuto(`equipBooster: resolving with ${data.success}`);
-                resolve(data.success);
+                settle(!!data.success);
             }, function (err){
                 logHHAuto('equipBooster: AJAX error callback - ' + err);
-                setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "true");
-                setTimeout(autoLoop,randomInterval(500,800));
+                // Network/server error also implies our cached state may be wrong — invalidate.
+                deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                 HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                 logHHAuto('equipBooster: resolving with false');
-                resolve(false);
+                settle(false);
             });
             // change referer
             window.history.replaceState(null, '', addNutakuSession(currentPath) as string);

--- a/src/Helper/StorageHelper.ts
+++ b/src/Helper/StorageHelper.ts
@@ -5,6 +5,14 @@
 // variable is registered in HHStoredVars (config/HHStoredVars.ts) with
 // a storage type, default value, and optional validation regex.
 //
+// IMPORTANT: getStoredValue / setStoredValue / deleteStoredValue ONLY
+// work for keys that are registered in HHStoredVars. Unregistered keys
+// are silently dropped on write and return undefined on read — no error,
+// no log, just a no-op. When adding a new SK/TK entry in StorageKeys.ts,
+// you MUST also register it in HHStoredVars.ts (with its storage type
+// "localStorage" | "sessionStorage" | "Storage()" and HHType
+// "Setting" | "Temp"), otherwise nothing will be persisted.
+//
 // Key design decisions:
 //   - Settings use localStorage (survive tab close); temp vars use
 //     sessionStorage (reset per session) unless the user enables

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -329,6 +329,23 @@ export class Booster {
         }
 
         setStoredValue(HHStoredVarPrefixKey+TK.boosterStatus, JSON.stringify(boosterStatus));
+        setStoredValue(HHStoredVarPrefixKey+TK.boosterStatusLastUpdate, String(Date.now()));
+    }
+
+    /** TTL for boosterStatus freshness in milliseconds (10 minutes). */
+    static BOOSTER_STATUS_TTL_MS = 10 * 60 * 1000;
+
+    /**
+     * Checks whether boosterStatus was refreshed from the market recently.
+     * Used to detect stale state when another browser/tab changed the equipped boosters.
+     * A missing timestamp is treated as stale (forces a market visit).
+     */
+    static hasFreshBoosterStatus(): boolean {
+        const lastUpdateRaw = getStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
+        if (!lastUpdateRaw) return false;
+        const lastUpdate = parseInt(lastUpdateRaw, 10);
+        if (isNaN(lastUpdate)) return false;
+        return (Date.now() - lastUpdate) < Booster.BOOSTER_STATUS_TTL_MS;
     }
 
     /**
@@ -499,6 +516,15 @@ export class Booster {
             logHHAuto("Auto-equip: No booster data from market. Navigating to market first.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
             return true; // Signal busy — the market visit will cache the data, next loop will equip
+        }
+
+        // Also refresh boosterStatus if it's stale — another browser/tab may have changed
+        // the equipped boosters. Without this, getBoostersToEquip() would use stale data
+        // and repeatedly try to equip slots that are actually already occupied server-side.
+        if (!Booster.hasFreshBoosterStatus()) {
+            logHHAuto("Auto-equip: boosterStatus is stale or missing. Navigating to market to refresh.");
+            gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
+            return true; // Signal busy — market visit will refresh boosterStatus via collectBoostersFromMarket
         }
 
         const boostersToEquip = Booster.getBoostersToEquip();

--- a/src/config/HHStoredVars.ts
+++ b/src/config/HHStoredVars.ts
@@ -2400,6 +2400,11 @@ HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatus] =
     storage:"sessionStorage",
     HHType:"Temp"
 };
+HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatusLastUpdate] =
+    {
+    storage:"sessionStorage",
+    HHType:"Temp"
+};
 HHStoredVars[HHStoredVarPrefixKey + TK.boosterIdMap] =
     {
     storage:"sessionStorage",

--- a/src/config/StorageKeys.ts
+++ b/src/config/StorageKeys.ts
@@ -6,6 +6,15 @@
  * Usage:
  *   import { SK } from '../config/StorageKeys';
  *   getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle)
+ *
+ * IMPORTANT: Adding an entry here is NOT enough to make the key work at
+ * runtime. StorageHelper.getStoredValue / setStoredValue / deleteStoredValue
+ * silently ignore any key that isn't registered in HHStoredVars.ts. When
+ * you add a new SK / TK entry below, you MUST also add a matching
+ * registration in config/HHStoredVars.ts with the correct storage type
+ * ("localStorage" | "sessionStorage" | "Storage()") and HHType
+ * ("Setting" | "Temp"), otherwise reads return undefined and writes are
+ * dropped without any warning.
  */
 
 // ── Setting_ keys (user settings) ─────────────────────────────────

--- a/src/config/StorageKeys.ts
+++ b/src/config/StorageKeys.ts
@@ -282,6 +282,7 @@ export const TK = {
     charLevel: "Temp_charLevel",
     storeContents: "Temp_storeContents",
     boosterStatus: "Temp_boosterStatus",
+    boosterStatusLastUpdate: "Temp_boosterStatusLastUpdate",
     boosterIdMap: "Temp_boosterIdMap",
 
     // Troll


### PR DESCRIPTION
## Summary

Fixes #1562.

When boosters were changed in another browser or tab while the script was paused, the cached `boosterStatus` stayed empty. `autoEquipBoosters` then repeatedly tried to equip already-occupied slots; the server returned `success:false`, but nothing invalidated the cached state, so the loop continued indefinitely — later surfaced as an endless Market reload loop once a freshness guard was added with a missing `HHStoredVars` registration.

## What changed

- Add `boosterStatusLastUpdate` timestamp, written on every `collectBoostersFromMarket()` call
- `autoEquipBoosters` refreshes via a shop visit when the status is stale (TTL 10 min)
- `equipBooster` invalidates the freshness stamp on `success:false`, AJAX error, or timeout, forcing a shop refresh on the next cycle
- `equipBooster` gains a 15s safety timeout so a hanging AJAX call no longer leaves `autoLoop` paused forever
- Register `boosterStatusLastUpdate` in `HHStoredVars.ts` — without registration `StorageHelper` silently drops writes and returns undefined on reads
- Document the `HHStoredVars` registration requirement in `StorageHelper.ts` and `StorageKeys.ts` top-of-file comments to prevent the same mistake
- Bump version to 7.35.6 and add user-facing release notes

## Test plan

- [x] Reproduced loop in Edge after manual booster changes in Chrome
- [x] Verified `npm run build` passes
- [x] Verified branch version matches package.json (7.35.6)

---

_Note: this PR was originally filed referencing #1565 by mistake; the actual issue tracking this bug is #1562._