### PR TITLE
fix: troll fallback no longer fights unavailable trolls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 coverage/*
 node_modules/*
+.kiro/
 
 # Projektanweisungen (Claude.ai)
 PROJEKTANWEISUNGEN.md

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/Roukys/HHauto
-// @version      7.35.12
+// @version      7.35.13
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -7464,7 +7464,10 @@ class Troll {
             const trollz = ConfigHelper.getHHScriptVars("trollzList");
             const currentPage = getPage();
             if (!TTF || TTF <= 0) {
-                if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
+                const autoTrollSelectedIndex = Troll.getTrollSelectedIndex();
+                if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true"
+                    && autoTrollSelectedIndex !== 98 && autoTrollSelectedIndex !== 99) {
+                    // Fixed troll or "last troll" mode: retry once, then fallback to troll 1
                     if (getStoredValue(HHStoredVarPrefixKey + TK.TrollInvalid) === "true") {
                         LogUtils_logHHAuto(`ERROR: Invalid troll N°${TTF}, again, going to first troll`);
                         TTF = 1;
@@ -7476,7 +7479,8 @@ class Troll {
                     }
                 }
                 else {
-                    LogUtils_logHHAuto("No troll target found (events/raids only mode), skipping fight.");
+                    // First/last troll with girls found no valid target, or events/raids only mode
+                    LogUtils_logHHAuto("No troll target found, skipping fight.");
                     return false;
                 }
             }
@@ -7576,7 +7580,7 @@ class Troll {
                         trollWithGirls[TTF - 1] = 0;
                         setStoredValue(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify(trollWithGirls));
                         const newTroll = Troll.getTrollIdToFight();
-                        if (TTF != newTroll) {
+                        if (newTroll > 0 && TTF != newTroll) {
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: newTroll });
                             return true;
                         }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.13 - Troll fallback no longer fights unavailable trolls
+
+Fixes [#1582](https://github.com/Roukys/HHauto/issues/1582).
+
+When "Last troll with girls" or "First troll with girls" was selected and no troll had any girls left to collect, the script would fall back to fighting the first troll in the game - even if that troll had no girls either. This caused an endless loop of pointless fights and could navigate to a troll that was not yet unlocked, showing "This Troll is not available yet!" in the game. The script now correctly stops fighting and waits for Raids or Events when no troll with girls is available. Affects all game variants.
+
+---
+
 ### v7.35.12 - "Possible Best" team assignment now works on first click
 
 Fixes an issue where clicking "Possible Best" after "Current Best" on the Edit Team page would assign the wrong girls. The correct team is now applied on the first attempt.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.12",
+  "version": "7.35.13",
   "description": "[English](https://github.com/Roukys/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -348,7 +348,10 @@ export class Troll {
         const currentPage = getPage();
 
         if (!TTF || TTF <= 0) {
-            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
+            const autoTrollSelectedIndex = Troll.getTrollSelectedIndex();
+            if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true"
+                && autoTrollSelectedIndex !== 98 && autoTrollSelectedIndex !== 99) {
+                // Fixed troll or "last troll" mode: retry once, then fallback to troll 1
                 if (getStoredValue(HHStoredVarPrefixKey + TK.TrollInvalid) === "true") {
                     logHHAuto(`ERROR: Invalid troll N°${TTF}, again, going to first troll`);
                     TTF = 1;
@@ -358,7 +361,8 @@ export class Troll {
                     return true;
                 }
             } else {
-                logHHAuto("No troll target found (events/raids only mode), skipping fight.");
+                // First/last troll with girls found no valid target, or events/raids only mode
+                logHHAuto("No troll target found, skipping fight.");
                 return false;
             }
         }
@@ -470,7 +474,7 @@ export class Troll {
                     trollWithGirls[TTF - 1] = 0;
                     setStoredValue(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify(trollWithGirls));
                     const newTroll = Troll.getTrollIdToFight();
-                    if (TTF != newTroll) {
+                    if (newTroll > 0 && TTF != newTroll) {
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: newTroll });
                         return true;
                     } else {


### PR DESCRIPTION
Fixes #1582.

When 'Last troll with girls' or 'First troll with girls' was selected and no troll had any girls left, the script would fall back to fighting the first troll - even if it had no girls. This caused an endless loop and could navigate to a troll not yet unlocked ('This Troll is not available yet!'). The script now stops fighting and waits for Raids or Events instead. Affects all game variants.

**Changes:**
- doBossBattle: respect first/last troll with girls mode (index 98/99) in the fallback path
- CrushThemFights: guard against navigating to troll 0 when no valid target exists
- Version bumped to 7.35.13