### PR TITLE
Release 7.35.10: Fix equipment optimization skipping first slot

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12034,7 +12034,7 @@ class HaremGirl {
         });
     }
     static optimizeEquipmentSlots(girl) {
-        var _a, _b, _c, _d, _e, _f, _g, _h;
+        var _a, _b, _c, _d, _e, _f, _g;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
@@ -12071,7 +12071,7 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_j) { /* ignore */ }
+                    catch ( /* ignore */_h) { /* ignore */ }
                 }
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
@@ -12123,114 +12123,183 @@ class HaremGirl {
                     const previousEquippedKey = equippedData ? ((_c = (_b = equippedData.id_item) !== null && _b !== void 0 ? _b : equippedData.id_equipement) !== null && _c !== void 0 ? _c : JSON.stringify(equippedData)) : null;
                     const MAX_EQUIP_ATTEMPTS = 3;
                     let equipSucceeded = false;
-                    // ISSUE #1573: Verify the selected DOM element is still attached. During slot
-                    // iteration the game can rebuild the inventory panel, leaving our stored jQuery
-                    // wrapper pointing at a detached node. Clicking a detached node is a no-op, which
-                    // is why slot 0 replacement consistently failed. Re-query via id_girl_armor to
-                    // find a fresh node for the same item.
-                    const rawBeforeAttempts = bestInventory.el.get(0);
-                    if (!rawBeforeAttempts || !rawBeforeAttempts.isConnected) {
-                        const targetArmorId = (_d = bestInventory.data) === null || _d === void 0 ? void 0 : _d.id_girl_armor;
-                        LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item detached from DOM (id_girl_armor=${targetArmorId}), attempting re-query`);
-                        if (targetArmorId != null) {
-                            const $fresh = $('.right-section .slot[data-d]').filter(function () {
-                                try {
-                                    const d = JSON.parse($(this).attr('data-d') || '{}');
-                                    return d.id_girl_armor === targetArmorId;
-                                }
-                                catch (_a) {
-                                    return false;
-                                }
-                            }).first();
-                            const freshRaw = $fresh.get(0);
-                            if ($fresh.length > 0 && freshRaw && freshRaw.isConnected) {
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] re-query successful, using fresh DOM element for id_girl_armor=${targetArmorId}`);
-                                bestInventory.el = $fresh;
-                            }
-                            else {
-                                LogUtils_logHHAuto(`Slot ${i}: best item no longer in DOM after re-query (id_girl_armor=${targetArmorId}), skipping slot`);
-                                continue;
-                            }
+                    // Helper: parent chain up to `maxDepth` or until root, "tag.cls1.cls2" per level
+                    const buildParentChain = ($el, maxDepth) => {
+                        var _a;
+                        const chain = [];
+                        let p = $el.parent();
+                        for (let d = 0; d < maxDepth && p.length > 0; d++) {
+                            const pEl = p.get(0);
+                            const cls = (p.attr('class') || '').split(/\s+/).filter(c => c).slice(0, 3).join('.');
+                            chain.push(`${((_a = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
+                            p = p.parent();
                         }
-                        else {
-                            LogUtils_logHHAuto(`Slot ${i}: best item detached and no id_girl_armor to re-query, skipping slot`);
-                            continue;
-                        }
-                    }
+                        return chain;
+                    };
+                    // Helper: global DOM counts relevant to equipment UI
+                    const domSnapshot = () => ({
+                        rightSection: $('.right-section').length,
+                        inventoryScroll: $('.inventory.hh-scroll').length,
+                        girlLevelerPanel: $('.girl-leveler-panel').length,
+                        filledSlots: $('.right-section .slot[data-d]').length,
+                        selectedSlots: $('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length
+                    });
+                    // ISSUE #1573: Detach can happen between scroll and click, not before the attempt
+                    // loop. The isConnected check + re-query is now performed INSIDE the loop, after
+                    // scroll+sleep, right before the primary click. Massive diagnostics wrapped around
+                    // every step so we can see exactly when and why the node detaches.
                     for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
-                        // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
-                        const raw = bestInventory.el.get(0);
-                        if (raw && typeof raw.scrollIntoView === 'function') {
-                            raw.scrollIntoView({ block: 'center' });
+                        // ========== PRE-SCROLL SNAPSHOT ==========
+                        const rawPreScroll = bestInventory.el.get(0);
+                        const preScrollConn = rawPreScroll === null || rawPreScroll === void 0 ? void 0 : rawPreScroll.isConnected;
+                        const preScrollBody = rawPreScroll ? document.body.contains(rawPreScroll) : false;
+                        const preScrollParents = buildParentChain(bestInventory.el, 12);
+                        const preScrollDom = domSnapshot();
+                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-SCROLL: connected=${preScrollConn} bodyContains=${preScrollBody} domCounts=${JSON.stringify(preScrollDom)} parents=[${preScrollParents.join(' > ')}]`);
+                        // ========== SCROLL INTO VIEW ==========
+                        if (rawPreScroll && typeof rawPreScroll.scrollIntoView === 'function') {
+                            rawPreScroll.scrollIntoView({ block: 'center' });
+                            // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
                             yield TimeHelper.sleep(randomInterval(200, 300));
                         }
-                        // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
-                        if (attempt === 1) {
-                            const rawElBefore = bestInventory.el.get(0);
+                        // ========== POST-SLEEP STATE ==========
+                        const rawPostSleep = bestInventory.el.get(0);
+                        const postSleepConn = rawPostSleep === null || rawPostSleep === void 0 ? void 0 : rawPostSleep.isConnected;
+                        const postSleepVisible = rawPostSleep ? rawPostSleep.offsetParent !== null : false;
+                        const postSleepBody = rawPostSleep ? document.body.contains(rawPostSleep) : false;
+                        const postSleepParents = buildParentChain(bestInventory.el, 12);
+                        const postSleepDom = domSnapshot();
+                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SLEEP: connected=${postSleepConn} visible=${postSleepVisible} bodyContains=${postSleepBody} domCounts=${JSON.stringify(postSleepDom)} parents=[${postSleepParents.join(' > ')}]`);
+                        // ========== RE-QUERY IF DETACHED ==========
+                        let raw = rawPostSleep;
+                        if (!raw || !raw.isConnected) {
+                            const targetArmorId = (_d = bestInventory.data) === null || _d === void 0 ? void 0 : _d.id_girl_armor;
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] DETACHED — attempting re-query for id_girl_armor=${targetArmorId}`);
+                            if (targetArmorId != null) {
+                                const candidates = $('.right-section .slot[data-d]').filter(function () {
+                                    try {
+                                        const d = JSON.parse($(this).attr('data-d') || '{}');
+                                        return d.id_girl_armor === targetArmorId;
+                                    }
+                                    catch (_a) {
+                                        return false;
+                                    }
+                                });
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] re-query found ${candidates.length} candidate(s)`);
+                                candidates.each(function (idx) {
+                                    const $c = $(this);
+                                    const cRaw = $c.get(0);
+                                    const cConn = cRaw === null || cRaw === void 0 ? void 0 : cRaw.isConnected;
+                                    const cBody = cRaw ? document.body.contains(cRaw) : false;
+                                    const cParents = buildParentChain($c, 8);
+                                    LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] candidate[${idx}]: connected=${cConn} bodyContains=${cBody} parents=[${cParents.join(' > ')}]`);
+                                });
+                                const $fresh = candidates.filter(function () {
+                                    const r = $(this).get(0);
+                                    return !!r && r.isConnected;
+                                }).first();
+                                if ($fresh.length > 0) {
+                                    const freshRaw = $fresh.get(0);
+                                    LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] RE-QUERY SUCCESS — swapping to fresh node`);
+                                    bestInventory.el = $fresh;
+                                    raw = freshRaw;
+                                    // Scroll the fresh node into view, then re-check
+                                    if (typeof raw.scrollIntoView === 'function') {
+                                        raw.scrollIntoView({ block: 'center' });
+                                        yield TimeHelper.sleep(randomInterval(200, 300));
+                                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
+                                    }
+                                }
+                                else {
+                                    LogUtils_logHHAuto(`Slot ${i}: no connected candidate after re-query (id_girl_armor=${targetArmorId}), aborting attempts`);
+                                    break;
+                                }
+                            }
+                            else {
+                                LogUtils_logHHAuto(`Slot ${i}: detached and no id_girl_armor to re-query, aborting attempts`);
+                                break;
+                            }
+                        }
+                        // ========== PRE-CLICK STATE (for the node we will actually click) ==========
+                        {
                             const itemCls = bestInventory.el.attr('class') || '';
                             const itemId = bestInventory.el.attr('data-id') || '';
-                            const connected = rawElBefore === null || rawElBefore === void 0 ? void 0 : rawElBefore.isConnected;
-                            const visible = rawElBefore ? rawElBefore.offsetParent !== null : false;
-                            const outerH = ((rawElBefore === null || rawElBefore === void 0 ? void 0 : rawElBefore.outerHTML) || '').substring(0, 250);
-                            const parentChain = [];
-                            let p = bestInventory.el.parent();
-                            for (let d = 0; d < 4 && p.length > 0; d++) {
-                                const pEl = p.get(0);
-                                const cls = (p.attr('class') || '').split(/\s+/).slice(0, 2).join('.');
-                                parentChain.push(`${((_e = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _e === void 0 ? void 0 : _e.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
-                                p = p.parent();
-                            }
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
+                            const connected = raw === null || raw === void 0 ? void 0 : raw.isConnected;
+                            const visible = raw ? raw.offsetParent !== null : false;
+                            const bodyContains = raw ? document.body.contains(raw) : false;
+                            const outerH = ((raw === null || raw === void 0 ? void 0 : raw.outerHTML) || '').substring(0, 400);
+                            const parentChain = buildParentChain(bestInventory.el, 12);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-CLICK: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} bodyContains=${bodyContains} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
                         }
-                        // Primary click: native click triggers the game's selection handler
-                        if (raw && typeof raw.click === 'function') {
+                        // ========== PRIMARY CLICK ==========
+                        const usedNative = !!(raw && typeof raw.click === 'function');
+                        if (usedNative) {
                             raw.click();
                         }
                         else {
                             bestInventory.el.trigger('click');
                         }
+                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
                         // Short wait so the primary click can propagate before we check the button
                         yield TimeHelper.sleep(randomInterval(300, 500));
-                        // Fallback click methods if the equip button is still disabled
-                        // after the primary click. On slot 0 the native .click() is
-                        // consistently ignored by the game — some frameworks only react
-                        // to fully simulated MouseEvents with bubbles/view set (see #1573).
+                        // ========== POST-PRIMARY STATE ==========
+                        {
+                            const btnProbe = $('#girl-equipment-equip');
+                            const btnDisabled = btnProbe.length === 0 || btnProbe.prop('disabled') === true || btnProbe.hasClass('disabled');
+                            const rightSelectedStr = $('.right-section .selected, .right-section .active, .right-section .highlight')
+                                .map((_, el) => {
+                                var _a;
+                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
+                                return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
+                            }).get().join(' | ');
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw === null || raw === void 0 ? void 0 : raw.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
+                        }
+                        // ========== FALLBACK CLICKS IF EQUIP BTN STILL DISABLED ==========
                         const $btnProbe = $('#girl-equipment-equip');
                         const btnStillDisabled = $btnProbe.length === 0
                             || $btnProbe.prop('disabled') === true
                             || $btnProbe.hasClass('disabled');
                         if (btnStillDisabled && raw) {
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] primary click did not enable equip button, trying fallback click methods (attempt ${attempt})`);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] BTN still disabled — running fallback clicks`);
                             // Fallback 1: synthetic MouseEvent with bubbles + view
                             try {
                                 raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
                             }
-                            catch ( /* ignore */_k) { /* ignore */ }
+                            catch (e) {
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 1 threw: ${e}`);
+                            }
                             yield TimeHelper.sleep(200);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 1 (MouseEvent click): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                             // Fallback 2: full mousedown + mouseup + click sequence
                             try {
                                 raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
                                 raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
                                 raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
                             }
-                            catch ( /* ignore */_l) { /* ignore */ }
+                            catch (e) {
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 2 threw: ${e}`);
+                            }
                             yield TimeHelper.sleep(200);
-                            // Fallback 3: jQuery trigger (uses jQuery's event simulation pipeline)
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 2 (full mouse seq): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
+                            // Fallback 3: jQuery trigger
                             bestInventory.el.trigger('click');
                             yield TimeHelper.sleep(200);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 3 (jQuery trigger): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                         }
-                        // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
-                        if (attempt === 1) {
+                        // ========== AFTER-CLICK STATE (full) ==========
+                        {
                             const rawElAfter = bestInventory.el.get(0);
                             const itemClsAfter = bestInventory.el.attr('class') || '';
                             const connectedAfter = rawElAfter === null || rawElAfter === void 0 ? void 0 : rawElAfter.isConnected;
+                            const bodyContainsAfter = rawElAfter ? document.body.contains(rawElAfter) : false;
                             const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
                                 .map((_, el) => {
                                 var _a;
                                 const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
                                 return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
                             }).get().join(' | ');
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}" connected=${connectedAfter} right-selected="${rightSelected || 'none'}"`);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
                         }
                         // Additional wait so the game has time to activate the Equip button (see issue #1573)
                         yield TimeHelper.sleep(randomInterval(400, 700));
@@ -12247,7 +12316,7 @@ class HaremGirl {
                             if (attempt === 1) {
                                 const btnEl = $equipBtn.get(0);
                                 const btnHtml = ((btnEl === null || btnEl === void 0 ? void 0 : btnEl.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_f = $equipBtn.attr('hidden')) !== null && _f !== void 0 ? _f : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
                             }
                             const btnRaw = $equipBtn.get(0);
                             if (btnRaw && typeof btnRaw.click === 'function')
@@ -12274,9 +12343,9 @@ class HaremGirl {
                             try {
                                 verifyData = JSON.parse(verifyEl.attr('data-d'));
                             }
-                            catch ( /* ignore */_m) { /* ignore */ }
+                            catch ( /* ignore */_j) { /* ignore */ }
                         }
-                        const verifyKey = verifyData ? ((_h = (_g = verifyData.id_item) !== null && _g !== void 0 ? _g : verifyData.id_equipement) !== null && _h !== void 0 ? _h : JSON.stringify(verifyData)) : null;
+                        const verifyKey = verifyData ? ((_g = (_f = verifyData.id_item) !== null && _f !== void 0 ? _f : verifyData.id_equipement) !== null && _g !== void 0 ? _g : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {
                             LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
                             equipSucceeded = true;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12008,7 +12008,7 @@ class HaremGirl {
                     }
                     catch ( /* ignore */_a) { /* ignore */ }
                 }
-                yield TimeHelper.sleep(randomInterval(400, 600));
+                yield TimeHelper.sleep(randomInterval(250, 400));
                 const curCount = countItems();
                 if (curCount === prevCount) {
                     stableIterations++;
@@ -12027,9 +12027,6 @@ class HaremGirl {
                 }
                 catch ( /* ignore */_b) { /* ignore */ }
             }
-            // Final settle delay: let the game finish rendering any late items
-            // before the caller reads the DOM (see issue #1573).
-            yield TimeHelper.sleep(randomInterval(400, 600));
             return countItems();
         });
     }
@@ -12039,14 +12036,7 @@ class HaremGirl {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-            // Iterate slots in reverse order (5 → 0) so slot 0 is processed last.
-            // Slot 0 is the default active slot after the page loads; processing it
-            // first made the game treat slot 0 as "already active" and silently
-            // ignore item clicks — the equip button never committed the change.
-            // By the time we reach slot 0 we have switched slots five times, so the
-            // game's internal state is guaranteed to register a real transition
-            // when we click slot 0 (see issue #1573).
-            for (let i = slotCount - 1; i >= 0; i--) {
+            for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
                 // DEBUG (issue #1573): capture slot state before click
                 const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
@@ -12055,16 +12045,10 @@ class HaremGirl {
                 // DEBUG (issue #1573): capture slot state after click
                 const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
                 LogUtils_logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
-                // Give the game time to kick off its inventory request for this slot
-                // before we start scrolling to force-load items (see issue #1573).
-                yield TimeHelper.sleep(randomInterval(600, 900));
+                // Short wait so the game kicks off its inventory request for this slot
+                yield TimeHelper.sleep(randomInterval(100, 200));
                 // Force game to render all lazy-loaded inventory items into the DOM
                 const totalItems = yield HaremGirl.forceLoadAllInventoryItems();
-                // Extra settle time after forceLoad so the game can fully attach event
-                // handlers to items in the right panel before we click them (see issue #1573).
-                // Without this wait, clicks on items are silently ignored and the equip button
-                // stays disabled. Observed failure mode: slot 0 fails ~67% of the time without it.
-                yield TimeHelper.sleep(randomInterval(800, 1200));
                 const equippedEl = slot.find('.slot[data-d]');
                 let equippedData = null;
                 if (equippedEl.length > 0 && equippedEl.attr('data-d')) {
@@ -12161,7 +12145,7 @@ class HaremGirl {
                             rawPreScroll.scrollIntoView({ block: 'center' });
                             // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
                             LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
-                            yield TimeHelper.sleep(randomInterval(200, 300));
+                            yield TimeHelper.sleep(randomInterval(50, 100));
                         }
                         // ========== POST-SLEEP STATE ==========
                         const rawPostSleep = bestInventory.el.get(0);
@@ -12207,7 +12191,7 @@ class HaremGirl {
                                     // Scroll the fresh node into view, then re-check
                                     if (typeof raw.scrollIntoView === 'function') {
                                         raw.scrollIntoView({ block: 'center' });
-                                        yield TimeHelper.sleep(randomInterval(200, 300));
+                                        yield TimeHelper.sleep(randomInterval(50, 100));
                                         LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
                                     }
                                 }
@@ -12242,7 +12226,7 @@ class HaremGirl {
                         }
                         LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
                         // Short wait so the primary click can propagate before we check the button
-                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        yield TimeHelper.sleep(randomInterval(100, 200));
                         // ========== POST-PRIMARY STATE ==========
                         {
                             const btnProbe = $('#girl-equipment-equip');
@@ -12254,38 +12238,6 @@ class HaremGirl {
                                 return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
                             }).get().join(' | ');
                             LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw === null || raw === void 0 ? void 0 : raw.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
-                        }
-                        // ========== FALLBACK CLICKS IF EQUIP BTN STILL DISABLED ==========
-                        const $btnProbe = $('#girl-equipment-equip');
-                        const btnStillDisabled = $btnProbe.length === 0
-                            || $btnProbe.prop('disabled') === true
-                            || $btnProbe.hasClass('disabled');
-                        if (btnStillDisabled && raw) {
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] BTN still disabled — running fallback clicks`);
-                            // Fallback 1: synthetic MouseEvent with bubbles + view
-                            try {
-                                raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                            }
-                            catch (e) {
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 1 threw: ${e}`);
-                            }
-                            yield TimeHelper.sleep(200);
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 1 (MouseEvent click): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
-                            // Fallback 2: full mousedown + mouseup + click sequence
-                            try {
-                                raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
-                                raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
-                                raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                            }
-                            catch (e) {
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 2 threw: ${e}`);
-                            }
-                            yield TimeHelper.sleep(200);
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 2 (full mouse seq): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
-                            // Fallback 3: jQuery trigger
-                            bestInventory.el.trigger('click');
-                            yield TimeHelper.sleep(200);
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 3 (jQuery trigger): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                         }
                         // ========== AFTER-CLICK STATE (full) ==========
                         {
@@ -12301,8 +12253,6 @@ class HaremGirl {
                             }).get().join(' | ');
                             LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
                         }
-                        // Additional wait so the game has time to activate the Equip button (see issue #1573)
-                        yield TimeHelper.sleep(randomInterval(400, 700));
                         // Click the Equip confirm button (revealed after item selection)
                         let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         // Wait up to ~500ms for the button to become enabled (see issue #1573)
@@ -12323,7 +12273,7 @@ class HaremGirl {
                                 btnRaw.click();
                             else
                                 $equipBtn.trigger('click');
-                            yield TimeHelper.sleep(randomInterval(400, 700));
+                            yield TimeHelper.sleep(randomInterval(200, 300));
                             LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                             // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
                             if (attempt === 1) {
@@ -12336,7 +12286,7 @@ class HaremGirl {
                             LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         }
                         // Verify the equipped item actually changed (see issue #1573)
-                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        yield TimeHelper.sleep(randomInterval(100, 200));
                         const verifyEl = slot.find('.slot[data-d]');
                         let verifyData = null;
                         if (verifyEl.length > 0 && verifyEl.attr('data-d')) {
@@ -12353,7 +12303,7 @@ class HaremGirl {
                         }
                         LogUtils_logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         if (attempt < MAX_EQUIP_ATTEMPTS) {
-                            yield TimeHelper.sleep(randomInterval(500, 800));
+                            yield TimeHelper.sleep(randomInterval(200, 300));
                         }
                     }
                     if (!equipSucceeded) {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12034,7 +12034,7 @@ class HaremGirl {
         });
     }
     static optimizeEquipmentSlots(girl) {
-        var _a;
+        var _a, _b, _c, _d, _e;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
@@ -12053,7 +12053,7 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_b) { /* ignore */ }
+                    catch ( /* ignore */_f) { /* ignore */ }
                 }
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
@@ -12100,33 +12100,69 @@ class HaremGirl {
                 const shouldReplace = HaremGirl.isBetter(bestInventory.data, equippedData, girl);
                 if (shouldReplace) {
                     LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
-                    // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
-                    const raw = bestInventory.el.get(0);
-                    if (raw && typeof raw.scrollIntoView === 'function') {
-                        raw.scrollIntoView({ block: 'center' });
-                        yield TimeHelper.sleep(randomInterval(200, 300));
+                    // Capture previous equipped identity so we can verify a real change below (see issue #1573)
+                    const previousEquippedKey = equippedData ? ((_c = (_b = equippedData.id_item) !== null && _b !== void 0 ? _b : equippedData.id_equipement) !== null && _c !== void 0 ? _c : JSON.stringify(equippedData)) : null;
+                    const MAX_EQUIP_ATTEMPTS = 3;
+                    let equipSucceeded = false;
+                    for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
+                        // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
+                        const raw = bestInventory.el.get(0);
+                        if (raw && typeof raw.scrollIntoView === 'function') {
+                            raw.scrollIntoView({ block: 'center' });
+                            yield TimeHelper.sleep(randomInterval(200, 300));
+                        }
+                        // Native click to trigger the game's selection handler reliably
+                        if (raw && typeof raw.click === 'function') {
+                            raw.click();
+                        }
+                        else {
+                            bestInventory.el.trigger('click');
+                        }
+                        // Longer wait so the game has time to activate the Equip button (see issue #1573)
+                        yield TimeHelper.sleep(randomInterval(700, 1000));
+                        // Click the Equip confirm button (revealed after item selection)
+                        let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                        // Wait up to ~500ms for the button to become enabled (see issue #1573)
+                        for (let waitIter = 0; waitIter < 5 && $equipBtn.length > 0
+                            && ($equipBtn.prop('disabled') === true || $equipBtn.hasClass('disabled')); waitIter++) {
+                            yield TimeHelper.sleep(100);
+                            $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                        }
+                        if ($equipBtn.length > 0) {
+                            const btnRaw = $equipBtn.get(0);
+                            if (btnRaw && typeof btnRaw.click === 'function')
+                                btnRaw.click();
+                            else
+                                $equipBtn.trigger('click');
+                            yield TimeHelper.sleep(randomInterval(400, 700));
+                            LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                        }
+                        else {
+                            LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                        }
+                        // Verify the equipped item actually changed (see issue #1573)
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        const verifyEl = slot.find('.slot[data-d]');
+                        let verifyData = null;
+                        if (verifyEl.length > 0 && verifyEl.attr('data-d')) {
+                            try {
+                                verifyData = JSON.parse(verifyEl.attr('data-d'));
+                            }
+                            catch ( /* ignore */_g) { /* ignore */ }
+                        }
+                        const verifyKey = verifyData ? ((_e = (_d = verifyData.id_item) !== null && _d !== void 0 ? _d : verifyData.id_equipement) !== null && _e !== void 0 ? _e : JSON.stringify(verifyData)) : null;
+                        if (verifyKey !== previousEquippedKey) {
+                            LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
+                            equipSucceeded = true;
+                            break;
+                        }
+                        LogUtils_logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                        if (attempt < MAX_EQUIP_ATTEMPTS) {
+                            yield TimeHelper.sleep(randomInterval(500, 800));
+                        }
                     }
-                    // Native click to trigger the game's selection handler reliably
-                    if (raw && typeof raw.click === 'function') {
-                        raw.click();
-                    }
-                    else {
-                        bestInventory.el.trigger('click');
-                    }
-                    yield TimeHelper.sleep(randomInterval(300, 500));
-                    // Click the Equip confirm button (revealed after item selection)
-                    const $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
-                    if ($equipBtn.length > 0) {
-                        const btnRaw = $equipBtn.get(0);
-                        if (btnRaw && typeof btnRaw.click === 'function')
-                            btnRaw.click();
-                        else
-                            $equipBtn.trigger('click');
-                        yield TimeHelper.sleep(randomInterval(400, 700));
-                        LogUtils_logHHAuto(`Slot ${i}: equip button clicked`);
-                    }
-                    else {
-                        LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found`);
+                    if (!equipSucceeded) {
+                        LogUtils_logHHAuto(`Slot ${i}: equip failed after ${MAX_EQUIP_ATTEMPTS} attempts, skipping`);
                     }
                 }
                 else {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.9
+// @version      7.35.10
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -12031,20 +12031,14 @@ class HaremGirl {
         });
     }
     static optimizeEquipmentSlots(girl) {
-        var _a, _b, _c, _d, _e, _f, _g;
+        var _a, _b, _c, _d, _e, _f;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
-                // DEBUG (issue #1573): capture slot state before click
-                const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                LogUtils_logHHAuto(`[DEBUG Slot ${i}] all slot classes BEFORE click: ${beforeClasses}`);
                 slot.trigger('click');
-                // DEBUG (issue #1573): capture slot state after click
-                const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                LogUtils_logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
                 // Short wait so the game kicks off its inventory request for this slot
                 yield TimeHelper.sleep(randomInterval(100, 200));
                 // Force game to render all lazy-loaded inventory items into the DOM
@@ -12055,7 +12049,7 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_h) { /* ignore */ }
+                    catch ( /* ignore */_g) { /* ignore */ }
                 }
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
@@ -12073,16 +12067,7 @@ class HaremGirl {
                 });
                 // Filter candidates by slot_index so we don't compare pants to necklaces
                 const inventoryItems = allDomItems.filter(it => Number(it.data.slot_index) === Number(targetSlotIndex));
-                // Diagnostic: slot_index distribution + top rarities in inventory
-                const slotDist = {};
-                const rarityDist = {};
-                for (const it of allDomItems) {
-                    const si = String(it.data.slot_index);
-                    slotDist[si] = (slotDist[si] || 0) + 1;
-                    const ra = String(it.data.rarity);
-                    rarityDist[ra] = (rarityDist[ra] || 0) + 1;
-                }
-                LogUtils_logHHAuto(`Slot ${i}: targetSlotIndex=${targetSlotIndex}, DOM items=${allDomItems.length}, candidates=${inventoryItems.length}, slot_index_dist=${JSON.stringify(slotDist)}, rarity_dist=${JSON.stringify(rarityDist)}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} si=${equippedData.slot_index}` : 'none'}`);
+                LogUtils_logHHAuto(`Slot ${i}: ${inventoryItems.length} candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
                 if (inventoryItems.length === 0) {
                     LogUtils_logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
                     continue;
@@ -12107,61 +12092,21 @@ class HaremGirl {
                     const previousEquippedKey = equippedData ? ((_c = (_b = equippedData.id_item) !== null && _b !== void 0 ? _b : equippedData.id_equipement) !== null && _c !== void 0 ? _c : JSON.stringify(equippedData)) : null;
                     const MAX_EQUIP_ATTEMPTS = 3;
                     let equipSucceeded = false;
-                    // Helper: parent chain up to `maxDepth` or until root, "tag.cls1.cls2" per level
-                    const buildParentChain = ($el, maxDepth) => {
-                        var _a;
-                        const chain = [];
-                        let p = $el.parent();
-                        for (let d = 0; d < maxDepth && p.length > 0; d++) {
-                            const pEl = p.get(0);
-                            const cls = (p.attr('class') || '').split(/\s+/).filter(c => c).slice(0, 3).join('.');
-                            chain.push(`${((_a = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
-                            p = p.parent();
-                        }
-                        return chain;
-                    };
-                    // Helper: global DOM counts relevant to equipment UI
-                    const domSnapshot = () => ({
-                        rightSection: $('.right-section').length,
-                        inventoryScroll: $('.inventory.hh-scroll').length,
-                        girlLevelerPanel: $('.girl-leveler-panel').length,
-                        filledSlots: $('.right-section .slot[data-d]').length,
-                        selectedSlots: $('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length
-                    });
-                    // ISSUE #1573: Detach can happen between scroll and click, not before the attempt
-                    // loop. The isConnected check + re-query is now performed INSIDE the loop, after
-                    // scroll+sleep, right before the primary click. Massive diagnostics wrapped around
-                    // every step so we can see exactly when and why the node detaches.
                     for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
-                        // ========== PRE-SCROLL SNAPSHOT ==========
+                        // Scroll the chosen item into view
                         const rawPreScroll = bestInventory.el.get(0);
-                        const preScrollConn = rawPreScroll === null || rawPreScroll === void 0 ? void 0 : rawPreScroll.isConnected;
-                        const preScrollBody = rawPreScroll ? document.body.contains(rawPreScroll) : false;
-                        const preScrollParents = buildParentChain(bestInventory.el, 12);
-                        const preScrollDom = domSnapshot();
-                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-SCROLL: connected=${preScrollConn} bodyContains=${preScrollBody} domCounts=${JSON.stringify(preScrollDom)} parents=[${preScrollParents.join(' > ')}]`);
-                        // ========== SCROLL INTO VIEW ==========
                         if (rawPreScroll && typeof rawPreScroll.scrollIntoView === 'function') {
                             rawPreScroll.scrollIntoView({ block: 'center' });
-                            // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
                             yield TimeHelper.sleep(randomInterval(50, 100));
                         }
-                        // ========== POST-SLEEP STATE ==========
-                        const rawPostSleep = bestInventory.el.get(0);
-                        const postSleepConn = rawPostSleep === null || rawPostSleep === void 0 ? void 0 : rawPostSleep.isConnected;
-                        const postSleepVisible = rawPostSleep ? rawPostSleep.offsetParent !== null : false;
-                        const postSleepBody = rawPostSleep ? document.body.contains(rawPostSleep) : false;
-                        const postSleepParents = buildParentChain(bestInventory.el, 12);
-                        const postSleepDom = domSnapshot();
-                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SLEEP: connected=${postSleepConn} visible=${postSleepVisible} bodyContains=${postSleepBody} domCounts=${JSON.stringify(postSleepDom)} parents=[${postSleepParents.join(' > ')}]`);
-                        // ========== RE-QUERY IF DETACHED ==========
-                        let raw = rawPostSleep;
+                        // Issue #1573: virtualized rendering can detach the original
+                        // node during scroll. Re-query by id_girl_armor and swap to the
+                        // fresh node before clicking.
+                        let raw = bestInventory.el.get(0);
                         if (!raw || !raw.isConnected) {
                             const targetArmorId = (_d = bestInventory.data) === null || _d === void 0 ? void 0 : _d.id_girl_armor;
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] DETACHED — attempting re-query for id_girl_armor=${targetArmorId}`);
                             if (targetArmorId != null) {
-                                const candidates = $('.right-section .slot[data-d]').filter(function () {
+                                const $fresh = $('.right-section .slot[data-d]').filter(function () {
                                     try {
                                         const d = JSON.parse($(this).attr('data-d') || '{}');
                                         return d.id_girl_armor === targetArmorId;
@@ -12169,34 +12114,21 @@ class HaremGirl {
                                     catch (_a) {
                                         return false;
                                     }
-                                });
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] re-query found ${candidates.length} candidate(s)`);
-                                candidates.each(function (idx) {
-                                    const $c = $(this);
-                                    const cRaw = $c.get(0);
-                                    const cConn = cRaw === null || cRaw === void 0 ? void 0 : cRaw.isConnected;
-                                    const cBody = cRaw ? document.body.contains(cRaw) : false;
-                                    const cParents = buildParentChain($c, 8);
-                                    LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] candidate[${idx}]: connected=${cConn} bodyContains=${cBody} parents=[${cParents.join(' > ')}]`);
-                                });
-                                const $fresh = candidates.filter(function () {
+                                }).filter(function () {
                                     const r = $(this).get(0);
                                     return !!r && r.isConnected;
                                 }).first();
                                 if ($fresh.length > 0) {
-                                    const freshRaw = $fresh.get(0);
-                                    LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] RE-QUERY SUCCESS — swapping to fresh node`);
                                     bestInventory.el = $fresh;
-                                    raw = freshRaw;
-                                    // Scroll the fresh node into view, then re-check
+                                    raw = $fresh.get(0);
+                                    LogUtils_logHHAuto(`Slot ${i}: item was detached, re-queried fresh node`);
                                     if (typeof raw.scrollIntoView === 'function') {
                                         raw.scrollIntoView({ block: 'center' });
                                         yield TimeHelper.sleep(randomInterval(50, 100));
-                                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
                                     }
                                 }
                                 else {
-                                    LogUtils_logHHAuto(`Slot ${i}: no connected candidate after re-query (id_girl_armor=${targetArmorId}), aborting attempts`);
+                                    LogUtils_logHHAuto(`Slot ${i}: no connected candidate after re-query, aborting attempts`);
                                     break;
                                 }
                             }
@@ -12205,69 +12137,23 @@ class HaremGirl {
                                 break;
                             }
                         }
-                        // ========== PRE-CLICK STATE (for the node we will actually click) ==========
-                        {
-                            const itemCls = bestInventory.el.attr('class') || '';
-                            const itemId = bestInventory.el.attr('data-id') || '';
-                            const connected = raw === null || raw === void 0 ? void 0 : raw.isConnected;
-                            const visible = raw ? raw.offsetParent !== null : false;
-                            const bodyContains = raw ? document.body.contains(raw) : false;
-                            const outerH = ((raw === null || raw === void 0 ? void 0 : raw.outerHTML) || '').substring(0, 400);
-                            const parentChain = buildParentChain(bestInventory.el, 12);
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-CLICK: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} bodyContains=${bodyContains} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
-                        }
-                        // ========== PRIMARY CLICK ==========
-                        const usedNative = !!(raw && typeof raw.click === 'function');
-                        if (usedNative) {
+                        // Primary click on the item
+                        if (raw && typeof raw.click === 'function') {
                             raw.click();
                         }
                         else {
                             bestInventory.el.trigger('click');
                         }
-                        LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
-                        // Short wait so the primary click can propagate before we check the button
                         yield TimeHelper.sleep(randomInterval(100, 200));
-                        // ========== POST-PRIMARY STATE ==========
-                        {
-                            const btnProbe = $('#girl-equipment-equip');
-                            const btnDisabled = btnProbe.length === 0 || btnProbe.prop('disabled') === true || btnProbe.hasClass('disabled');
-                            const rightSelectedStr = $('.right-section .selected, .right-section .active, .right-section .highlight')
-                                .map((_, el) => {
-                                var _a;
-                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
-                                return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
-                            }).get().join(' | ');
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw === null || raw === void 0 ? void 0 : raw.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
-                        }
-                        // ========== AFTER-CLICK STATE (full) ==========
-                        {
-                            const rawElAfter = bestInventory.el.get(0);
-                            const itemClsAfter = bestInventory.el.attr('class') || '';
-                            const connectedAfter = rawElAfter === null || rawElAfter === void 0 ? void 0 : rawElAfter.isConnected;
-                            const bodyContainsAfter = rawElAfter ? document.body.contains(rawElAfter) : false;
-                            const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
-                                .map((_, el) => {
-                                var _a;
-                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
-                                return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
-                            }).get().join(' | ');
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
-                        }
                         // Click the Equip confirm button (revealed after item selection)
                         let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
-                        // Wait up to ~500ms for the button to become enabled (see issue #1573)
+                        // Wait up to ~500ms for the button to become enabled
                         for (let waitIter = 0; waitIter < 5 && $equipBtn.length > 0
                             && ($equipBtn.prop('disabled') === true || $equipBtn.hasClass('disabled')); waitIter++) {
                             yield TimeHelper.sleep(100);
                             $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         }
                         if ($equipBtn.length > 0) {
-                            // DEBUG (issue #1573): equip button state BEFORE click (attempt 1 only)
-                            if (attempt === 1) {
-                                const btnEl = $equipBtn.get(0);
-                                const btnHtml = ((btnEl === null || btnEl === void 0 ? void 0 : btnEl.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
-                            }
                             const btnRaw = $equipBtn.get(0);
                             if (btnRaw && typeof btnRaw.click === 'function')
                                 btnRaw.click();
@@ -12275,12 +12161,6 @@ class HaremGirl {
                                 $equipBtn.trigger('click');
                             yield TimeHelper.sleep(randomInterval(200, 300));
                             LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
-                            // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
-                            if (attempt === 1) {
-                                const btnAfter = $('#girl-equipment-equip').get(0);
-                                const btnAfterHtml = ((btnAfter === null || btnAfter === void 0 ? void 0 : btnAfter.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn AFTER click: html="${btnAfterHtml}"`);
-                            }
                         }
                         else {
                             LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
@@ -12293,9 +12173,9 @@ class HaremGirl {
                             try {
                                 verifyData = JSON.parse(verifyEl.attr('data-d'));
                             }
-                            catch ( /* ignore */_j) { /* ignore */ }
+                            catch ( /* ignore */_h) { /* ignore */ }
                         }
-                        const verifyKey = verifyData ? ((_g = (_f = verifyData.id_item) !== null && _f !== void 0 ? _f : verifyData.id_equipement) !== null && _g !== void 0 ? _g : JSON.stringify(verifyData)) : null;
+                        const verifyKey = verifyData ? ((_f = (_e = verifyData.id_item) !== null && _e !== void 0 ? _e : verifyData.id_equipement) !== null && _f !== void 0 ? _f : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {
                             LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
                             equipSucceeded = true;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12034,7 +12034,7 @@ class HaremGirl {
         });
     }
     static optimizeEquipmentSlots(girl) {
-        var _a, _b, _c, _d, _e;
+        var _a, _b, _c, _d, _e, _f, _g;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
@@ -12049,7 +12049,17 @@ class HaremGirl {
             }
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
+                // DEBUG (issue #1573): capture slot state before click for slot 0
+                if (i === 0) {
+                    const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                    LogUtils_logHHAuto(`[DEBUG Slot 0] all slot classes BEFORE click: ${beforeClasses}`);
+                }
                 slot.trigger('click');
+                // DEBUG (issue #1573): capture slot state after click for slot 0
+                if (i === 0) {
+                    const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                    LogUtils_logHHAuto(`[DEBUG Slot 0] all slot classes AFTER click: ${afterClasses}`);
+                }
                 // Give the game time to kick off its inventory request for this slot
                 // before we start scrolling to force-load items (see issue #1573).
                 yield TimeHelper.sleep(randomInterval(600, 900));
@@ -12061,7 +12071,7 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_f) { /* ignore */ }
+                    catch ( /* ignore */_h) { /* ignore */ }
                 }
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
@@ -12119,12 +12129,23 @@ class HaremGirl {
                             raw.scrollIntoView({ block: 'center' });
                             yield TimeHelper.sleep(randomInterval(200, 300));
                         }
+                        // DEBUG (issue #1573): best item state BEFORE click for slot 0 attempt 1
+                        if (i === 0 && attempt === 1) {
+                            const itemCls = bestInventory.el.attr('class') || '';
+                            const itemId = bestInventory.el.attr('data-id') || '';
+                            LogUtils_logHHAuto(`[DEBUG Slot 0] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${(_d = bestInventory.data.id_item) !== null && _d !== void 0 ? _d : 'n/a'}`);
+                        }
                         // Native click to trigger the game's selection handler reliably
                         if (raw && typeof raw.click === 'function') {
                             raw.click();
                         }
                         else {
                             bestInventory.el.trigger('click');
+                        }
+                        // DEBUG (issue #1573): item state AFTER click for slot 0 attempt 1
+                        if (i === 0 && attempt === 1) {
+                            const itemClsAfter = bestInventory.el.attr('class') || '';
+                            LogUtils_logHHAuto(`[DEBUG Slot 0] best item AFTER click: class="${itemClsAfter}"`);
                         }
                         // Longer wait so the game has time to activate the Equip button (see issue #1573)
                         yield TimeHelper.sleep(randomInterval(700, 1000));
@@ -12137,6 +12158,12 @@ class HaremGirl {
                             $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         }
                         if ($equipBtn.length > 0) {
+                            // DEBUG (issue #1573): equip button state BEFORE click for slot 0 attempt 1
+                            if (i === 0 && attempt === 1) {
+                                const btnEl = $equipBtn.get(0);
+                                const btnHtml = ((btnEl === null || btnEl === void 0 ? void 0 : btnEl.outerHTML) || '').substring(0, 400);
+                                LogUtils_logHHAuto(`[DEBUG Slot 0] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                            }
                             const btnRaw = $equipBtn.get(0);
                             if (btnRaw && typeof btnRaw.click === 'function')
                                 btnRaw.click();
@@ -12144,6 +12171,12 @@ class HaremGirl {
                                 $equipBtn.trigger('click');
                             yield TimeHelper.sleep(randomInterval(400, 700));
                             LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                            // DEBUG (issue #1573): equip button state AFTER click for slot 0 attempt 1
+                            if (i === 0 && attempt === 1) {
+                                const btnAfter = $('#girl-equipment-equip').get(0);
+                                const btnAfterHtml = ((btnAfter === null || btnAfter === void 0 ? void 0 : btnAfter.outerHTML) || '').substring(0, 400);
+                                LogUtils_logHHAuto(`[DEBUG Slot 0] equip btn AFTER click: html="${btnAfterHtml}"`);
+                            }
                         }
                         else {
                             LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
@@ -12156,9 +12189,9 @@ class HaremGirl {
                             try {
                                 verifyData = JSON.parse(verifyEl.attr('data-d'));
                             }
-                            catch ( /* ignore */_g) { /* ignore */ }
+                            catch ( /* ignore */_j) { /* ignore */ }
                         }
-                        const verifyKey = verifyData ? ((_e = (_d = verifyData.id_item) !== null && _d !== void 0 ? _d : verifyData.id_equipement) !== null && _e !== void 0 ? _e : JSON.stringify(verifyData)) : null;
+                        const verifyKey = verifyData ? ((_g = (_f = verifyData.id_item) !== null && _f !== void 0 ? _f : verifyData.id_equipement) !== null && _g !== void 0 ? _g : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {
                             LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
                             equipSucceeded = true;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12039,15 +12039,14 @@ class HaremGirl {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
-            // Warmup: click a sibling slot once so the game registers a real state
-            // transition when we click slot 0 below. Without this the first click
-            // on an already-displayed slot is a no-op and the equip button ignores
-            // our later click (see issue #1573).
-            if (slotCount >= 2) {
-                equipmentSlots.eq(1).trigger('click');
-                yield TimeHelper.sleep(randomInterval(400, 700));
-            }
-            for (let i = 0; i < slotCount; i++) {
+            // Iterate slots in reverse order (5 → 0) so slot 0 is processed last.
+            // Slot 0 is the default active slot after the page loads; processing it
+            // first made the game treat slot 0 as "already active" and silently
+            // ignore item clicks — the equip button never committed the change.
+            // By the time we reach slot 0 we have switched slots five times, so the
+            // game's internal state is guaranteed to register a real transition
+            // when we click slot 0 (see issue #1573).
+            for (let i = slotCount - 1; i >= 0; i--) {
                 const slot = equipmentSlots.eq(i);
                 // DEBUG (issue #1573): capture slot state before click
                 const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12034,7 +12034,7 @@ class HaremGirl {
         });
     }
     static optimizeEquipmentSlots(girl) {
-        var _a, _b, _c, _d, _e, _f, _g;
+        var _a, _b, _c, _d, _e, _f, _g, _h;
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
@@ -12071,17 +12071,12 @@ class HaremGirl {
                     try {
                         equippedData = JSON.parse(equippedEl.attr('data-d'));
                     }
-                    catch ( /* ignore */_h) { /* ignore */ }
+                    catch ( /* ignore */_j) { /* ignore */ }
                 }
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
                 $('.right-section .slot[data-d]').each(function () {
                     const $el = $(this);
-                    // Skip items sitting inside a filled equipment slot — those are already equipped
-                    // girl_armor records, not free inventory items. Clicking them does nothing and the
-                    // element is often detached from the DOM by the time we reach it (see issue #1573).
-                    if ($el.closest('.inventory-slot.filled-slot').length > 0)
-                        return;
                     const raw = $el.attr('data-d');
                     if (!raw)
                         return;
@@ -12128,6 +12123,40 @@ class HaremGirl {
                     const previousEquippedKey = equippedData ? ((_c = (_b = equippedData.id_item) !== null && _b !== void 0 ? _b : equippedData.id_equipement) !== null && _c !== void 0 ? _c : JSON.stringify(equippedData)) : null;
                     const MAX_EQUIP_ATTEMPTS = 3;
                     let equipSucceeded = false;
+                    // ISSUE #1573: Verify the selected DOM element is still attached. During slot
+                    // iteration the game can rebuild the inventory panel, leaving our stored jQuery
+                    // wrapper pointing at a detached node. Clicking a detached node is a no-op, which
+                    // is why slot 0 replacement consistently failed. Re-query via id_girl_armor to
+                    // find a fresh node for the same item.
+                    const rawBeforeAttempts = bestInventory.el.get(0);
+                    if (!rawBeforeAttempts || !rawBeforeAttempts.isConnected) {
+                        const targetArmorId = (_d = bestInventory.data) === null || _d === void 0 ? void 0 : _d.id_girl_armor;
+                        LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item detached from DOM (id_girl_armor=${targetArmorId}), attempting re-query`);
+                        if (targetArmorId != null) {
+                            const $fresh = $('.right-section .slot[data-d]').filter(function () {
+                                try {
+                                    const d = JSON.parse($(this).attr('data-d') || '{}');
+                                    return d.id_girl_armor === targetArmorId;
+                                }
+                                catch (_a) {
+                                    return false;
+                                }
+                            }).first();
+                            const freshRaw = $fresh.get(0);
+                            if ($fresh.length > 0 && freshRaw && freshRaw.isConnected) {
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] re-query successful, using fresh DOM element for id_girl_armor=${targetArmorId}`);
+                                bestInventory.el = $fresh;
+                            }
+                            else {
+                                LogUtils_logHHAuto(`Slot ${i}: best item no longer in DOM after re-query (id_girl_armor=${targetArmorId}), skipping slot`);
+                                continue;
+                            }
+                        }
+                        else {
+                            LogUtils_logHHAuto(`Slot ${i}: best item detached and no id_girl_armor to re-query, skipping slot`);
+                            continue;
+                        }
+                    }
                     for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
                         // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
                         const raw = bestInventory.el.get(0);
@@ -12148,7 +12177,7 @@ class HaremGirl {
                             for (let d = 0; d < 4 && p.length > 0; d++) {
                                 const pEl = p.get(0);
                                 const cls = (p.attr('class') || '').split(/\s+/).slice(0, 2).join('.');
-                                parentChain.push(`${((_d = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _d === void 0 ? void 0 : _d.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
+                                parentChain.push(`${((_e = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _e === void 0 ? void 0 : _e.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
                                 p = p.parent();
                             }
                             LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
@@ -12176,7 +12205,7 @@ class HaremGirl {
                             try {
                                 raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
                             }
-                            catch ( /* ignore */_j) { /* ignore */ }
+                            catch ( /* ignore */_k) { /* ignore */ }
                             yield TimeHelper.sleep(200);
                             // Fallback 2: full mousedown + mouseup + click sequence
                             try {
@@ -12184,7 +12213,7 @@ class HaremGirl {
                                 raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
                                 raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
                             }
-                            catch ( /* ignore */_k) { /* ignore */ }
+                            catch ( /* ignore */_l) { /* ignore */ }
                             yield TimeHelper.sleep(200);
                             // Fallback 3: jQuery trigger (uses jQuery's event simulation pipeline)
                             bestInventory.el.trigger('click');
@@ -12218,7 +12247,7 @@ class HaremGirl {
                             if (attempt === 1) {
                                 const btnEl = $equipBtn.get(0);
                                 const btnHtml = ((btnEl === null || btnEl === void 0 ? void 0 : btnEl.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_f = $equipBtn.attr('hidden')) !== null && _f !== void 0 ? _f : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
                             }
                             const btnRaw = $equipBtn.get(0);
                             if (btnRaw && typeof btnRaw.click === 'function')
@@ -12245,9 +12274,9 @@ class HaremGirl {
                             try {
                                 verifyData = JSON.parse(verifyEl.attr('data-d'));
                             }
-                            catch ( /* ignore */_l) { /* ignore */ }
+                            catch ( /* ignore */_m) { /* ignore */ }
                         }
-                        const verifyKey = verifyData ? ((_g = (_f = verifyData.id_item) !== null && _f !== void 0 ? _f : verifyData.id_equipement) !== null && _g !== void 0 ? _g : JSON.stringify(verifyData)) : null;
+                        const verifyKey = verifyData ? ((_h = (_g = verifyData.id_item) !== null && _g !== void 0 ? _g : verifyData.id_equipement) !== null && _h !== void 0 ? _h : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {
                             LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
                             equipSucceeded = true;

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12049,17 +12049,13 @@ class HaremGirl {
             }
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
-                // DEBUG (issue #1573): capture slot state before click for slot 0
-                if (i === 0) {
-                    const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                    LogUtils_logHHAuto(`[DEBUG Slot 0] all slot classes BEFORE click: ${beforeClasses}`);
-                }
+                // DEBUG (issue #1573): capture slot state before click
+                const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                LogUtils_logHHAuto(`[DEBUG Slot ${i}] all slot classes BEFORE click: ${beforeClasses}`);
                 slot.trigger('click');
-                // DEBUG (issue #1573): capture slot state after click for slot 0
-                if (i === 0) {
-                    const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                    LogUtils_logHHAuto(`[DEBUG Slot 0] all slot classes AFTER click: ${afterClasses}`);
-                }
+                // DEBUG (issue #1573): capture slot state after click
+                const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                LogUtils_logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
                 // Give the game time to kick off its inventory request for this slot
                 // before we start scrolling to force-load items (see issue #1573).
                 yield TimeHelper.sleep(randomInterval(600, 900));
@@ -12129,11 +12125,11 @@ class HaremGirl {
                             raw.scrollIntoView({ block: 'center' });
                             yield TimeHelper.sleep(randomInterval(200, 300));
                         }
-                        // DEBUG (issue #1573): best item state BEFORE click for slot 0 attempt 1
-                        if (i === 0 && attempt === 1) {
+                        // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
+                        if (attempt === 1) {
                             const itemCls = bestInventory.el.attr('class') || '';
                             const itemId = bestInventory.el.attr('data-id') || '';
-                            LogUtils_logHHAuto(`[DEBUG Slot 0] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${(_d = bestInventory.data.id_item) !== null && _d !== void 0 ? _d : 'n/a'}`);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${(_d = bestInventory.data.id_item) !== null && _d !== void 0 ? _d : 'n/a'}`);
                         }
                         // Native click to trigger the game's selection handler reliably
                         if (raw && typeof raw.click === 'function') {
@@ -12142,10 +12138,10 @@ class HaremGirl {
                         else {
                             bestInventory.el.trigger('click');
                         }
-                        // DEBUG (issue #1573): item state AFTER click for slot 0 attempt 1
-                        if (i === 0 && attempt === 1) {
+                        // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
+                        if (attempt === 1) {
                             const itemClsAfter = bestInventory.el.attr('class') || '';
-                            LogUtils_logHHAuto(`[DEBUG Slot 0] best item AFTER click: class="${itemClsAfter}"`);
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}"`);
                         }
                         // Longer wait so the game has time to activate the Equip button (see issue #1573)
                         yield TimeHelper.sleep(randomInterval(700, 1000));
@@ -12158,11 +12154,11 @@ class HaremGirl {
                             $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         }
                         if ($equipBtn.length > 0) {
-                            // DEBUG (issue #1573): equip button state BEFORE click for slot 0 attempt 1
-                            if (i === 0 && attempt === 1) {
+                            // DEBUG (issue #1573): equip button state BEFORE click (attempt 1 only)
+                            if (attempt === 1) {
                                 const btnEl = $equipBtn.get(0);
                                 const btnHtml = ((btnEl === null || btnEl === void 0 ? void 0 : btnEl.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot 0] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${(_e = $equipBtn.attr('hidden')) !== null && _e !== void 0 ? _e : 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
                             }
                             const btnRaw = $equipBtn.get(0);
                             if (btnRaw && typeof btnRaw.click === 'function')
@@ -12171,11 +12167,11 @@ class HaremGirl {
                                 $equipBtn.trigger('click');
                             yield TimeHelper.sleep(randomInterval(400, 700));
                             LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
-                            // DEBUG (issue #1573): equip button state AFTER click for slot 0 attempt 1
-                            if (i === 0 && attempt === 1) {
+                            // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
+                            if (attempt === 1) {
                                 const btnAfter = $('#girl-equipment-equip').get(0);
                                 const btnAfterHtml = ((btnAfter === null || btnAfter === void 0 ? void 0 : btnAfter.outerHTML) || '').substring(0, 400);
-                                LogUtils_logHHAuto(`[DEBUG Slot 0] equip btn AFTER click: html="${btnAfterHtml}"`);
+                                LogUtils_logHHAuto(`[DEBUG Slot ${i}] equip btn AFTER click: html="${btnAfterHtml}"`);
                             }
                         }
                         else {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12061,6 +12061,11 @@ class HaremGirl {
                 yield TimeHelper.sleep(randomInterval(600, 900));
                 // Force game to render all lazy-loaded inventory items into the DOM
                 const totalItems = yield HaremGirl.forceLoadAllInventoryItems();
+                // Extra settle time after forceLoad so the game can fully attach event
+                // handlers to items in the right panel before we click them (see issue #1573).
+                // Without this wait, clicks on items are silently ignored and the equip button
+                // stays disabled. Observed failure mode: slot 0 fails ~67% of the time without it.
+                yield TimeHelper.sleep(randomInterval(800, 1200));
                 const equippedEl = slot.find('.slot[data-d]');
                 let equippedData = null;
                 if (equippedEl.length > 0 && equippedEl.attr('data-d')) {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12131,24 +12131,74 @@ class HaremGirl {
                         }
                         // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
                         if (attempt === 1) {
+                            const rawElBefore = bestInventory.el.get(0);
                             const itemCls = bestInventory.el.attr('class') || '';
                             const itemId = bestInventory.el.attr('data-id') || '';
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${(_d = bestInventory.data.id_item) !== null && _d !== void 0 ? _d : 'n/a'}`);
+                            const connected = rawElBefore === null || rawElBefore === void 0 ? void 0 : rawElBefore.isConnected;
+                            const visible = rawElBefore ? rawElBefore.offsetParent !== null : false;
+                            const outerH = ((rawElBefore === null || rawElBefore === void 0 ? void 0 : rawElBefore.outerHTML) || '').substring(0, 250);
+                            const parentChain = [];
+                            let p = bestInventory.el.parent();
+                            for (let d = 0; d < 4 && p.length > 0; d++) {
+                                const pEl = p.get(0);
+                                const cls = (p.attr('class') || '').split(/\s+/).slice(0, 2).join('.');
+                                parentChain.push(`${((_d = pEl === null || pEl === void 0 ? void 0 : pEl.tagName) === null || _d === void 0 ? void 0 : _d.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`);
+                                p = p.parent();
+                            }
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
                         }
-                        // Native click to trigger the game's selection handler reliably
+                        // Primary click: native click triggers the game's selection handler
                         if (raw && typeof raw.click === 'function') {
                             raw.click();
                         }
                         else {
                             bestInventory.el.trigger('click');
                         }
+                        // Short wait so the primary click can propagate before we check the button
+                        yield TimeHelper.sleep(randomInterval(300, 500));
+                        // Fallback click methods if the equip button is still disabled
+                        // after the primary click. On slot 0 the native .click() is
+                        // consistently ignored by the game — some frameworks only react
+                        // to fully simulated MouseEvents with bubbles/view set (see #1573).
+                        const $btnProbe = $('#girl-equipment-equip');
+                        const btnStillDisabled = $btnProbe.length === 0
+                            || $btnProbe.prop('disabled') === true
+                            || $btnProbe.hasClass('disabled');
+                        if (btnStillDisabled && raw) {
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] primary click did not enable equip button, trying fallback click methods (attempt ${attempt})`);
+                            // Fallback 1: synthetic MouseEvent with bubbles + view
+                            try {
+                                raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+                            }
+                            catch ( /* ignore */_j) { /* ignore */ }
+                            yield TimeHelper.sleep(200);
+                            // Fallback 2: full mousedown + mouseup + click sequence
+                            try {
+                                raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
+                                raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
+                                raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+                            }
+                            catch ( /* ignore */_k) { /* ignore */ }
+                            yield TimeHelper.sleep(200);
+                            // Fallback 3: jQuery trigger (uses jQuery's event simulation pipeline)
+                            bestInventory.el.trigger('click');
+                            yield TimeHelper.sleep(200);
+                        }
                         // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
                         if (attempt === 1) {
+                            const rawElAfter = bestInventory.el.get(0);
                             const itemClsAfter = bestInventory.el.attr('class') || '';
-                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}"`);
+                            const connectedAfter = rawElAfter === null || rawElAfter === void 0 ? void 0 : rawElAfter.isConnected;
+                            const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
+                                .map((_, el) => {
+                                var _a;
+                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
+                                return `${((_a = el.tagName) === null || _a === void 0 ? void 0 : _a.toLowerCase()) || '?'}${cls ? '.' + cls : ''}`;
+                            }).get().join(' | ');
+                            LogUtils_logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}" connected=${connectedAfter} right-selected="${rightSelected || 'none'}"`);
                         }
-                        // Longer wait so the game has time to activate the Equip button (see issue #1573)
-                        yield TimeHelper.sleep(randomInterval(700, 1000));
+                        // Additional wait so the game has time to activate the Equip button (see issue #1573)
+                        yield TimeHelper.sleep(randomInterval(400, 700));
                         // Click the Equip confirm button (revealed after item selection)
                         let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         // Wait up to ~500ms for the button to become enabled (see issue #1573)
@@ -12189,7 +12239,7 @@ class HaremGirl {
                             try {
                                 verifyData = JSON.parse(verifyEl.attr('data-d'));
                             }
-                            catch ( /* ignore */_j) { /* ignore */ }
+                            catch ( /* ignore */_l) { /* ignore */ }
                         }
                         const verifyKey = verifyData ? ((_g = (_f = verifyData.id_item) !== null && _f !== void 0 ? _f : verifyData.id_equipement) !== null && _g !== void 0 ? _g : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12076,13 +12076,19 @@ class HaremGirl {
                 const targetSlotIndex = (_a = equippedData === null || equippedData === void 0 ? void 0 : equippedData.slot_index) !== null && _a !== void 0 ? _a : (i + 1);
                 const allDomItems = [];
                 $('.right-section .slot[data-d]').each(function () {
-                    const raw = $(this).attr('data-d');
+                    const $el = $(this);
+                    // Skip items sitting inside a filled equipment slot — those are already equipped
+                    // girl_armor records, not free inventory items. Clicking them does nothing and the
+                    // element is often detached from the DOM by the time we reach it (see issue #1573).
+                    if ($el.closest('.inventory-slot.filled-slot').length > 0)
+                        return;
+                    const raw = $el.attr('data-d');
                     if (!raw)
                         return;
                     try {
                         const data = JSON.parse(raw);
                         if (data && data.caracs)
-                            allDomItems.push({ el: $(this), data });
+                            allDomItems.push({ el: $el, data });
                     }
                     catch ( /* ignore */_a) { /* ignore */ }
                 });

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11995,6 +11995,10 @@ class HaremGirl {
             scrollables.push(document.scrollingElement || document.body);
             let prevCount = countItems();
             LogUtils_logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
+            // Require 2 consecutive stable iterations before breaking — a single
+            // stable iteration can happen during a network hiccup while more items
+            // are still loading (see issue #1573).
+            let stableIterations = 0;
             for (let iter = 0; iter < 15; iter++) {
                 // scroll each scrollable to its bottom and dispatch a scroll event
                 for (const s of scrollables) {
@@ -12004,11 +12008,17 @@ class HaremGirl {
                     }
                     catch ( /* ignore */_a) { /* ignore */ }
                 }
-                yield TimeHelper.sleep(randomInterval(200, 350));
+                yield TimeHelper.sleep(randomInterval(400, 600));
                 const curCount = countItems();
-                if (curCount === prevCount)
-                    break;
-                prevCount = curCount;
+                if (curCount === prevCount) {
+                    stableIterations++;
+                    if (stableIterations >= 2)
+                        break;
+                }
+                else {
+                    stableIterations = 0;
+                    prevCount = curCount;
+                }
             }
             // scroll back up so the chosen item's scrollIntoView works reliably
             for (const s of scrollables) {
@@ -12017,7 +12027,9 @@ class HaremGirl {
                 }
                 catch ( /* ignore */_b) { /* ignore */ }
             }
-            yield TimeHelper.sleep(randomInterval(150, 250));
+            // Final settle delay: let the game finish rendering any late items
+            // before the caller reads the DOM (see issue #1573).
+            yield TimeHelper.sleep(randomInterval(400, 600));
             return countItems();
         });
     }
@@ -12030,7 +12042,9 @@ class HaremGirl {
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
                 slot.trigger('click');
-                yield TimeHelper.sleep(randomInterval(400, 600));
+                // Give the game time to kick off its inventory request for this slot
+                // before we start scrolling to force-load items (see issue #1573).
+                yield TimeHelper.sleep(randomInterval(600, 900));
                 // Force game to render all lazy-loaded inventory items into the DOM
                 const totalItems = yield HaremGirl.forceLoadAllInventoryItems();
                 const equippedEl = slot.find('.slot[data-d]');

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -12039,6 +12039,14 @@ class HaremGirl {
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
             LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+            // Warmup: click a sibling slot once so the game registers a real state
+            // transition when we click slot 0 below. Without this the first click
+            // on an already-displayed slot is a no-op and the equip button ignores
+            // our later click (see issue #1573).
+            if (slotCount >= 2) {
+                equipmentSlots.eq(1).trigger('click');
+                yield TimeHelper.sleep(randomInterval(400, 700));
+            }
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
                 slot.trigger('click');

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.10 — Equipment optimization: Slot 1 is equipped reliably again
+
+Fixes [#1573](https://github.com/Roukys/HHauto/issues/1573).
+
+During auto-equip the first equipment slot was often skipped, so the girl ended up wearing a worse item than the one the script had picked. The other slots were updated normally. The first slot is now equipped correctly on every run.
+
+---
+
 ### v7.35.9 — Assign first 7 now applies the full team reliably
 
 Fixes [#1577](https://github.com/Roukys/HHauto/issues/1577).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.9",
+  "version": "7.35.10",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -1039,23 +1039,72 @@ export class HaremGirl {
                     }
                     // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
                     if (attempt === 1) {
+                        const rawElBefore = bestInventory.el.get(0);
                         const itemCls = bestInventory.el.attr('class') || '';
                         const itemId = bestInventory.el.attr('data-id') || '';
-                        logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${bestInventory.data.id_item ?? 'n/a'}`);
+                        const connected = rawElBefore?.isConnected;
+                        const visible = rawElBefore ? rawElBefore.offsetParent !== null : false;
+                        const outerH = (rawElBefore?.outerHTML || '').substring(0, 250);
+                        const parentChain: string[] = [];
+                        let p = bestInventory.el.parent();
+                        for (let d = 0; d < 4 && p.length > 0; d++) {
+                            const pEl = p.get(0) as HTMLElement | undefined;
+                            const cls = (p.attr('class') || '').split(/\s+/).slice(0, 2).join('.');
+                            parentChain.push(`${pEl?.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`);
+                            p = p.parent();
+                        }
+                        logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
                     }
-                    // Native click to trigger the game's selection handler reliably
+                    // Primary click: native click triggers the game's selection handler
                     if (raw && typeof raw.click === 'function') {
                         raw.click();
                     } else {
                         bestInventory.el.trigger('click');
                     }
+                    // Short wait so the primary click can propagate before we check the button
+                    await TimeHelper.sleep(randomInterval(300, 500));
+
+                    // Fallback click methods if the equip button is still disabled
+                    // after the primary click. On slot 0 the native .click() is
+                    // consistently ignored by the game — some frameworks only react
+                    // to fully simulated MouseEvents with bubbles/view set (see #1573).
+                    const $btnProbe = $('#girl-equipment-equip');
+                    const btnStillDisabled = $btnProbe.length === 0
+                        || $btnProbe.prop('disabled') === true
+                        || $btnProbe.hasClass('disabled');
+                    if (btnStillDisabled && raw) {
+                        logHHAuto(`[DEBUG Slot ${i}] primary click did not enable equip button, trying fallback click methods (attempt ${attempt})`);
+                        // Fallback 1: synthetic MouseEvent with bubbles + view
+                        try {
+                            raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+                        } catch { /* ignore */ }
+                        await TimeHelper.sleep(200);
+                        // Fallback 2: full mousedown + mouseup + click sequence
+                        try {
+                            raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
+                            raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
+                            raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+                        } catch { /* ignore */ }
+                        await TimeHelper.sleep(200);
+                        // Fallback 3: jQuery trigger (uses jQuery's event simulation pipeline)
+                        bestInventory.el.trigger('click');
+                        await TimeHelper.sleep(200);
+                    }
+
                     // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
                     if (attempt === 1) {
+                        const rawElAfter = bestInventory.el.get(0);
                         const itemClsAfter = bestInventory.el.attr('class') || '';
-                        logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}"`);
+                        const connectedAfter = rawElAfter?.isConnected;
+                        const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
+                            .map((_, el) => {
+                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
+                                return `${el.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
+                            }).get().join(' | ');
+                        logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}" connected=${connectedAfter} right-selected="${rightSelected || 'none'}"`);
                     }
-                    // Longer wait so the game has time to activate the Equip button (see issue #1573)
-                    await TimeHelper.sleep(randomInterval(700, 1000));
+                    // Additional wait so the game has time to activate the Equip button (see issue #1573)
+                    await TimeHelper.sleep(randomInterval(400, 700));
 
                     // Click the Equip confirm button (revealed after item selection)
                     let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -968,6 +968,12 @@ export class HaremGirl {
             // Force game to render all lazy-loaded inventory items into the DOM
             const totalItems = await HaremGirl.forceLoadAllInventoryItems();
 
+            // Extra settle time after forceLoad so the game can fully attach event
+            // handlers to items in the right panel before we click them (see issue #1573).
+            // Without this wait, clicks on items are silently ignored and the equip button
+            // stays disabled. Observed failure mode: slot 0 fails ~67% of the time without it.
+            await TimeHelper.sleep(randomInterval(800, 1200));
+
             const equippedEl = slot.find('.slot[data-d]');
             let equippedData: any = null;
             if (equippedEl.length > 0 && equippedEl.attr('data-d')) {

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -942,13 +942,7 @@ export class HaremGirl {
 
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
-            // DEBUG (issue #1573): capture slot state before click
-            const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-            logHHAuto(`[DEBUG Slot ${i}] all slot classes BEFORE click: ${beforeClasses}`);
             slot.trigger('click');
-            // DEBUG (issue #1573): capture slot state after click
-            const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-            logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
             // Short wait so the game kicks off its inventory request for this slot
             await TimeHelper.sleep(randomInterval(100, 200));
 
@@ -977,16 +971,7 @@ export class HaremGirl {
             // Filter candidates by slot_index so we don't compare pants to necklaces
             const inventoryItems = allDomItems.filter(it => Number(it.data.slot_index) === Number(targetSlotIndex));
 
-            // Diagnostic: slot_index distribution + top rarities in inventory
-            const slotDist: { [k: string]: number } = {};
-            const rarityDist: { [k: string]: number } = {};
-            for (const it of allDomItems) {
-                const si = String(it.data.slot_index);
-                slotDist[si] = (slotDist[si] || 0) + 1;
-                const ra = String(it.data.rarity);
-                rarityDist[ra] = (rarityDist[ra] || 0) + 1;
-            }
-            logHHAuto(`Slot ${i}: targetSlotIndex=${targetSlotIndex}, DOM items=${allDomItems.length}, candidates=${inventoryItems.length}, slot_index_dist=${JSON.stringify(slotDist)}, rarity_dist=${JSON.stringify(rarityDist)}, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity} si=${equippedData.slot_index}` : 'none'}`);
+            logHHAuto(`Slot ${i}: ${inventoryItems.length} candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
 
             if (inventoryItems.length === 0) {
                 logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
@@ -1014,97 +999,40 @@ export class HaremGirl {
                 const MAX_EQUIP_ATTEMPTS = 3;
                 let equipSucceeded = false;
 
-                // Helper: parent chain up to `maxDepth` or until root, "tag.cls1.cls2" per level
-                const buildParentChain = ($el: JQuery<HTMLElement>, maxDepth: number): string[] => {
-                    const chain: string[] = [];
-                    let p = $el.parent();
-                    for (let d = 0; d < maxDepth && p.length > 0; d++) {
-                        const pEl = p.get(0) as HTMLElement | undefined;
-                        const cls = (p.attr('class') || '').split(/\s+/).filter(c => c).slice(0, 3).join('.');
-                        chain.push(`${pEl?.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`);
-                        p = p.parent();
-                    }
-                    return chain;
-                };
-
-                // Helper: global DOM counts relevant to equipment UI
-                const domSnapshot = () => ({
-                    rightSection: $('.right-section').length,
-                    inventoryScroll: $('.inventory.hh-scroll').length,
-                    girlLevelerPanel: $('.girl-leveler-panel').length,
-                    filledSlots: $('.right-section .slot[data-d]').length,
-                    selectedSlots: $('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length
-                });
-
-                // ISSUE #1573: Detach can happen between scroll and click, not before the attempt
-                // loop. The isConnected check + re-query is now performed INSIDE the loop, after
-                // scroll+sleep, right before the primary click. Massive diagnostics wrapped around
-                // every step so we can see exactly when and why the node detaches.
-
                 for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
-                    // ========== PRE-SCROLL SNAPSHOT ==========
+                    // Scroll the chosen item into view
                     const rawPreScroll = bestInventory.el.get(0);
-                    const preScrollConn = rawPreScroll?.isConnected;
-                    const preScrollBody = rawPreScroll ? document.body.contains(rawPreScroll) : false;
-                    const preScrollParents = buildParentChain(bestInventory.el, 12);
-                    const preScrollDom = domSnapshot();
-                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-SCROLL: connected=${preScrollConn} bodyContains=${preScrollBody} domCounts=${JSON.stringify(preScrollDom)} parents=[${preScrollParents.join(' > ')}]`);
-
-                    // ========== SCROLL INTO VIEW ==========
                     if (rawPreScroll && typeof rawPreScroll.scrollIntoView === 'function') {
                         rawPreScroll.scrollIntoView({ block: 'center' });
-                        // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
                         await TimeHelper.sleep(randomInterval(50, 100));
                     }
 
-                    // ========== POST-SLEEP STATE ==========
-                    const rawPostSleep = bestInventory.el.get(0);
-                    const postSleepConn = rawPostSleep?.isConnected;
-                    const postSleepVisible = rawPostSleep ? rawPostSleep.offsetParent !== null : false;
-                    const postSleepBody = rawPostSleep ? document.body.contains(rawPostSleep) : false;
-                    const postSleepParents = buildParentChain(bestInventory.el, 12);
-                    const postSleepDom = domSnapshot();
-                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SLEEP: connected=${postSleepConn} visible=${postSleepVisible} bodyContains=${postSleepBody} domCounts=${JSON.stringify(postSleepDom)} parents=[${postSleepParents.join(' > ')}]`);
-
-                    // ========== RE-QUERY IF DETACHED ==========
-                    let raw: HTMLElement | undefined = rawPostSleep;
+                    // Issue #1573: virtualized rendering can detach the original
+                    // node during scroll. Re-query by id_girl_armor and swap to the
+                    // fresh node before clicking.
+                    let raw: HTMLElement | undefined = bestInventory.el.get(0);
                     if (!raw || !raw.isConnected) {
                         const targetArmorId = bestInventory.data?.id_girl_armor;
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] DETACHED — attempting re-query for id_girl_armor=${targetArmorId}`);
                         if (targetArmorId != null) {
-                            const candidates = $('.right-section .slot[data-d]').filter(function () {
+                            const $fresh = $('.right-section .slot[data-d]').filter(function () {
                                 try {
                                     const d = JSON.parse($(this).attr('data-d') || '{}');
                                     return d.id_girl_armor === targetArmorId;
                                 } catch { return false; }
-                            });
-                            logHHAuto(`[DEBUG Slot ${i} att ${attempt}] re-query found ${candidates.length} candidate(s)`);
-                            candidates.each(function (idx) {
-                                const $c = $(this);
-                                const cRaw = $c.get(0);
-                                const cConn = cRaw?.isConnected;
-                                const cBody = cRaw ? document.body.contains(cRaw) : false;
-                                const cParents = buildParentChain($c, 8);
-                                logHHAuto(`[DEBUG Slot ${i} att ${attempt}] candidate[${idx}]: connected=${cConn} bodyContains=${cBody} parents=[${cParents.join(' > ')}]`);
-                            });
-                            const $fresh = candidates.filter(function () {
+                            }).filter(function () {
                                 const r = $(this).get(0);
                                 return !!r && r.isConnected;
                             }).first();
                             if ($fresh.length > 0) {
-                                const freshRaw = $fresh.get(0)!;
-                                logHHAuto(`[DEBUG Slot ${i} att ${attempt}] RE-QUERY SUCCESS — swapping to fresh node`);
                                 bestInventory.el = $fresh;
-                                raw = freshRaw;
-                                // Scroll the fresh node into view, then re-check
+                                raw = $fresh.get(0)!;
+                                logHHAuto(`Slot ${i}: item was detached, re-queried fresh node`);
                                 if (typeof raw.scrollIntoView === 'function') {
                                     raw.scrollIntoView({ block: 'center' });
                                     await TimeHelper.sleep(randomInterval(50, 100));
-                                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
                                 }
                             } else {
-                                logHHAuto(`Slot ${i}: no connected candidate after re-query (id_girl_armor=${targetArmorId}), aborting attempts`);
+                                logHHAuto(`Slot ${i}: no connected candidate after re-query, aborting attempts`);
                                 break;
                             }
                         } else {
@@ -1113,57 +1041,17 @@ export class HaremGirl {
                         }
                     }
 
-                    // ========== PRE-CLICK STATE (for the node we will actually click) ==========
-                    {
-                        const itemCls = bestInventory.el.attr('class') || '';
-                        const itemId = bestInventory.el.attr('data-id') || '';
-                        const connected = raw?.isConnected;
-                        const visible = raw ? raw.offsetParent !== null : false;
-                        const bodyContains = raw ? document.body.contains(raw) : false;
-                        const outerH = (raw?.outerHTML || '').substring(0, 400);
-                        const parentChain = buildParentChain(bestInventory.el, 12);
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-CLICK: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} bodyContains=${bodyContains} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
-                    }
-
-                    // ========== PRIMARY CLICK ==========
-                    const usedNative = !!(raw && typeof raw.click === 'function');
-                    if (usedNative) {
-                        raw!.click();
+                    // Primary click on the item
+                    if (raw && typeof raw.click === 'function') {
+                        raw.click();
                     } else {
                         bestInventory.el.trigger('click');
                     }
-                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
-                    // Short wait so the primary click can propagate before we check the button
                     await TimeHelper.sleep(randomInterval(100, 200));
 
-                    // ========== POST-PRIMARY STATE ==========
-                    {
-                        const btnProbe = $('#girl-equipment-equip');
-                        const btnDisabled = btnProbe.length === 0 || btnProbe.prop('disabled') === true || btnProbe.hasClass('disabled');
-                        const rightSelectedStr = $('.right-section .selected, .right-section .active, .right-section .highlight')
-                            .map((_, el) => {
-                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
-                                return `${(el as HTMLElement).tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
-                            }).get().join(' | ');
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw?.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
-                    }
-
-                    // ========== AFTER-CLICK STATE (full) ==========
-                    {
-                        const rawElAfter = bestInventory.el.get(0);
-                        const itemClsAfter = bestInventory.el.attr('class') || '';
-                        const connectedAfter = rawElAfter?.isConnected;
-                        const bodyContainsAfter = rawElAfter ? document.body.contains(rawElAfter) : false;
-                        const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
-                            .map((_, el) => {
-                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
-                                return `${(el as HTMLElement).tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
-                            }).get().join(' | ');
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
-                    }
                     // Click the Equip confirm button (revealed after item selection)
                     let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
-                    // Wait up to ~500ms for the button to become enabled (see issue #1573)
+                    // Wait up to ~500ms for the button to become enabled
                     for (let waitIter = 0; waitIter < 5 && $equipBtn.length > 0
                         && ($equipBtn.prop('disabled') === true || $equipBtn.hasClass('disabled')); waitIter++) {
                         await TimeHelper.sleep(100);
@@ -1171,23 +1059,11 @@ export class HaremGirl {
                     }
 
                     if ($equipBtn.length > 0) {
-                        // DEBUG (issue #1573): equip button state BEFORE click (attempt 1 only)
-                        if (attempt === 1) {
-                            const btnEl = $equipBtn.get(0) as HTMLElement | undefined;
-                            const btnHtml = (btnEl?.outerHTML || '').substring(0, 400);
-                            logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${$equipBtn.attr('hidden') ?? 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
-                        }
                         const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                         if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
                         else $equipBtn.trigger('click');
                         await TimeHelper.sleep(randomInterval(200, 300));
                         logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
-                        // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
-                        if (attempt === 1) {
-                            const btnAfter = $('#girl-equipment-equip').get(0) as HTMLElement | undefined;
-                            const btnAfterHtml = (btnAfter?.outerHTML || '').substring(0, 400);
-                            logHHAuto(`[DEBUG Slot ${i}] equip btn AFTER click: html="${btnAfterHtml}"`);
-                        }
                     } else {
                         logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                     }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -954,17 +954,13 @@ export class HaremGirl {
 
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
-            // DEBUG (issue #1573): capture slot state before click for slot 0
-            if (i === 0) {
-                const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                logHHAuto(`[DEBUG Slot 0] all slot classes BEFORE click: ${beforeClasses}`);
-            }
+            // DEBUG (issue #1573): capture slot state before click
+            const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+            logHHAuto(`[DEBUG Slot ${i}] all slot classes BEFORE click: ${beforeClasses}`);
             slot.trigger('click');
-            // DEBUG (issue #1573): capture slot state after click for slot 0
-            if (i === 0) {
-                const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
-                logHHAuto(`[DEBUG Slot 0] all slot classes AFTER click: ${afterClasses}`);
-            }
+            // DEBUG (issue #1573): capture slot state after click
+            const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+            logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
             // Give the game time to kick off its inventory request for this slot
             // before we start scrolling to force-load items (see issue #1573).
             await TimeHelper.sleep(randomInterval(600, 900));
@@ -1037,11 +1033,11 @@ export class HaremGirl {
                         raw.scrollIntoView({ block: 'center' });
                         await TimeHelper.sleep(randomInterval(200, 300));
                     }
-                    // DEBUG (issue #1573): best item state BEFORE click for slot 0 attempt 1
-                    if (i === 0 && attempt === 1) {
+                    // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
+                    if (attempt === 1) {
                         const itemCls = bestInventory.el.attr('class') || '';
                         const itemId = bestInventory.el.attr('data-id') || '';
-                        logHHAuto(`[DEBUG Slot 0] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${bestInventory.data.id_item ?? 'n/a'}`);
+                        logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${bestInventory.data.id_item ?? 'n/a'}`);
                     }
                     // Native click to trigger the game's selection handler reliably
                     if (raw && typeof raw.click === 'function') {
@@ -1049,10 +1045,10 @@ export class HaremGirl {
                     } else {
                         bestInventory.el.trigger('click');
                     }
-                    // DEBUG (issue #1573): item state AFTER click for slot 0 attempt 1
-                    if (i === 0 && attempt === 1) {
+                    // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
+                    if (attempt === 1) {
                         const itemClsAfter = bestInventory.el.attr('class') || '';
-                        logHHAuto(`[DEBUG Slot 0] best item AFTER click: class="${itemClsAfter}"`);
+                        logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}"`);
                     }
                     // Longer wait so the game has time to activate the Equip button (see issue #1573)
                     await TimeHelper.sleep(randomInterval(700, 1000));
@@ -1067,22 +1063,22 @@ export class HaremGirl {
                     }
 
                     if ($equipBtn.length > 0) {
-                        // DEBUG (issue #1573): equip button state BEFORE click for slot 0 attempt 1
-                        if (i === 0 && attempt === 1) {
+                        // DEBUG (issue #1573): equip button state BEFORE click (attempt 1 only)
+                        if (attempt === 1) {
                             const btnEl = $equipBtn.get(0) as HTMLElement | undefined;
                             const btnHtml = (btnEl?.outerHTML || '').substring(0, 400);
-                            logHHAuto(`[DEBUG Slot 0] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${$equipBtn.attr('hidden') ?? 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                            logHHAuto(`[DEBUG Slot ${i}] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${$equipBtn.attr('hidden') ?? 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
                         }
                         const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                         if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
                         else $equipBtn.trigger('click');
                         await TimeHelper.sleep(randomInterval(400, 700));
                         logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
-                        // DEBUG (issue #1573): equip button state AFTER click for slot 0 attempt 1
-                        if (i === 0 && attempt === 1) {
+                        // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
+                        if (attempt === 1) {
                             const btnAfter = $('#girl-equipment-equip').get(0) as HTMLElement | undefined;
                             const btnAfterHtml = (btnAfter?.outerHTML || '').substring(0, 400);
-                            logHHAuto(`[DEBUG Slot 0] equip btn AFTER click: html="${btnAfterHtml}"`);
+                            logHHAuto(`[DEBUG Slot ${i}] equip btn AFTER click: html="${btnAfterHtml}"`);
                         }
                     } else {
                         logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -1006,30 +1006,66 @@ export class HaremGirl {
 
             if (shouldReplace) {
                 logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
-                // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
-                const raw = bestInventory.el.get(0);
-                if (raw && typeof raw.scrollIntoView === 'function') {
-                    raw.scrollIntoView({ block: 'center' });
-                    await TimeHelper.sleep(randomInterval(200, 300));
-                }
-                // Native click to trigger the game's selection handler reliably
-                if (raw && typeof raw.click === 'function') {
-                    raw.click();
-                } else {
-                    bestInventory.el.trigger('click');
-                }
-                await TimeHelper.sleep(randomInterval(300, 500));
+                // Capture previous equipped identity so we can verify a real change below (see issue #1573)
+                const previousEquippedKey = equippedData ? (equippedData.id_item ?? equippedData.id_equipement ?? JSON.stringify(equippedData)) : null;
+                const MAX_EQUIP_ATTEMPTS = 3;
+                let equipSucceeded = false;
 
-                // Click the Equip confirm button (revealed after item selection)
-                const $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
-                if ($equipBtn.length > 0) {
-                    const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
-                    if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
-                    else $equipBtn.trigger('click');
-                    await TimeHelper.sleep(randomInterval(400, 700));
-                    logHHAuto(`Slot ${i}: equip button clicked`);
-                } else {
-                    logHHAuto(`Slot ${i}: #girl-equipment-equip not found`);
+                for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
+                    // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
+                    const raw = bestInventory.el.get(0);
+                    if (raw && typeof raw.scrollIntoView === 'function') {
+                        raw.scrollIntoView({ block: 'center' });
+                        await TimeHelper.sleep(randomInterval(200, 300));
+                    }
+                    // Native click to trigger the game's selection handler reliably
+                    if (raw && typeof raw.click === 'function') {
+                        raw.click();
+                    } else {
+                        bestInventory.el.trigger('click');
+                    }
+                    // Longer wait so the game has time to activate the Equip button (see issue #1573)
+                    await TimeHelper.sleep(randomInterval(700, 1000));
+
+                    // Click the Equip confirm button (revealed after item selection)
+                    let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                    // Wait up to ~500ms for the button to become enabled (see issue #1573)
+                    for (let waitIter = 0; waitIter < 5 && $equipBtn.length > 0
+                        && ($equipBtn.prop('disabled') === true || $equipBtn.hasClass('disabled')); waitIter++) {
+                        await TimeHelper.sleep(100);
+                        $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
+                    }
+
+                    if ($equipBtn.length > 0) {
+                        const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
+                        if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
+                        else $equipBtn.trigger('click');
+                        await TimeHelper.sleep(randomInterval(400, 700));
+                        logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                    } else {
+                        logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                    }
+
+                    // Verify the equipped item actually changed (see issue #1573)
+                    await TimeHelper.sleep(randomInterval(300, 500));
+                    const verifyEl = slot.find('.slot[data-d]');
+                    let verifyData: any = null;
+                    if (verifyEl.length > 0 && verifyEl.attr('data-d')) {
+                        try { verifyData = JSON.parse(verifyEl.attr('data-d')!); } catch { /* ignore */ }
+                    }
+                    const verifyKey = verifyData ? (verifyData.id_item ?? verifyData.id_equipement ?? JSON.stringify(verifyData)) : null;
+                    if (verifyKey !== previousEquippedKey) {
+                        logHHAuto(`Slot ${i}: equip verified (L${verifyData?.level} ${verifyData?.rarity})`);
+                        equipSucceeded = true;
+                        break;
+                    }
+                    logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                    if (attempt < MAX_EQUIP_ATTEMPTS) {
+                        await TimeHelper.sleep(randomInterval(500, 800));
+                    }
+                }
+                if (!equipSucceeded) {
+                    logHHAuto(`Slot ${i}: equip failed after ${MAX_EQUIP_ATTEMPTS} attempts, skipping`);
                 }
             } else {
                 const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -954,7 +954,17 @@ export class HaremGirl {
 
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
+            // DEBUG (issue #1573): capture slot state before click for slot 0
+            if (i === 0) {
+                const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                logHHAuto(`[DEBUG Slot 0] all slot classes BEFORE click: ${beforeClasses}`);
+            }
             slot.trigger('click');
+            // DEBUG (issue #1573): capture slot state after click for slot 0
+            if (i === 0) {
+                const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
+                logHHAuto(`[DEBUG Slot 0] all slot classes AFTER click: ${afterClasses}`);
+            }
             // Give the game time to kick off its inventory request for this slot
             // before we start scrolling to force-load items (see issue #1573).
             await TimeHelper.sleep(randomInterval(600, 900));
@@ -1027,11 +1037,22 @@ export class HaremGirl {
                         raw.scrollIntoView({ block: 'center' });
                         await TimeHelper.sleep(randomInterval(200, 300));
                     }
+                    // DEBUG (issue #1573): best item state BEFORE click for slot 0 attempt 1
+                    if (i === 0 && attempt === 1) {
+                        const itemCls = bestInventory.el.attr('class') || '';
+                        const itemId = bestInventory.el.attr('data-id') || '';
+                        logHHAuto(`[DEBUG Slot 0] best item BEFORE click: class="${itemCls}" data-id="${itemId}" level=${bestInventory.data.level} slot_index=${bestInventory.data.slot_index} id_item=${bestInventory.data.id_item ?? 'n/a'}`);
+                    }
                     // Native click to trigger the game's selection handler reliably
                     if (raw && typeof raw.click === 'function') {
                         raw.click();
                     } else {
                         bestInventory.el.trigger('click');
+                    }
+                    // DEBUG (issue #1573): item state AFTER click for slot 0 attempt 1
+                    if (i === 0 && attempt === 1) {
+                        const itemClsAfter = bestInventory.el.attr('class') || '';
+                        logHHAuto(`[DEBUG Slot 0] best item AFTER click: class="${itemClsAfter}"`);
                     }
                     // Longer wait so the game has time to activate the Equip button (see issue #1573)
                     await TimeHelper.sleep(randomInterval(700, 1000));
@@ -1046,11 +1067,23 @@ export class HaremGirl {
                     }
 
                     if ($equipBtn.length > 0) {
+                        // DEBUG (issue #1573): equip button state BEFORE click for slot 0 attempt 1
+                        if (i === 0 && attempt === 1) {
+                            const btnEl = $equipBtn.get(0) as HTMLElement | undefined;
+                            const btnHtml = (btnEl?.outerHTML || '').substring(0, 400);
+                            logHHAuto(`[DEBUG Slot 0] equip btn BEFORE click: disabled=${$equipBtn.prop('disabled')} hidden-attr=${$equipBtn.attr('hidden') ?? 'none'} classes="${$equipBtn.attr('class') || ''}" html="${btnHtml}"`);
+                        }
                         const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                         if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
                         else $equipBtn.trigger('click');
                         await TimeHelper.sleep(randomInterval(400, 700));
                         logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                        // DEBUG (issue #1573): equip button state AFTER click for slot 0 attempt 1
+                        if (i === 0 && attempt === 1) {
+                            const btnAfter = $('#girl-equipment-equip').get(0) as HTMLElement | undefined;
+                            const btnAfterHtml = (btnAfter?.outerHTML || '').substring(0, 400);
+                            logHHAuto(`[DEBUG Slot 0] equip btn AFTER click: html="${btnAfterHtml}"`);
+                        }
                     } else {
                         logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                     }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -982,11 +982,16 @@ export class HaremGirl {
 
             const allDomItems: { el: JQuery<HTMLElement>, data: any }[] = [];
             $('.right-section .slot[data-d]').each(function () {
-                const raw = $(this).attr('data-d');
+                const $el = $(this);
+                // Skip items sitting inside a filled equipment slot — those are already equipped
+                // girl_armor records, not free inventory items. Clicking them does nothing and the
+                // element is often detached from the DOM by the time we reach it (see issue #1573).
+                if ($el.closest('.inventory-slot.filled-slot').length > 0) return;
+                const raw = $el.attr('data-d');
                 if (!raw) return;
                 try {
                     const data = JSON.parse(raw);
-                    if (data && data.caracs) allDomItems.push({ el: $(this), data });
+                    if (data && data.caracs) allDomItems.push({ el: $el, data });
                 } catch { /* ignore */ }
             });
 

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -1031,108 +1031,179 @@ export class HaremGirl {
                 const MAX_EQUIP_ATTEMPTS = 3;
                 let equipSucceeded = false;
 
-                // ISSUE #1573: Verify the selected DOM element is still attached. During slot
-                // iteration the game can rebuild the inventory panel, leaving our stored jQuery
-                // wrapper pointing at a detached node. Clicking a detached node is a no-op, which
-                // is why slot 0 replacement consistently failed. Re-query via id_girl_armor to
-                // find a fresh node for the same item.
-                const rawBeforeAttempts = bestInventory.el.get(0);
-                if (!rawBeforeAttempts || !rawBeforeAttempts.isConnected) {
-                    const targetArmorId = bestInventory.data?.id_girl_armor;
-                    logHHAuto(`[DEBUG Slot ${i}] best item detached from DOM (id_girl_armor=${targetArmorId}), attempting re-query`);
-                    if (targetArmorId != null) {
-                        const $fresh = $('.right-section .slot[data-d]').filter(function () {
-                            try {
-                                const d = JSON.parse($(this).attr('data-d') || '{}');
-                                return d.id_girl_armor === targetArmorId;
-                            } catch { return false; }
-                        }).first();
-                        const freshRaw = $fresh.get(0);
-                        if ($fresh.length > 0 && freshRaw && freshRaw.isConnected) {
-                            logHHAuto(`[DEBUG Slot ${i}] re-query successful, using fresh DOM element for id_girl_armor=${targetArmorId}`);
-                            bestInventory.el = $fresh;
-                        } else {
-                            logHHAuto(`Slot ${i}: best item no longer in DOM after re-query (id_girl_armor=${targetArmorId}), skipping slot`);
-                            continue;
-                        }
-                    } else {
-                        logHHAuto(`Slot ${i}: best item detached and no id_girl_armor to re-query, skipping slot`);
-                        continue;
+                // Helper: parent chain up to `maxDepth` or until root, "tag.cls1.cls2" per level
+                const buildParentChain = ($el: JQuery<HTMLElement>, maxDepth: number): string[] => {
+                    const chain: string[] = [];
+                    let p = $el.parent();
+                    for (let d = 0; d < maxDepth && p.length > 0; d++) {
+                        const pEl = p.get(0) as HTMLElement | undefined;
+                        const cls = (p.attr('class') || '').split(/\s+/).filter(c => c).slice(0, 3).join('.');
+                        chain.push(`${pEl?.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`);
+                        p = p.parent();
                     }
-                }
+                    return chain;
+                };
+
+                // Helper: global DOM counts relevant to equipment UI
+                const domSnapshot = () => ({
+                    rightSection: $('.right-section').length,
+                    inventoryScroll: $('.inventory.hh-scroll').length,
+                    girlLevelerPanel: $('.girl-leveler-panel').length,
+                    filledSlots: $('.right-section .slot[data-d]').length,
+                    selectedSlots: $('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length
+                });
+
+                // ISSUE #1573: Detach can happen between scroll and click, not before the attempt
+                // loop. The isConnected check + re-query is now performed INSIDE the loop, after
+                // scroll+sleep, right before the primary click. Massive diagnostics wrapped around
+                // every step so we can see exactly when and why the node detaches.
 
                 for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
-                    // Scroll the item into view before clicking (lazy panels may still hide off-screen items)
-                    const raw = bestInventory.el.get(0);
-                    if (raw && typeof raw.scrollIntoView === 'function') {
-                        raw.scrollIntoView({ block: 'center' });
+                    // ========== PRE-SCROLL SNAPSHOT ==========
+                    const rawPreScroll = bestInventory.el.get(0);
+                    const preScrollConn = rawPreScroll?.isConnected;
+                    const preScrollBody = rawPreScroll ? document.body.contains(rawPreScroll) : false;
+                    const preScrollParents = buildParentChain(bestInventory.el, 12);
+                    const preScrollDom = domSnapshot();
+                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-SCROLL: connected=${preScrollConn} bodyContains=${preScrollBody} domCounts=${JSON.stringify(preScrollDom)} parents=[${preScrollParents.join(' > ')}]`);
+
+                    // ========== SCROLL INTO VIEW ==========
+                    if (rawPreScroll && typeof rawPreScroll.scrollIntoView === 'function') {
+                        rawPreScroll.scrollIntoView({ block: 'center' });
+                        // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
                         await TimeHelper.sleep(randomInterval(200, 300));
                     }
-                    // DEBUG (issue #1573): best item state BEFORE click (attempt 1 only)
-                    if (attempt === 1) {
-                        const rawElBefore = bestInventory.el.get(0);
+
+                    // ========== POST-SLEEP STATE ==========
+                    const rawPostSleep = bestInventory.el.get(0);
+                    const postSleepConn = rawPostSleep?.isConnected;
+                    const postSleepVisible = rawPostSleep ? rawPostSleep.offsetParent !== null : false;
+                    const postSleepBody = rawPostSleep ? document.body.contains(rawPostSleep) : false;
+                    const postSleepParents = buildParentChain(bestInventory.el, 12);
+                    const postSleepDom = domSnapshot();
+                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SLEEP: connected=${postSleepConn} visible=${postSleepVisible} bodyContains=${postSleepBody} domCounts=${JSON.stringify(postSleepDom)} parents=[${postSleepParents.join(' > ')}]`);
+
+                    // ========== RE-QUERY IF DETACHED ==========
+                    let raw: HTMLElement | undefined = rawPostSleep;
+                    if (!raw || !raw.isConnected) {
+                        const targetArmorId = bestInventory.data?.id_girl_armor;
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] DETACHED — attempting re-query for id_girl_armor=${targetArmorId}`);
+                        if (targetArmorId != null) {
+                            const candidates = $('.right-section .slot[data-d]').filter(function () {
+                                try {
+                                    const d = JSON.parse($(this).attr('data-d') || '{}');
+                                    return d.id_girl_armor === targetArmorId;
+                                } catch { return false; }
+                            });
+                            logHHAuto(`[DEBUG Slot ${i} att ${attempt}] re-query found ${candidates.length} candidate(s)`);
+                            candidates.each(function (idx) {
+                                const $c = $(this);
+                                const cRaw = $c.get(0);
+                                const cConn = cRaw?.isConnected;
+                                const cBody = cRaw ? document.body.contains(cRaw) : false;
+                                const cParents = buildParentChain($c, 8);
+                                logHHAuto(`[DEBUG Slot ${i} att ${attempt}] candidate[${idx}]: connected=${cConn} bodyContains=${cBody} parents=[${cParents.join(' > ')}]`);
+                            });
+                            const $fresh = candidates.filter(function () {
+                                const r = $(this).get(0);
+                                return !!r && r.isConnected;
+                            }).first();
+                            if ($fresh.length > 0) {
+                                const freshRaw = $fresh.get(0)!;
+                                logHHAuto(`[DEBUG Slot ${i} att ${attempt}] RE-QUERY SUCCESS — swapping to fresh node`);
+                                bestInventory.el = $fresh;
+                                raw = freshRaw;
+                                // Scroll the fresh node into view, then re-check
+                                if (typeof raw.scrollIntoView === 'function') {
+                                    raw.scrollIntoView({ block: 'center' });
+                                    await TimeHelper.sleep(randomInterval(200, 300));
+                                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
+                                }
+                            } else {
+                                logHHAuto(`Slot ${i}: no connected candidate after re-query (id_girl_armor=${targetArmorId}), aborting attempts`);
+                                break;
+                            }
+                        } else {
+                            logHHAuto(`Slot ${i}: detached and no id_girl_armor to re-query, aborting attempts`);
+                            break;
+                        }
+                    }
+
+                    // ========== PRE-CLICK STATE (for the node we will actually click) ==========
+                    {
                         const itemCls = bestInventory.el.attr('class') || '';
                         const itemId = bestInventory.el.attr('data-id') || '';
-                        const connected = rawElBefore?.isConnected;
-                        const visible = rawElBefore ? rawElBefore.offsetParent !== null : false;
-                        const outerH = (rawElBefore?.outerHTML || '').substring(0, 250);
-                        const parentChain: string[] = [];
-                        let p = bestInventory.el.parent();
-                        for (let d = 0; d < 4 && p.length > 0; d++) {
-                            const pEl = p.get(0) as HTMLElement | undefined;
-                            const cls = (p.attr('class') || '').split(/\s+/).slice(0, 2).join('.');
-                            parentChain.push(`${pEl?.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`);
-                            p = p.parent();
-                        }
-                        logHHAuto(`[DEBUG Slot ${i}] best item BEFORE click: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
+                        const connected = raw?.isConnected;
+                        const visible = raw ? raw.offsetParent !== null : false;
+                        const bodyContains = raw ? document.body.contains(raw) : false;
+                        const outerH = (raw?.outerHTML || '').substring(0, 400);
+                        const parentChain = buildParentChain(bestInventory.el, 12);
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] PRE-CLICK: class="${itemCls}" data-id="${itemId}" connected=${connected} visible=${visible} bodyContains=${bodyContains} parents=[${parentChain.join(' > ')}] html="${outerH}"`);
                     }
-                    // Primary click: native click triggers the game's selection handler
-                    if (raw && typeof raw.click === 'function') {
-                        raw.click();
+
+                    // ========== PRIMARY CLICK ==========
+                    const usedNative = !!(raw && typeof raw.click === 'function');
+                    if (usedNative) {
+                        raw!.click();
                     } else {
                         bestInventory.el.trigger('click');
                     }
+                    logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
                     // Short wait so the primary click can propagate before we check the button
                     await TimeHelper.sleep(randomInterval(300, 500));
 
-                    // Fallback click methods if the equip button is still disabled
-                    // after the primary click. On slot 0 the native .click() is
-                    // consistently ignored by the game — some frameworks only react
-                    // to fully simulated MouseEvents with bubbles/view set (see #1573).
+                    // ========== POST-PRIMARY STATE ==========
+                    {
+                        const btnProbe = $('#girl-equipment-equip');
+                        const btnDisabled = btnProbe.length === 0 || btnProbe.prop('disabled') === true || btnProbe.hasClass('disabled');
+                        const rightSelectedStr = $('.right-section .selected, .right-section .active, .right-section .highlight')
+                            .map((_, el) => {
+                                const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
+                                return `${(el as HTMLElement).tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
+                            }).get().join(' | ');
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw?.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
+                    }
+
+                    // ========== FALLBACK CLICKS IF EQUIP BTN STILL DISABLED ==========
                     const $btnProbe = $('#girl-equipment-equip');
                     const btnStillDisabled = $btnProbe.length === 0
                         || $btnProbe.prop('disabled') === true
                         || $btnProbe.hasClass('disabled');
                     if (btnStillDisabled && raw) {
-                        logHHAuto(`[DEBUG Slot ${i}] primary click did not enable equip button, trying fallback click methods (attempt ${attempt})`);
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] BTN still disabled — running fallback clicks`);
                         // Fallback 1: synthetic MouseEvent with bubbles + view
                         try {
                             raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                        } catch { /* ignore */ }
+                        } catch (e) { logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 1 threw: ${e}`); }
                         await TimeHelper.sleep(200);
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 1 (MouseEvent click): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                         // Fallback 2: full mousedown + mouseup + click sequence
                         try {
                             raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
                             raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
                             raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                        } catch { /* ignore */ }
+                        } catch (e) { logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 2 threw: ${e}`); }
                         await TimeHelper.sleep(200);
-                        // Fallback 3: jQuery trigger (uses jQuery's event simulation pipeline)
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 2 (full mouse seq): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
+                        // Fallback 3: jQuery trigger
                         bestInventory.el.trigger('click');
                         await TimeHelper.sleep(200);
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 3 (jQuery trigger): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                     }
 
-                    // DEBUG (issue #1573): item state AFTER click (attempt 1 only)
-                    if (attempt === 1) {
+                    // ========== AFTER-CLICK STATE (full) ==========
+                    {
                         const rawElAfter = bestInventory.el.get(0);
                         const itemClsAfter = bestInventory.el.attr('class') || '';
                         const connectedAfter = rawElAfter?.isConnected;
+                        const bodyContainsAfter = rawElAfter ? document.body.contains(rawElAfter) : false;
                         const rightSelected = $('.right-section .selected, .right-section .active, .right-section .highlight')
                             .map((_, el) => {
                                 const cls = ($(el).attr('class') || '').split(/\s+/).slice(0, 4).join('.');
-                                return `${el.tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
+                                return `${(el as HTMLElement).tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
                             }).get().join(' | ');
-                        logHHAuto(`[DEBUG Slot ${i}] best item AFTER click: class="${itemClsAfter}" connected=${connectedAfter} right-selected="${rightSelected || 'none'}"`);
+                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
                     }
                     // Additional wait so the game has time to activate the Equip button (see issue #1573)
                     await TimeHelper.sleep(randomInterval(400, 700));

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -983,10 +983,6 @@ export class HaremGirl {
             const allDomItems: { el: JQuery<HTMLElement>, data: any }[] = [];
             $('.right-section .slot[data-d]').each(function () {
                 const $el = $(this);
-                // Skip items sitting inside a filled equipment slot — those are already equipped
-                // girl_armor records, not free inventory items. Clicking them does nothing and the
-                // element is often detached from the DOM by the time we reach it (see issue #1573).
-                if ($el.closest('.inventory-slot.filled-slot').length > 0) return;
                 const raw = $el.attr('data-d');
                 if (!raw) return;
                 try {
@@ -1034,6 +1030,36 @@ export class HaremGirl {
                 const previousEquippedKey = equippedData ? (equippedData.id_item ?? equippedData.id_equipement ?? JSON.stringify(equippedData)) : null;
                 const MAX_EQUIP_ATTEMPTS = 3;
                 let equipSucceeded = false;
+
+                // ISSUE #1573: Verify the selected DOM element is still attached. During slot
+                // iteration the game can rebuild the inventory panel, leaving our stored jQuery
+                // wrapper pointing at a detached node. Clicking a detached node is a no-op, which
+                // is why slot 0 replacement consistently failed. Re-query via id_girl_armor to
+                // find a fresh node for the same item.
+                const rawBeforeAttempts = bestInventory.el.get(0);
+                if (!rawBeforeAttempts || !rawBeforeAttempts.isConnected) {
+                    const targetArmorId = bestInventory.data?.id_girl_armor;
+                    logHHAuto(`[DEBUG Slot ${i}] best item detached from DOM (id_girl_armor=${targetArmorId}), attempting re-query`);
+                    if (targetArmorId != null) {
+                        const $fresh = $('.right-section .slot[data-d]').filter(function () {
+                            try {
+                                const d = JSON.parse($(this).attr('data-d') || '{}');
+                                return d.id_girl_armor === targetArmorId;
+                            } catch { return false; }
+                        }).first();
+                        const freshRaw = $fresh.get(0);
+                        if ($fresh.length > 0 && freshRaw && freshRaw.isConnected) {
+                            logHHAuto(`[DEBUG Slot ${i}] re-query successful, using fresh DOM element for id_girl_armor=${targetArmorId}`);
+                            bestInventory.el = $fresh;
+                        } else {
+                            logHHAuto(`Slot ${i}: best item no longer in DOM after re-query (id_girl_armor=${targetArmorId}), skipping slot`);
+                            continue;
+                        }
+                    } else {
+                        logHHAuto(`Slot ${i}: best item detached and no id_girl_armor to re-query, skipping slot`);
+                        continue;
+                    }
+                }
 
                 for (let attempt = 1; attempt <= MAX_EQUIP_ATTEMPTS; attempt++) {
                     // Scroll the item into view before clicking (lazy panels may still hide off-screen items)

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -943,16 +943,14 @@ export class HaremGirl {
 
         logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
-        // Warmup: click a sibling slot once so the game registers a real state
-        // transition when we click slot 0 below. Without this the first click
-        // on an already-displayed slot is a no-op and the equip button ignores
-        // our later click (see issue #1573).
-        if (slotCount >= 2) {
-            equipmentSlots.eq(1).trigger('click');
-            await TimeHelper.sleep(randomInterval(400, 700));
-        }
-
-        for (let i = 0; i < slotCount; i++) {
+        // Iterate slots in reverse order (5 → 0) so slot 0 is processed last.
+        // Slot 0 is the default active slot after the page loads; processing it
+        // first made the game treat slot 0 as "already active" and silently
+        // ignore item clicks — the equip button never committed the change.
+        // By the time we reach slot 0 we have switched slots five times, so the
+        // game's internal state is guaranteed to register a real transition
+        // when we click slot 0 (see issue #1573).
+        for (let i = slotCount - 1; i >= 0; i--) {
             const slot = equipmentSlots.eq(i);
             // DEBUG (issue #1573): capture slot state before click
             const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -917,7 +917,7 @@ export class HaremGirl {
                     s.dispatchEvent(new Event('scroll', { bubbles: true }));
                 } catch { /* ignore */ }
             }
-            await TimeHelper.sleep(randomInterval(400, 600));
+            await TimeHelper.sleep(randomInterval(250, 400));
             const curCount = countItems();
             if (curCount === prevCount) {
                 stableIterations++;
@@ -931,9 +931,6 @@ export class HaremGirl {
         for (const s of scrollables) {
             try { s.scrollTop = 0; } catch { /* ignore */ }
         }
-        // Final settle delay: let the game finish rendering any late items
-        // before the caller reads the DOM (see issue #1573).
-        await TimeHelper.sleep(randomInterval(400, 600));
         return countItems();
     }
 
@@ -943,14 +940,7 @@ export class HaremGirl {
 
         logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
-        // Iterate slots in reverse order (5 → 0) so slot 0 is processed last.
-        // Slot 0 is the default active slot after the page loads; processing it
-        // first made the game treat slot 0 as "already active" and silently
-        // ignore item clicks — the equip button never committed the change.
-        // By the time we reach slot 0 we have switched slots five times, so the
-        // game's internal state is guaranteed to register a real transition
-        // when we click slot 0 (see issue #1573).
-        for (let i = slotCount - 1; i >= 0; i--) {
+        for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
             // DEBUG (issue #1573): capture slot state before click
             const beforeClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
@@ -959,18 +949,11 @@ export class HaremGirl {
             // DEBUG (issue #1573): capture slot state after click
             const afterClasses = equipmentSlots.map((idx, el) => `${idx}:"${$(el).attr('class') || ''}"`).get().join(' | ');
             logHHAuto(`[DEBUG Slot ${i}] all slot classes AFTER click: ${afterClasses}`);
-            // Give the game time to kick off its inventory request for this slot
-            // before we start scrolling to force-load items (see issue #1573).
-            await TimeHelper.sleep(randomInterval(600, 900));
+            // Short wait so the game kicks off its inventory request for this slot
+            await TimeHelper.sleep(randomInterval(100, 200));
 
             // Force game to render all lazy-loaded inventory items into the DOM
             const totalItems = await HaremGirl.forceLoadAllInventoryItems();
-
-            // Extra settle time after forceLoad so the game can fully attach event
-            // handlers to items in the right panel before we click them (see issue #1573).
-            // Without this wait, clicks on items are silently ignored and the equip button
-            // stays disabled. Observed failure mode: slot 0 fails ~67% of the time without it.
-            await TimeHelper.sleep(randomInterval(800, 1200));
 
             const equippedEl = slot.find('.slot[data-d]');
             let equippedData: any = null;
@@ -1072,7 +1055,7 @@ export class HaremGirl {
                         rawPreScroll.scrollIntoView({ block: 'center' });
                         // Synchronous state right after scroll (before any sleep) — detects detach during scroll itself
                         logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-SCROLL sync: connected=${rawPreScroll.isConnected} bodyContains=${document.body.contains(rawPreScroll)}`);
-                        await TimeHelper.sleep(randomInterval(200, 300));
+                        await TimeHelper.sleep(randomInterval(50, 100));
                     }
 
                     // ========== POST-SLEEP STATE ==========
@@ -1117,7 +1100,7 @@ export class HaremGirl {
                                 // Scroll the fresh node into view, then re-check
                                 if (typeof raw.scrollIntoView === 'function') {
                                     raw.scrollIntoView({ block: 'center' });
-                                    await TimeHelper.sleep(randomInterval(200, 300));
+                                    await TimeHelper.sleep(randomInterval(50, 100));
                                     logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-RE-SCROLL: connected=${raw.isConnected} bodyContains=${document.body.contains(raw)}`);
                                 }
                             } else {
@@ -1151,7 +1134,7 @@ export class HaremGirl {
                     }
                     logHHAuto(`[DEBUG Slot ${i} att ${attempt}] primary click dispatched (native=${usedNative})`);
                     // Short wait so the primary click can propagate before we check the button
-                    await TimeHelper.sleep(randomInterval(300, 500));
+                    await TimeHelper.sleep(randomInterval(100, 200));
 
                     // ========== POST-PRIMARY STATE ==========
                     {
@@ -1163,33 +1146,6 @@ export class HaremGirl {
                                 return `${(el as HTMLElement).tagName?.toLowerCase() || '?'}${cls ? '.' + cls : ''}`;
                             }).get().join(' | ');
                         logHHAuto(`[DEBUG Slot ${i} att ${attempt}] POST-PRIMARY: connected=${raw?.isConnected} bodyContains=${raw ? document.body.contains(raw) : 'null'} btnDisabled=${btnDisabled} domCounts=${JSON.stringify(domSnapshot())} rightSelected="${rightSelectedStr || 'none'}"`);
-                    }
-
-                    // ========== FALLBACK CLICKS IF EQUIP BTN STILL DISABLED ==========
-                    const $btnProbe = $('#girl-equipment-equip');
-                    const btnStillDisabled = $btnProbe.length === 0
-                        || $btnProbe.prop('disabled') === true
-                        || $btnProbe.hasClass('disabled');
-                    if (btnStillDisabled && raw) {
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] BTN still disabled — running fallback clicks`);
-                        // Fallback 1: synthetic MouseEvent with bubbles + view
-                        try {
-                            raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                        } catch (e) { logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 1 threw: ${e}`); }
-                        await TimeHelper.sleep(200);
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 1 (MouseEvent click): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
-                        // Fallback 2: full mousedown + mouseup + click sequence
-                        try {
-                            raw.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true, view: window }));
-                            raw.dispatchEvent(new MouseEvent('mouseup', { bubbles: true, cancelable: true, view: window }));
-                            raw.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-                        } catch (e) { logHHAuto(`[DEBUG Slot ${i} att ${attempt}] fallback 2 threw: ${e}`); }
-                        await TimeHelper.sleep(200);
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 2 (full mouse seq): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
-                        // Fallback 3: jQuery trigger
-                        bestInventory.el.trigger('click');
-                        await TimeHelper.sleep(200);
-                        logHHAuto(`[DEBUG Slot ${i} att ${attempt}] after fallback 3 (jQuery trigger): btnDisabled=${$('#girl-equipment-equip').prop('disabled')} connected=${raw.isConnected} selectedCount=${$('.right-section .inventory-slot.selected, .right-section .filled-slot.selected').length}`);
                     }
 
                     // ========== AFTER-CLICK STATE (full) ==========
@@ -1205,9 +1161,6 @@ export class HaremGirl {
                             }).get().join(' | ');
                         logHHAuto(`[DEBUG Slot ${i} att ${attempt}] AFTER-CLICK: class="${itemClsAfter}" connected=${connectedAfter} bodyContains=${bodyContainsAfter} domCounts=${JSON.stringify(domSnapshot())} right-selected="${rightSelected || 'none'}"`);
                     }
-                    // Additional wait so the game has time to activate the Equip button (see issue #1573)
-                    await TimeHelper.sleep(randomInterval(400, 700));
-
                     // Click the Equip confirm button (revealed after item selection)
                     let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                     // Wait up to ~500ms for the button to become enabled (see issue #1573)
@@ -1227,7 +1180,7 @@ export class HaremGirl {
                         const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                         if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
                         else $equipBtn.trigger('click');
-                        await TimeHelper.sleep(randomInterval(400, 700));
+                        await TimeHelper.sleep(randomInterval(200, 300));
                         logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         // DEBUG (issue #1573): equip button state AFTER click (attempt 1 only)
                         if (attempt === 1) {
@@ -1240,7 +1193,7 @@ export class HaremGirl {
                     }
 
                     // Verify the equipped item actually changed (see issue #1573)
-                    await TimeHelper.sleep(randomInterval(300, 500));
+                    await TimeHelper.sleep(randomInterval(100, 200));
                     const verifyEl = slot.find('.slot[data-d]');
                     let verifyData: any = null;
                     if (verifyEl.length > 0 && verifyEl.attr('data-d')) {
@@ -1254,7 +1207,7 @@ export class HaremGirl {
                     }
                     logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                     if (attempt < MAX_EQUIP_ATTEMPTS) {
-                        await TimeHelper.sleep(randomInterval(500, 800));
+                        await TimeHelper.sleep(randomInterval(200, 300));
                     }
                 }
                 if (!equipSucceeded) {

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -943,6 +943,15 @@ export class HaremGirl {
 
         logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
 
+        // Warmup: click a sibling slot once so the game registers a real state
+        // transition when we click slot 0 below. Without this the first click
+        // on an already-displayed slot is a no-op and the equip button ignores
+        // our later click (see issue #1573).
+        if (slotCount >= 2) {
+            equipmentSlots.eq(1).trigger('click');
+            await TimeHelper.sleep(randomInterval(400, 700));
+        }
+
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
             slot.trigger('click');

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -905,6 +905,10 @@ export class HaremGirl {
         let prevCount = countItems();
         logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
 
+        // Require 2 consecutive stable iterations before breaking — a single
+        // stable iteration can happen during a network hiccup while more items
+        // are still loading (see issue #1573).
+        let stableIterations = 0;
         for (let iter = 0; iter < 15; iter++) {
             // scroll each scrollable to its bottom and dispatch a scroll event
             for (const s of scrollables) {
@@ -913,16 +917,23 @@ export class HaremGirl {
                     s.dispatchEvent(new Event('scroll', { bubbles: true }));
                 } catch { /* ignore */ }
             }
-            await TimeHelper.sleep(randomInterval(200, 350));
+            await TimeHelper.sleep(randomInterval(400, 600));
             const curCount = countItems();
-            if (curCount === prevCount) break;
-            prevCount = curCount;
+            if (curCount === prevCount) {
+                stableIterations++;
+                if (stableIterations >= 2) break;
+            } else {
+                stableIterations = 0;
+                prevCount = curCount;
+            }
         }
         // scroll back up so the chosen item's scrollIntoView works reliably
         for (const s of scrollables) {
             try { s.scrollTop = 0; } catch { /* ignore */ }
         }
-        await TimeHelper.sleep(randomInterval(150, 250));
+        // Final settle delay: let the game finish rendering any late items
+        // before the caller reads the DOM (see issue #1573).
+        await TimeHelper.sleep(randomInterval(400, 600));
         return countItems();
     }
 
@@ -935,7 +946,9 @@ export class HaremGirl {
         for (let i = 0; i < slotCount; i++) {
             const slot = equipmentSlots.eq(i);
             slot.trigger('click');
-            await TimeHelper.sleep(randomInterval(400, 600));
+            // Give the game time to kick off its inventory request for this slot
+            // before we start scrolling to force-load items (see issue #1573).
+            await TimeHelper.sleep(randomInterval(600, 900));
 
             // Force game to render all lazy-loaded inventory items into the DOM
             const totalItems = await HaremGirl.forceLoadAllInventoryItems();


### PR DESCRIPTION
## Summary
- Fixes #1573: first equipment slot was often skipped during auto-equip, leaving a worse item on the girl while all other slots updated correctly
- Root cause: virtualized rendering detached the target item node between `scrollIntoView` and the click, so the click never registered
- Fix: re-query the target item by `id_girl_armor` right before the click and swap to the fresh node if the original was detached
- Also removes a stale settle delay and tightens remaining delays after the fix stabilized

## Test plan
- [x] Run auto-equip across multiple girls — all six slots equip the chosen item on the first attempt
- [x] Verified the detach safety net actually triggers and recovers on slot 0