### PR TITLE
fix(#1567): update league promotion cutoff to top 20

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.6
+// @version      7.35.7
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -14051,9 +14051,9 @@ class LeagueHelper {
                         maxLeague = leagues.length;
                     }
                     if (leagueTargetValue === Number(getPlayerCurrentLevel) && leagueTargetValue < maxLeague) {
-                        var rankStay = 16;
-                        if (currentRank > 15) {
-                            rankStay = 15;
+                        var rankStay = 21;
+                        if (currentRank > 20) {
+                            rankStay = 20;
                         }
                         LogUtils_logHHAuto("Current league is target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to stay. max rank : " + rankStay);
                         let getRankStay = $(".data-list .data-row.body-row .data-column[column='place']:contains(" + rankStay + ")").filter(function () {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.7 — League promotion threshold updated to top 20
+
+Fixes [#1567](https://github.com/Roukys/HHauto/issues/1567).
+
+The game now promotes the top 20 players of a league bracket instead of the top 15. The "Target League" / "Allow win" automation has been updated to match, so the script keeps you in the correct league instead of accidentally promoting or blocking fights based on the old cutoff.
+
+---
+
 ### v7.35.6 — Booster auto-equip recovers from external changes
 
 Fixes [#1565](https://github.com/Roukys/HHauto/issues/1565).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.6",
+  "version": "7.35.7",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/League.ts
+++ b/src/Module/League.ts
@@ -768,10 +768,10 @@ export class LeagueHelper {
 
                 if (leagueTargetValue === Number(getPlayerCurrentLevel) && leagueTargetValue < maxLeague)
                 {
-                    var rankStay = 16;
-                    if (currentRank > 15)
+                    var rankStay = 21;
+                    if (currentRank > 20)
                     {
-                        rankStay = 15;
+                        rankStay = 20;
                     }
                     logHHAuto("Current league is target ("+Number(getPlayerCurrentLevel)+"/"+leagueTargetValue+"), needs to stay. max rank : "+rankStay);
                     let getRankStay = $(".data-list .data-row.body-row .data-column[column='place']:contains("+rankStay+")").filter(function()


### PR DESCRIPTION
## Summary
- Aligns the "Target League" / "Allow win" stay-in-league logic with the new league rules: top 20 are promoted (previously top 15).
- Bumps version to 7.35.7 and adds release notes.

Fixes #1567.

## Test plan
- [ ] Verify in a league where you are at your target level: script no longer blocks fights when your rank is between 16 and 20.
- [ ] Verify it still blocks fights when you are within the top 20 and risk promotion.