### PR TITLE
fix(troll): buy combativity for +Raid Stars raids when energy is 0

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -7421,10 +7421,15 @@ class Troll {
             if (currentPower < 1) {
                 const eventGirl = EventModule.getEventGirl();
                 const eventMythicGirl = EventModule.getEventMythicGirl();
-                const loveRaid = LoveRaidManager.isAnyActivated() ? LoveRaidManager.getRaidToFight(LoveRaidManager.getTrollRaids(), false) : undefined;
+                const allTrollRaids = LoveRaidManager.isAnyActivated() ? LoveRaidManager.getTrollRaids() : [];
+                const raidStarsFiltered = LoveRaidManager.filterByRaidStars(allTrollRaids);
+                const raidStarsRaid = LoveRaidManager.getRaidStarsRaidToFight(raidStarsFiltered);
+                const loveRaid = LoveRaidManager.isActivated()
+                    ? LoveRaidManager.getRaidToFight(allTrollRaids, false)
+                    : undefined;
                 //logHHAuto("No power for battle.");
                 if (!Troll.canBuyFight(eventGirl).canBuy && !Troll.canBuyFight(eventMythicGirl).canBuy &&
-                    !Troll.canBuyFightForRaid(loveRaid).canBuy) {
+                    !Troll.canBuyFightForRaid(loveRaid).canBuy && !Troll.canBuyFightForRaid(raidStarsRaid).canBuy) {
                     return false;
                 }
             }

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.7
+// @version      7.35.8
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.8 — Buy combativity for +Raid Stars raids
+
+When +Raid Stars was the only active raid mode and energy ran out, the script would not spend kobans to refill — even with enough kobans available above the reserve. Energy is now topped up as expected for +Raid Stars raids as well.
+
+---
+
 ### v7.35.7 — League promotion threshold updated to top 20
 
 Fixes [#1567](https://github.com/Roukys/HHauto/issues/1567).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.7",
+  "version": "7.35.8",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -304,11 +304,16 @@ export class Troll {
         {
             const eventGirl = EventModule.getEventGirl();
             const eventMythicGirl = EventModule.getEventMythicGirl();
-            const loveRaid = LoveRaidManager.isAnyActivated() ? LoveRaidManager.getRaidToFight(LoveRaidManager.getTrollRaids(), false) : undefined;
+            const allTrollRaids = LoveRaidManager.isAnyActivated() ? LoveRaidManager.getTrollRaids() : [];
+            const raidStarsFiltered = LoveRaidManager.filterByRaidStars(allTrollRaids);
+            const raidStarsRaid: LoveRaid = LoveRaidManager.getRaidStarsRaidToFight(raidStarsFiltered);
+            const loveRaid: LoveRaid = LoveRaidManager.isActivated()
+                ? LoveRaidManager.getRaidToFight(allTrollRaids, false)
+                : undefined;
             //logHHAuto("No power for battle.");
             if (
                 !Troll.canBuyFight(eventGirl).canBuy && !Troll.canBuyFight(eventMythicGirl).canBuy &&
-                !Troll.canBuyFightForRaid(loveRaid).canBuy)
+                !Troll.canBuyFightForRaid(loveRaid).canBuy && !Troll.canBuyFightForRaid(raidStarsRaid).canBuy)
             {
                 return false;
             }


### PR DESCRIPTION
## Summary
- When the "Raid selector" dropdown is set to "Choose a girl" (0) but +Raid Stars is driving the fight, `doBossBattle` looked up the raid only via `getRaidToFight`, which returns `undefined` for selector 0. The buy-combativity check then short-circuited and no kobans were spent, even with enough kobans above the reserve.
- `doBossBattle` now also considers the `raidStarsRaid` candidate, mirroring the logic already used in `handleTrollBattle`.
- Bump to 7.35.8 + release note in README.

## Test plan
- [x] Build passes (`npm run build`)
- [x] Verified live: 5★ raid with "Raid selector" = "Choose a girl", energy 0, enough kobans above reserve → energy is topped up and fight continues
- [ ] Existing +Raid (user-selected girl) flow unaffected
- [ ] +Mythic Event buy flow unaffected