### PR TITLE
fix: first/last troll with girls fights troll without girls (#1582)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.10
+// @version      7.35.11
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -7331,13 +7331,35 @@ class Troll {
                     if (debugEnabled && logging)
                         LogUtils_logHHAuto("First troll with girls from storage");
                     TTF = trollWithGirls.findIndex((troll) => troll > 0) + 1;
+                    if (TTF > lastTrollIdAvailable) {
+                        if (logging)
+                            LogUtils_logHHAuto(`First troll with girls (${TTF}) is beyond last available (${lastTrollIdAvailable}), no valid troll target.`);
+                        TTF = 0;
+                    }
                 }
                 else if (autoTrollSelectedIndex === 99) {
                     if (debugEnabled && logging)
                         LogUtils_logHHAuto("Last troll with girls from storage");
                     TTF = trollWithGirls.findLastIndex((troll) => troll > 0) + 1;
                     if (TTF > lastTrollIdAvailable) {
-                        TTF = lastTrollIdAvailable;
+                        // Find the last troll with girls that is actually unlocked
+                        let found = false;
+                        for (let i = lastTrollIdAvailable - 1; i >= 0; i--) {
+                            if (trollWithGirls[i] > 0) {
+                                TTF = i + 1;
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            if (logging)
+                                LogUtils_logHHAuto(`No unlocked troll has girls (last available: ${lastTrollIdAvailable}), no valid troll target.`);
+                            TTF = 0;
+                        }
+                        else {
+                            if (logging)
+                                LogUtils_logHHAuto(`Last troll with girls capped to ${TTF} (last available: ${lastTrollIdAvailable}).`);
+                        }
                     }
                 }
             }
@@ -7384,16 +7406,17 @@ class Troll {
             TTF = 0;
         }
         if (TTF <= 0) {
-            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
-                // Only fallback to last troll if normal troll fighting is enabled
+            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true"
+                && autoTrollSelectedIndex !== 98 && autoTrollSelectedIndex !== 99) {
+                // Only fallback to last troll when not using first/last troll with girls mode
                 TTF = lastTrollIdAvailable > 0 ? lastTrollIdAvailable : 1;
                 if (logging)
                     LogUtils_logHHAuto(`Error: wrong troll target found. Backup to ${TTF}`);
             }
             else {
-                // Events/Raids only mode — no target available, skip fight
+                // First/last troll with girls found no valid target, or events/raids only mode
                 if (logging)
-                    LogUtils_logHHAuto("No event/raid troll target available, skipping.");
+                    LogUtils_logHHAuto("No valid troll target found, skipping.");
                 return 0;
             }
         }
@@ -7558,7 +7581,9 @@ class Troll {
                             return true;
                         }
                         else {
-                            LogUtils_logHHAuto(`Same troll found, go for it.`);
+                            LogUtils_logHHAuto(`Same troll found and no girls available, stopping troll fight.`);
+                            gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
+                            return;
                         }
                     }
                     let canBuyFightsResult = Troll.canBuyFight(eventTrollGirl);

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.11 — First/Last troll with girls no longer fights trolls without girls
+
+Addresses [#1582](https://github.com/Roukys/HHauto/issues/1582).
+
+When “Last troll with girls” or “First troll with girls” was selected and the only remaining trolls with girls were beyond the unlocked adventure range, the script would fight the last unlocked troll even though it had no girls left. The script now correctly skips trolls without girls and waits for Raids or Events instead.
+
+---
+
 ### v7.35.10 — Equipment optimization: Slot 1 is equipped reliably again
 
 Fixes [#1573](https://github.com/Roukys/HHauto/issues/1573).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.10",
+  "version": "7.35.11",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -217,12 +217,30 @@ export class Troll {
                 if (autoTrollSelectedIndex === 98) {
                     if (debugEnabled && logging) logHHAuto("First troll with girls from storage");
                     TTF = trollWithGirls.findIndex((troll: number) => troll > 0) + 1;
+                    if (TTF > lastTrollIdAvailable) {
+                        if (logging) logHHAuto(`First troll with girls (${TTF}) is beyond last available (${lastTrollIdAvailable}), no valid troll target.`);
+                        TTF = 0;
+                    }
                 }
                 else if (autoTrollSelectedIndex === 99) {
                     if (debugEnabled && logging) logHHAuto("Last troll with girls from storage");
                     TTF = trollWithGirls.findLastIndex((troll: number) => troll > 0) + 1;
                     if(TTF > lastTrollIdAvailable) {
-                        TTF=lastTrollIdAvailable;
+                        // Find the last troll with girls that is actually unlocked
+                        let found = false;
+                        for (let i = lastTrollIdAvailable - 1; i >= 0; i--) {
+                            if (trollWithGirls[i] > 0) {
+                                TTF = i + 1;
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            if (logging) logHHAuto(`No unlocked troll has girls (last available: ${lastTrollIdAvailable}), no valid troll target.`);
+                            TTF = 0;
+                        } else {
+                            if (logging) logHHAuto(`Last troll with girls capped to ${TTF} (last available: ${lastTrollIdAvailable}).`);
+                        }
                     }
                 }
             } else if(getPage()!==ConfigHelper.getHHScriptVars("pagesIDHome")) {
@@ -269,13 +287,14 @@ export class Troll {
         }
 
         if (TTF <= 0) {
-            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
-                // Only fallback to last troll if normal troll fighting is enabled
+            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true"
+                && autoTrollSelectedIndex !== 98 && autoTrollSelectedIndex !== 99) {
+                // Only fallback to last troll when not using first/last troll with girls mode
                 TTF = lastTrollIdAvailable > 0 ? lastTrollIdAvailable : 1;
                 if (logging) logHHAuto(`Error: wrong troll target found. Backup to ${TTF}`);
             } else {
-                // Events/Raids only mode — no target available, skip fight
-                if (logging) logHHAuto("No event/raid troll target available, skipping.");
+                // First/last troll with girls found no valid target, or events/raids only mode
+                if (logging) logHHAuto("No valid troll target found, skipping.");
                 return 0;
             }
         }
@@ -455,7 +474,9 @@ export class Troll {
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: newTroll });
                         return true;
                     } else {
-                        logHHAuto(`Same troll found, go for it.`);
+                        logHHAuto(`Same troll found and no girls available, stopping troll fight.`);
+                        gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
+                        return;
                     }
                 }
                 let canBuyFightsResult = Troll.canBuyFight(eventTrollGirl);


### PR DESCRIPTION
## Summary

- Fix troll selection when using 'First troll with girls' or 'Last troll with girls' and the only trolls with girls are beyond the unlocked adventure range
- Instead of blindly capping to the last available troll (which may have no girls), the script now searches for the last unlocked troll that actually has girls
- When no valid troll target is found, the script stops fighting and waits for Raids/Events
- When the same troll is found again with no girls on the pre-battle page, the script navigates home instead of fighting anyway

## Test plan

- Select 'Last troll with girls' and verify the script does not fight trolls without girls
- Verify the script correctly falls back to Raids/Events when no unlocked troll has girls
- Select 'First troll with girls' and verify the same behavior
- Test with active Love Raids to confirm they are picked up when no troll target is valid

Addresses #1582