### PR TITLE
Fix Possible Best team assignment on first click

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.11
+// @version      7.35.12
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17933,6 +17933,10 @@ class TeamModule {
     }
     static updateTeamUI(deckID, teamResult) {
         const arr = $('div[id_girl]');
+        // Remove all existing topNumber elements to prevent stale entries
+        // from a previous team calculation (e.g. Current Best) interfering
+        // with the current one (e.g. Best Possible) during assignTopTeam.
+        $('.topNumber').remove();
         for (let i = arr.length - 1; i > -1; i--) {
             let gID = Number($(arr[i]).attr('id_girl'));
             if (!deckID.includes(gID)) {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.12 — "Possible Best" team assignment now works on first click
+
+Fixes an issue where clicking "Possible Best" after "Current Best" on the Edit Team page would assign the wrong girls. The correct team is now applied on the first attempt.
+
+---
+
 ### v7.35.11 â€” First/Last troll with girls no longer fights trolls without girls
 
 Addresses [#1582](https://github.com/Roukys/HHauto/issues/1582).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.11",
+  "version": "7.35.12",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -579,6 +579,11 @@ export class TeamModule {
 
     private static updateTeamUI(deckID: number[], teamResult?: TeamResult) {
         const arr = $('div[id_girl]');
+        // Remove all existing topNumber elements to prevent stale entries
+        // from a previous team calculation (e.g. Current Best) interfering
+        // with the current one (e.g. Best Possible) during assignTopTeam.
+        $('.topNumber').remove();
+
         for (let i = arr.length - 1; i > -1; i--) {
             let gID = Number($(arr[i]).attr('id_girl'));
             if (!deckID.includes(gID)) {


### PR DESCRIPTION
Fixes an issue where clicking Possible Best after Current Best on the Edit Team page would assign the wrong girls. The correct team is now applied on the first attempt.

**Changes:**
- Remove stale .topNumber position markers in updateTeamUI before creating new ones
- Bump version to 7.35.12
- Update README changelog