### PR TITLE
fix: update feature popup version to 7.35.15

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -23849,7 +23849,7 @@ const FEATURE_POPUP_CLOSE_LABEL = "OK";
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION = "7.35.14";
+const FEATURE_POPUP_VERSION = "7.35.15";
 /**
  * Title shown in the popup header.
  */

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.14
+// @version      7.35.15
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -7372,6 +7372,17 @@ class Troll {
                 if (logging)
                     LogUtils_logHHAuto("Can't get troll with girls, going to last troll.");
                 TTF = lastTrollIdAvailable;
+            }
+            // No troll with girls found - fall through to love raids before giving up
+            if (TTF <= 0 && LoveRaidManager.isActivated() && loveRaids.length > 0) {
+                if (logging)
+                    LogUtils_logHHAuto("No troll with girls, checking love raids as fallback.");
+                const loveRaid = LoveRaidManager.getRaidToFight(loveRaids, logging);
+                if (loveRaid) {
+                    TTF = loveRaid.trollId;
+                    if (logging)
+                        LogUtils_logHHAuto(`Love raid fallback: fighting troll ${TTF} for raid girl ${loveRaid.id_girl}.`);
+                }
             }
         }
         else if (LoveRaidManager.isActivated() && loveRaids.length > 0) {

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.15 - Troll with girls now falls through to love raids
+
+Addresses [#1582](https://github.com/Roukys/HHauto/issues/1582).
+
+When `Last troll with girls` or `First troll with girls` was selected and no troll had any girls left, the script would skip fighting entirely and idle in a loop - even when love raids with girls were available. The troll selection now falls through to love raids as a fallback when no troll target is found, so raid girls are still fought as expected.
+
+---
+
 ### v7.35.14 - Repository transfer notice
 
 The HHAuto repository will be transferred to a new owner (`OldRon1977/HHauto`) in the coming days. All repository URLs in the script (`@updateURL`, `@downloadURL`, namespace, wiki and issue links) have been switched to the new location ahead of the transfer. A one-time popup informs users about the move; GitHub redirects and Tampermonkey auto-update will handle the rest for users with auto-update enabled.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.14",
+  "version": "7.35.15",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -250,6 +250,16 @@ export class Troll {
                 if (logging) logHHAuto("Can't get troll with girls, going to last troll.");
                 TTF=lastTrollIdAvailable;
             }
+
+            // No troll with girls found - fall through to love raids before giving up
+            if (TTF <= 0 && LoveRaidManager.isActivated() && loveRaids.length > 0) {
+                if (logging) logHHAuto("No troll with girls, checking love raids as fallback.");
+                const loveRaid = LoveRaidManager.getRaidToFight(loveRaids, logging);
+                if (loveRaid) {
+                    TTF = loveRaid.trollId;
+                    if (logging) logHHAuto(`Love raid fallback: fighting troll ${TTF} for raid girl ${loveRaid.id_girl}.`);
+                }
+            }
         }
         else if (LoveRaidManager.isActivated() && loveRaids.length > 0){
             const loveRaid = LoveRaidManager.getRaidToFight(loveRaids, logging);

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -46,7 +46,7 @@ const FEATURE_POPUP_CLOSE_LABEL: string = "OK";
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION: string = "7.35.14";
+const FEATURE_POPUP_VERSION: string = "7.35.15";
 
 /**
  * Title shown in the popup header.


### PR DESCRIPTION
The repository transfer popup was pinned to 7.35.14 and would not show on 7.35.15. Updated FEATURE_POPUP_VERSION so the popup reappears on the new version as intended.