### PR TITLE
fix(#1577): Assign first 7 now applies the full team reliably

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -17717,7 +17717,7 @@ class TeamModule {
         let topNumbers = $('.topNumber');
         if (topNumbers.length > 0) {
             TeamModule.resetTeam();
-            assignToTeam(1, true); // true = jump to best team directly
+            setTimeout(function () { assignToTeam(1, true); }, randomInterval(300, 600)); // wait for clear-team UI to settle before assigning
         }
     }
     static setTopTeam(sumFormulaType) {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.8
+// @version      7.35.9
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.9 — Assign first 7 now applies the full team reliably
+
+Fixes [#1577](https://github.com/Roukys/HHauto/issues/1577).
+
+When using "Assign first 7" on the team edit page, some girls from the previous team could stay assigned instead of being replaced, leaving the team only partially updated. The new team is now applied correctly on the first click.
+
+---
+
 ### v7.35.8 — Buy combativity for +Raid Stars raids
 
 When +Raid Stars was the only active raid mode and energy ran out, the script would not spend kobans to refill — even with enough kobans available above the reserve. Energy is now topped up as expected for +Raid Stars raids as well.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.8",
+  "version": "7.35.9",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -449,7 +449,7 @@ export class TeamModule {
         let topNumbers = $('.topNumber')
         if (topNumbers.length > 0) {
             TeamModule.resetTeam();
-            assignToTeam(1, true); // true = jump to best team directly
+            setTimeout(function () { assignToTeam(1, true); }, randomInterval(300, 600)); // wait for clear-team UI to settle before assigning
         }
     }
 


### PR DESCRIPTION
## Summary

- Fixes [#1577](https://github.com/Roukys/HHauto/issues/1577): "Assign first 7" could leave some previous team girls in place instead of fully replacing the team.
- Waits for the clear-team UI to settle before starting to assign the new girls, so the first click applies the full new team.
- Bumps version to 7.35.9 and adds release notes.

## Test plan

- [x] Open the team edit page and click "Assign first 7" — new team is applied correctly on the first click.
- [x] Verified on reporter's scenario (raid/troll team swap that previously mixed old and new girls).