### PR TITLE
v7.35.21: League team algorithm rebuild + inspector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules/*
 
 # Projektanweisungen (Claude.ai)
 PROJEKTANWEISUNGEN.md
+
+# Lokale Dump-Dateien vom Debug-Inspector (nicht syncen)
+INPUT/

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.20
+// @version      7.35.21
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -16966,6 +16966,575 @@ Spreadsheet.LINK_CLASS = 'hhauto-spreadsheet-link';
 Spreadsheet.BDSMPP_CLASS = 'script-blessing-spreadsheet-link';
 Spreadsheet.POPUP_SELECTOR = '#blessings_popup .blessings_wrapper';
 
+;// CONCATENATED MODULE: ./src/Service/TeamScoringService.ts
+// TeamScoringService.ts -- Scoring engine for team selection v4.
+//
+// Provides Tier 3 trait matching, element synergy calculations,
+// and leader skill evaluation for team optimization.
+//
+// Two modes (both filter Mythic + Legendary only, hard-filter to player class):
+//   - "Current Best": uses current main-class stat (blessed, equipment-free)
+//   - "Best Possible": projects main-class stat to player level + max grades
+//
+// Player class is HC=1 (carac1), Charm=2 (carac2), KH=3 (carac3).
+// Only the matching carac counts for scoring -- the game's own class
+// system does the rest (Wiki: "never build cross-class").
+// Synergy bonus multiplier per girl of each element in the team
+const ELEMENT_SYNERGY_PER_GIRL = {
+    fire: { field: 'critDamage', bonus: 0.10 },
+    water: { field: 'healOnHit', bonus: 0.03 },
+    nature: { field: 'ego', bonus: 0.03 },
+    stone: { field: 'critChance', bonus: 0.02 },
+    sun: { field: 'defReduce', bonus: 0.02 },
+    darkness: { field: 'damage', bonus: 0.02 },
+    psychic: { field: 'defense', bonus: 0.02 },
+    light: { field: 'harmony', bonus: 0.02 },
+};
+// Tier-5 skill mapping by element, with priority ranking
+// Priority: Shield (light/stone) > Stun (sun/darkness) > Execute (fire/water) > Reflect
+const ELEMENT_TO_TIER5 = {
+    light: { id: 12, name: 'Shield', priority: 4 },
+    stone: { id: 12, name: 'Shield', priority: 4 },
+    sun: { id: 11, name: 'Stun', priority: 3 },
+    darkness: { id: 11, name: 'Stun', priority: 3 },
+    fire: { id: 14, name: 'Execute', priority: 2 },
+    water: { id: 14, name: 'Execute', priority: 2 },
+    psychic: { id: 13, name: 'Reflect', priority: 1 },
+    nature: { id: 13, name: 'Reflect', priority: 1 },
+};
+// Each element's Tier 3 bonus is based on a specific trait category.
+// Girls from the same element pair share the same trait category.
+const ELEMENT_TO_TRAIT_CATEGORY = {
+    darkness: 'eyeColor', // Black
+    fire: 'eyeColor', // Red
+    light: 'hairColor', // White
+    nature: 'hairColor', // Green
+    stone: 'zodiac', // Orange
+    psychic: 'zodiac', // Purple
+    water: 'position', // Blue
+    sun: 'position', // Yellow
+};
+// Element pairs that share a trait category
+const ELEMENT_PAIRS = [
+    { elements: ['darkness', 'fire'], trait: 'eyeColor' },
+    { elements: ['light', 'nature'], trait: 'hairColor' },
+    { elements: ['stone', 'psychic'], trait: 'zodiac' },
+    { elements: ['water', 'sun'], trait: 'position' },
+];
+// Rarities allowed for team selection (both modes)
+const HIGH_RARITIES = new Set(['mythic', 'legendary']);
+// Tier 3 bonus per matching teammate: 1.0% for Mythic, 0.8% for Legendary
+const TIER3_BONUS_MYTHIC = 0.01;
+const TIER3_BONUS_LEGENDARY = 0.008;
+// Blessed-category boost when scoring trait groups (heuristic only;
+// the actual stat impact already lives inside girl.caracs once the
+// game applies the weekly blessing).
+const BLESSED_CATEGORY_BOOST = 1.5;
+class TeamScoringService {
+    /**
+     * Get the girl's main-class stat (carac1/2/3 by player class).
+     * Uses caracs sub-object if available (already equipment-free),
+     * falls back to direct fields.
+     *
+     * Player class -> stat field:
+     *   1 (Hardcore) -> carac1
+     *   2 (Charm)    -> carac2
+     *   3 (Know-how) -> carac3
+     */
+    static getMainCarac(girl, playerClass) {
+        const src = girl.caracs || { carac1: girl.carac1, carac2: girl.carac2, carac3: girl.carac3 };
+        switch (playerClass) {
+            case 1: return Number(src.carac1) || 0;
+            case 2: return Number(src.carac2) || 0;
+            case 3: return Number(src.carac3) || 0;
+        }
+    }
+    /**
+     * Score a girl for "Current Best" mode.
+     * Returns the current main-carac (already includes blessings).
+     */
+    static scoreCurrentBest(girl, playerClass) {
+        return TeamScoringService.getMainCarac(girl, playerClass);
+    }
+    /**
+     * Score a girl for "Best Possible" mode.
+     * Projects main-carac to player level and full grades.
+     *
+     * Formula:
+     *   potential = currentMainCarac / level * playerLevel
+     *               / (1 + 0.3 * currentGrades) * (1 + 0.3 * maxGrades)
+     *
+     * Returns max(projected, current) so blessing-inflated current
+     * stats never get demoted by the projection.
+     */
+    static scoreBestPossible(girl, playerClass, playerLevel) {
+        const currentMain = TeamScoringService.getMainCarac(girl, playerClass);
+        const level = girl.level || 1;
+        const currentGrades = girl.graded || 0;
+        const maxGrades = girl.nb_grades || 0;
+        const levelFactor = playerLevel / Math.max(level, 1);
+        const gradeDeflator = 1 + 0.3 * currentGrades;
+        const gradeInflator = 1 + 0.3 * maxGrades;
+        const projected = (currentMain * levelFactor / gradeDeflator) * gradeInflator;
+        return Math.max(projected, currentMain);
+    }
+    /**
+     * Filter girls: only Mythic and Legendary 5-star, plus hard class match.
+     * Cross-class girls always lose because their main-carac is the
+     * non-matching one; filtering them out up-front keeps the pool small.
+     */
+    static filterEligible(girls, playerClass) {
+        return girls.filter(g => {
+            // Class filter (hard)
+            if (typeof g.class === 'number' && g.class !== playerClass)
+                return false;
+            // Rarity filter
+            if (g.rarity === 'mythic')
+                return true;
+            if (g.rarity === 'legendary')
+                return g.nb_grades >= 5;
+            return false;
+        });
+    }
+    /**
+     * Backwards-compatible alias used by existing tests.
+     * @deprecated Use filterEligible(girls, playerClass) instead.
+     */
+    static filterHighRarity(girls) {
+        return girls.filter(g => {
+            if (g.rarity === 'mythic')
+                return true;
+            if (g.rarity === 'legendary')
+                return g.nb_grades >= 5;
+            return false;
+        });
+    }
+    /**
+     * Get the Tier-5 skill info for a given element.
+     */
+    static getTier5Skill(element) {
+        return ELEMENT_TO_TIER5[element];
+    }
+    // --- Trait / Tier 3 logic --------------------------------------
+    /**
+     * Get the trait category for a girl based on her element.
+     */
+    static getTraitCategory(element) {
+        return ELEMENT_TO_TRAIT_CATEGORY[element];
+    }
+    /**
+     * Get the trait value for a girl based on her element's trait category.
+     * Returns undefined if the trait data is not available.
+     */
+    static getTraitValue(girl) {
+        const category = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
+        switch (category) {
+            case 'eyeColor': return girl.eyeColor;
+            case 'hairColor': return girl.hairColor;
+            case 'zodiac': return girl.zodiac;
+            case 'position': return girl.position;
+        }
+    }
+    /**
+     * Calculate the total Tier 3 bonus percentage for a team.
+     *
+     * Each girl checks how many teammates share her element pair's trait value.
+     * Mythic: 1.0% per matching teammate, Legendary: 0.8% per matching teammate.
+     * The bonus is calculated per girl and summed for the team total.
+     */
+    static calculateTier3TeamBonus(team) {
+        let totalBonus = 0;
+        for (const girl of team) {
+            const category = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
+            const myValue = TeamScoringService.getTraitValue(girl);
+            if (!myValue)
+                continue;
+            let matchCount = 0;
+            for (const teammate of team) {
+                if (teammate.id_girl === girl.id_girl)
+                    continue;
+                const teammateCategory = ELEMENT_TO_TRAIT_CATEGORY[teammate.element];
+                if (teammateCategory !== category)
+                    continue;
+                const teammateValue = TeamScoringService.getTraitValue(teammate);
+                if (teammateValue === myValue) {
+                    matchCount++;
+                }
+            }
+            const bonusPerMatch = girl.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
+            totalBonus += matchCount * bonusPerMatch;
+        }
+        return totalBonus;
+    }
+    /**
+     * Detect which trait categories are currently blessed by analyzing
+     * blessing_bonuses across all girls. Returns a set of blessed TraitCategories.
+     */
+    static detectBlessedTraits(girls) {
+        const blessedCategories = new Set();
+        let blessedGirlCount = 0;
+        for (const girl of girls) {
+            if (!girl.blessingBonuses)
+                continue;
+            const bonuses = girl.blessingBonuses;
+            if (typeof bonuses !== 'object')
+                continue;
+            let hasBlessing = false;
+            for (const key of Object.keys(bonuses)) {
+                const lk = key.toLowerCase();
+                if (lk.includes('zodiac') || lk.includes('sign') || lk.includes('astro')) {
+                    blessedCategories.add('zodiac');
+                    hasBlessing = true;
+                }
+                if (lk.includes('hair') || lk.includes('cheveu')) {
+                    blessedCategories.add('hairColor');
+                    hasBlessing = true;
+                }
+                if (lk.includes('eye') || lk.includes('yeux') || lk.includes('oeil')) {
+                    blessedCategories.add('eyeColor');
+                    hasBlessing = true;
+                }
+                if (lk.includes('position') || lk.includes('pose') || lk.includes('favourite_position')) {
+                    blessedCategories.add('position');
+                    hasBlessing = true;
+                }
+            }
+            if (!hasBlessing) {
+                for (const val of Object.values(bonuses)) {
+                    if (typeof val === 'number' && val > 0) {
+                        hasBlessing = true;
+                        break;
+                    }
+                }
+            }
+            if (hasBlessing)
+                blessedGirlCount++;
+        }
+        return { blessedCategories, blessedGirlCount };
+    }
+    /**
+     * Find all possible trait groups from a pool of girls.
+     *
+     * For each element pair, groups girls by their shared trait value
+     * and scores each group by `count * avg_main_carac`.
+     * Groups matching a currently blessed trait receive a heuristic
+     * boost to surface them in early evaluation; the actual stat
+     * impact is already in the girl's caracs from the game API.
+     *
+     * Returns groups sorted by score descending.
+     */
+    static findTraitGroups(girls, playerClass, blessedCategories) {
+        const results = [];
+        for (const pair of ELEMENT_PAIRS) {
+            const pairGirls = girls.filter(g => pair.elements.includes(g.element));
+            if (pairGirls.length === 0)
+                continue;
+            // Group by trait value
+            const groups = new Map();
+            for (const girl of pairGirls) {
+                const value = TeamScoringService.getTraitValue(girl);
+                if (!value)
+                    continue;
+                if (!groups.has(value))
+                    groups.set(value, []);
+                groups.get(value).push(girl);
+            }
+            for (const [traitValue, groupGirls] of groups) {
+                const avgMain = groupGirls.reduce((sum, g) => sum + TeamScoringService.getMainCarac(g, playerClass), 0) / groupGirls.length;
+                let score = groupGirls.length * avgMain;
+                // Heuristic boost for blessed trait categories
+                if (blessedCategories && blessedCategories.has(pair.trait)) {
+                    score *= BLESSED_CATEGORY_BOOST;
+                }
+                results.push({
+                    traitCategory: pair.trait,
+                    traitValue,
+                    girls: groupGirls,
+                    score,
+                });
+            }
+        }
+        return results.sort((a, b) => b.score - a.score);
+    }
+    // --- Synergy calculations (informational) ---------------------
+    /**
+     * Calculate synergy bonuses for a set of elements (one per team member).
+     */
+    static calculateSynergies(elements) {
+        const synergies = {
+            critDamage: 0,
+            healOnHit: 0,
+            ego: 0,
+            critChance: 0,
+            defReduce: 0,
+            damage: 0,
+            defense: 0,
+            harmony: 0,
+        };
+        for (const element of elements) {
+            const mapping = ELEMENT_SYNERGY_PER_GIRL[element];
+            if (mapping) {
+                synergies[mapping.field] += mapping.bonus;
+            }
+        }
+        return synergies;
+    }
+    /**
+     * Calculate a numeric "synergy value" for a team composition.
+     * Weighs each synergy type by its combat impact.
+     */
+    static calculateSynergyValue(elements) {
+        const syn = TeamScoringService.calculateSynergies(elements);
+        return (syn.critDamage * 1.0 +
+            syn.critChance * 2.0 +
+            syn.defReduce * 2.0 +
+            syn.healOnHit * 1.5 +
+            syn.damage * 1.5 +
+            syn.ego * 1.0 +
+            syn.defense * 1.0 +
+            syn.harmony * 1.0);
+    }
+    // --- Leader selection ----------------------------------------
+    /**
+     * Rank leader candidates by element priority (Shield > Stun > Execute > Reflect).
+     * Leader must be Mythic. Among same priority: prefer trait match, then highest stats.
+     */
+    static rankLeaderCandidates(girls, statScores, traitCategory, traitValue) {
+        const mythicGirls = girls.filter(g => g.rarity === 'mythic');
+        if (mythicGirls.length === 0) {
+            return TeamScoringService._sortLeaderCandidates(girls, statScores, traitCategory, traitValue);
+        }
+        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue);
+    }
+    static _sortLeaderCandidates(girls, statScores, traitCategory, traitValue) {
+        return [...girls].sort((a, b) => {
+            const tier5A = ELEMENT_TO_TIER5[a.element];
+            const tier5B = ELEMENT_TO_TIER5[b.element];
+            // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect)
+            if (tier5A.priority !== tier5B.priority) {
+                return tier5B.priority - tier5A.priority;
+            }
+            // Secondary: trait match bonus
+            if (traitCategory && traitValue) {
+                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
+                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
+                if (aMatches !== bMatches) {
+                    return aMatches ? -1 : 1;
+                }
+            }
+            // Tertiary: stat score
+            const scoreA = statScores.get(a.id_girl) || 0;
+            const scoreB = statScores.get(b.id_girl) || 0;
+            return scoreB - scoreA;
+        });
+    }
+    /**
+     * Check if a leader candidate matches the team's trait.
+     */
+    static _leaderMatchesTrait(girl, teamTraitCategory, teamTraitValue) {
+        const girlCategory = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
+        if (girlCategory !== teamTraitCategory)
+            return false;
+        const girlValue = TeamScoringService.getTraitValue(girl);
+        return girlValue === teamTraitValue;
+    }
+}
+
+;// CONCATENATED MODULE: ./src/Service/TeamBuilderService.ts
+// TeamBuilderService.ts -- Builds optimal 7-girl teams using Tier 3
+// trait-group optimization (v4).
+//
+// Algorithm:
+//   1. Hard-filter to Mythic + Legendary 5-star, player class only
+//   2. Score by player main-carac (current or projected)
+//   3. Find best trait group (element pair + shared trait value)
+//      compared by main_sum * (1 + tier3Bonus)
+//   4. Select Mythic leader (Shield/Stun priority)
+//   5. Fill slots 2-7 from trait group, then by main-carac
+
+const TEAM_SIZE = 7;
+// No pool cap: the Mythic + Legendary-5* filter is already strict
+// (max ~170 girls per class even if a player owned every released one).
+// Capping here would only risk excluding viable mythics on edge cases.
+// CANDIDATE_POOL_SIZE removed in v7.35.21.
+// Map trait category to its element pair for quick lookup
+const ELEMENT_PAIRS_MAP = {
+    'eyeColor': ['darkness', 'fire'],
+    'hairColor': ['light', 'nature'],
+    'zodiac': ['stone', 'psychic'],
+    'position': ['water', 'sun'],
+};
+class TeamBuilderService {
+    /**
+     * Build the optimal team for the given mode.
+     *
+     * @param allGirls    - All available girls (from availableGirls)
+     * @param mode        - 1 = Current Best, 2 = Best Possible
+     * @param playerLevel - Player's current level (needed for mode 2)
+     * @param playerClass - Player's class (1=HC, 2=Charm, 3=KH)
+     * @returns TeamResult with the selected 7 girls, or null if not enough girls
+     */
+    static buildTeam(allGirls, mode, playerLevel, playerClass) {
+        // Phase 1: Hard filter -- Mythic/Legendary AND own class
+        const candidates = TeamScoringService.filterEligible(allGirls, playerClass);
+        if (candidates.length < TEAM_SIZE) {
+            return null;
+        }
+        // Phase 2: Score all candidates by main-carac
+        const scoreMap = new Map();
+        for (const girl of candidates) {
+            const score = mode === 1
+                ? TeamScoringService.scoreCurrentBest(girl, playerClass)
+                : TeamScoringService.scoreBestPossible(girl, playerClass, playerLevel);
+            scoreMap.set(girl.id_girl, score);
+        }
+        // Pre-sort and pick a reasonable candidate pool
+        // Sort by score; no cap -- evaluate every eligible girl
+        const pool = [...candidates].sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+        // Phase 2b: Detect active blessings (informational + heuristic)
+        const { blessedCategories, blessedGirlCount } = TeamScoringService.detectBlessedTraits(candidates);
+        // Phase 3: Build teams for multiple trait groups, pick highest effective power
+        const traitGroups = TeamScoringService.findTraitGroups(pool, playerClass, blessedCategories);
+        // Evaluate top groups + all blessed groups
+        const groupsToEvaluate = [];
+        const seenKeys = new Set();
+        for (const g of traitGroups.slice(0, 5)) {
+            const key = g.traitCategory + '=' + g.traitValue;
+            if (!seenKeys.has(key)) {
+                groupsToEvaluate.push(g);
+                seenKeys.add(key);
+            }
+        }
+        for (const g of traitGroups) {
+            const key = g.traitCategory + '=' + g.traitValue;
+            if (seenKeys.has(key))
+                continue;
+            if (blessedCategories.has(g.traitCategory)) {
+                groupsToEvaluate.push(g);
+                seenKeys.add(key);
+            }
+        }
+        if (groupsToEvaluate.length === 0 && traitGroups.length > 0) {
+            groupsToEvaluate.push(traitGroups[0]);
+        }
+        // Build a team for each group and compare effective power
+        let bestBuilt = null;
+        const alternatives = [];
+        for (const group of groupsToEvaluate) {
+            const builtTeam = TeamBuilderService._buildTeamForGroup(group.traitCategory, group.traitValue, pool, scoreMap);
+            if (!builtTeam || builtTeam.length < TEAM_SIZE)
+                continue;
+            const statSum = builtTeam.reduce((s, g) => s + (scoreMap.get(g.id_girl) || 0), 0);
+            const t3 = TeamScoringService.calculateTier3TeamBonus(builtTeam);
+            const power = Math.round(statSum * (1 + t3));
+            alternatives.push({ traitCategory: group.traitCategory, traitValue: group.traitValue, effectivePower: power });
+            if (!bestBuilt || power > bestBuilt.power) {
+                bestBuilt = { team: builtTeam, cat: group.traitCategory, val: group.traitValue, power };
+            }
+        }
+        if (!bestBuilt)
+            return null;
+        const team = bestBuilt.team;
+        const teamElements = team.map(g => g.element);
+        const leader = team[0];
+        const traitCategory = bestBuilt.cat;
+        const traitValue = bestBuilt.val;
+        const statScores = team.map(g => scoreMap.get(g.id_girl) || 0);
+        const synergyValue = TeamScoringService.calculateSynergyValue(teamElements);
+        const leaderTier5 = TeamScoringService.getTier5Skill(leader.element);
+        const tier3Bonus = TeamScoringService.calculateTier3TeamBonus(team);
+        let traitMatchCount = 0;
+        for (const girl of team) {
+            const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+            if (girlCategory === traitCategory) {
+                const girlValue = TeamScoringService.getTraitValue(girl);
+                if (girlValue === traitValue) {
+                    traitMatchCount++;
+                }
+            }
+        }
+        return {
+            girls: team,
+            statScores,
+            synergyValue,
+            leaderTier5,
+            elements: teamElements,
+            traitCategory,
+            traitValue,
+            tier3Bonus,
+            traitMatchCount,
+            blessedCategories: Array.from(blessedCategories),
+            blessedGirlCount,
+            effectivePower: bestBuilt.power,
+            alternatives,
+            playerClass,
+        };
+    }
+    /**
+     * Build a team for a specific trait group.
+     *
+     * Pass 1: same element pair + matching trait value (max Tier-3 bonus).
+     * Pass 2: same element pair, any trait value (still keeps cluster).
+     * Pass 3: any element by score (last-resort fillers).
+     */
+    static _buildTeamForGroup(cat, val, pool, scoreMap) {
+        const elems = ELEMENT_PAIRS_MAP[cat] || [];
+        const leaders = pool.filter(g => g.rarity === 'mythic' && elems.includes(g.element));
+        const ranked = TeamScoringService.rankLeaderCandidates(leaders.length > 0 ? leaders : pool, scoreMap, cat, val);
+        if (ranked.length === 0)
+            return null;
+        const team = [ranked[0]];
+        const used = new Set([ranked[0].id_girl]);
+        // Pass 1: matching trait value AND correct element
+        const pass1 = pool
+            .filter(g => !used.has(g.id_girl) && elems.includes(g.element) && TeamScoringService.getTraitValue(g) === val)
+            .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+        for (const g of pass1) {
+            if (team.length >= TEAM_SIZE)
+                break;
+            team.push(g);
+            used.add(g.id_girl);
+        }
+        // Pass 2: correct element, any trait value
+        if (team.length < TEAM_SIZE) {
+            const pass2 = pool
+                .filter(g => !used.has(g.id_girl) && elems.includes(g.element))
+                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+            for (const g of pass2) {
+                if (team.length >= TEAM_SIZE)
+                    break;
+                team.push(g);
+                used.add(g.id_girl);
+            }
+        }
+        // Pass 3: any element by score
+        if (team.length < TEAM_SIZE) {
+            const pass3 = pool
+                .filter(g => !used.has(g.id_girl))
+                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+            for (const g of pass3) {
+                if (team.length >= TEAM_SIZE)
+                    break;
+                team.push(g);
+                used.add(g.id_girl);
+            }
+        }
+        return team.length >= TEAM_SIZE ? team : null;
+    }
+    /**
+     * Get a summary of element distribution in the team.
+     */
+    static getElementDistribution(team) {
+        const counts = new Map();
+        for (const el of team.elements) {
+            counts.set(el, (counts.get(el) || 0) + 1);
+        }
+        return Array.from(counts.entries())
+            .map(([element, count]) => ({ element, count }))
+            .sort((a, b) => b.count - a.count);
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/Service/BlessingService.ts
 // BlessingService.ts -- Loads and caches weekly blessing data.
 //
@@ -17103,773 +17672,142 @@ class BlessingService {
         }
         return undefined;
     }
-    /**
-     * Resolve the hex code for a blessed trait by analyzing blessing_bonuses on girls.
-     *
-     * Strategy: The Blessing API gives us names (e.g. "grey", "dolphin") but girl data
-     * uses hex codes (e.g. "888") or filenames (e.g. "2.png"). This method finds the
-     * mapping by looking at which girls have the blessing bonus and what trait value
-     * they share uniformly.
-     *
-     * @param girls - All available girls with their raw data
-     * @param blessedCategory - The trait category (eyeColor, hairColor, position)
-     * @param blessingPercent - The bonus percentage from the blessing (e.g. 30, 40)
-     * @returns The hex code / filename that corresponds to the blessed value, or undefined
-     */
-    static resolveHexForBlessing(girls, blessedCategory, blessingPercent) {
-        var _a;
-        // Find girls that have pvp_v3 blessing bonuses
-        const blessedGirls = girls.filter(g => {
-            if (!g.blessing_bonuses || typeof g.blessing_bonuses !== 'object')
-                return false;
-            if (Array.isArray(g.blessing_bonuses) && g.blessing_bonuses.length === 0)
-                return false;
-            return g.blessing_bonuses.pvp_v3 !== undefined;
-        });
-        if (blessedGirls.length === 0)
-            return undefined;
-        // Group blessed girls by their bonus percentage
-        const byPercent = new Map();
-        for (const g of blessedGirls) {
-            const pcts = (_a = g.blessing_bonuses.pvp_v3) === null || _a === void 0 ? void 0 : _a.carac1;
-            if (!Array.isArray(pcts))
-                continue;
-            for (const pct of pcts) {
-                if (!byPercent.has(pct))
-                    byPercent.set(pct, []);
-                byPercent.get(pct).push(g);
-            }
-        }
-        // For each percentage group, check if the target trait has a uniform value
-        const fieldMap = {
-            eyeColor: 'eye_color1',
-            hairColor: 'hair_color1',
-            position: 'position_img',
-        };
-        const field = fieldMap[blessedCategory];
-        if (!field)
-            return undefined;
-        // If we know the exact percentage, check that group first
-        const groupsToCheck = blessingPercent
-            ? [byPercent.get(blessingPercent), ...Array.from(byPercent.values())]
-            : Array.from(byPercent.values());
-        for (const group of groupsToCheck) {
-            if (!group || group.length < 1)
-                continue;
-            // Count trait values in this group
-            const valueCounts = new Map();
-            for (const g of group) {
-                const val = g[field];
-                if (val && val !== '') {
-                    valueCounts.set(val, (valueCounts.get(val) || 0) + 1);
-                }
-            }
-            // Check if one value dominates (>90% of the group)
-            for (const [val, count] of valueCounts) {
-                if (count / group.length >= 0.9) {
-                    LogUtils_logHHAuto('BlessingService: resolved ' + blessedCategory + ' -> hex="' + val + '" (' + count + '/' + group.length + ' girls)');
-                    return val;
-                }
-            }
-        }
-        return undefined;
-    }
-    /**
-     * Parse the blessing bonus percentage for a given trait category.
-     * E.g. "Eye Color Grey" with "+ 40%" -> 40
-     */
-    static parseBlessingPercent(response, category) {
-        const active = (response === null || response === void 0 ? void 0 : response.active) || [];
-        if (!Array.isArray(active))
-            return undefined;
-        const categoryKeywords = {
-            eyeColor: ['eye color'],
-            hairColor: ['hair color', 'hair colour'],
-            position: ['favourite position', 'favorite position'],
-            zodiac: ['zodiac', 'astrological', 'sign'],
-        };
-        const keywords = categoryKeywords[category];
-        if (!keywords)
-            return undefined;
-        for (const blessing of active) {
-            const desc = (blessing.description || '').toLowerCase();
-            if (!desc.includes('bonus on all attributes') || desc.includes('labyrinth'))
-                continue;
-            if (keywords.some(kw => desc.includes(kw))) {
-                const pctMatch = desc.match(/\+\s*(\d+)\s*%/);
-                if (pctMatch)
-                    return Number(pctMatch[1]);
-            }
-        }
-        return undefined;
-    }
 }
 
-;// CONCATENATED MODULE: ./src/Service/TeamScoringService.ts
-// TeamScoringService.ts -- Scoring engine for team selection v3.
+;// CONCATENATED MODULE: ./src/Service/TraitMappings.ts
+// TraitMappings.ts -- Maps internal hex / image / unicode codes to
+// human-readable trait names.
 //
-// Provides Tier 3 trait matching, element synergy calculations,
-// and leader skill evaluation for team optimization.
+// The game stores girl traits as compact codes:
+//   - eye_color1 / hair_color1: 3-character hex like "00F", "888", "F90"
+//   - position_img: numbered image like "1.png" .. "12.png"
+//   - zodiac: unicode glyph + name like "GLYPH Aries"
 //
-// Two modes (both filter Mythic + Legendary only):
-//   - "Current Best": uses current stats (blessed)
-//   - "Best Possible": projects stats to max level + full grades
-// Synergy bonus multiplier per girl of each element in the team
-const ELEMENT_SYNERGY_PER_GIRL = {
-    fire: { field: 'critDamage', bonus: 0.10 },
-    water: { field: 'healOnHit', bonus: 0.03 },
-    nature: { field: 'ego', bonus: 0.03 },
-    stone: { field: 'critChance', bonus: 0.02 },
-    sun: { field: 'defReduce', bonus: 0.02 },
-    darkness: { field: 'damage', bonus: 0.02 },
-    psychic: { field: 'defense', bonus: 0.02 },
-    light: { field: 'harmony', bonus: 0.02 },
+// At runtime, the game UI translates these via window.GT.design.colors
+// and window.GT.design.figures. We try the runtime lookup first
+// (covers patches that add new colors) and fall back to hardcoded
+// English values from Tom-208's userscript reference.
+//
+// Used by: TeamModule UI box (cluster name, blessing match indicator)
+// Hardcoded English fallback. Mirrors the Tom-208 userscript (gist
+// a5c7065866fe1de5032aabbbd1ed9eff) which itself is reverse-engineered
+// from window.GT.design.colors.
+const COLOR_FALLBACK_EN = {
+    'F99': 'Pink',
+    'B06': 'Dark Pink',
+    'F00': 'Red',
+    'B62': 'Dark blond',
+    'FFF': 'White',
+    '321': 'Dark',
+    '00F': 'Blue',
+    'FF0': 'Blond',
+    '0F0': 'Green',
+    'XXX': 'Unknown',
+    'A55': 'Brown',
+    '000': 'Black',
+    'CCC': 'Silver',
+    'F0F': 'Purple',
+    'F90': 'Orange',
+    'EB8': 'Strawberry blonde',
+    '888': 'Grey',
+    'FD0': 'Golden',
+    'D83': 'Bronze',
+    '765': 'Ash brown',
 };
-// Tier-5 skill mapping by element, with priority ranking
-// Priority: Shield (light/stone) > Stun (sun/darkness) > Execute (fire/water) > Reflect
-const ELEMENT_TO_TIER5 = {
-    light: { id: 12, name: 'Shield', priority: 4 },
-    stone: { id: 12, name: 'Shield', priority: 4 },
-    sun: { id: 11, name: 'Stun', priority: 3 },
-    darkness: { id: 11, name: 'Stun', priority: 3 },
-    fire: { id: 14, name: 'Execute', priority: 2 },
-    water: { id: 14, name: 'Execute', priority: 2 },
-    psychic: { id: 13, name: 'Reflect', priority: 1 },
-    nature: { id: 13, name: 'Reflect', priority: 1 },
-};
-// Each element's Tier 3 bonus is based on a specific trait category.
-// Girls from the same element pair share the same trait category.
-const ELEMENT_TO_TRAIT_CATEGORY = {
-    darkness: 'eyeColor', // Black
-    fire: 'eyeColor', // Red
-    light: 'hairColor', // White
-    nature: 'hairColor', // Green
-    stone: 'zodiac', // Orange
-    psychic: 'zodiac', // Purple
-    water: 'position', // Blue
-    sun: 'position', // Yellow
-};
-// Element pairs that share a trait category
-const ELEMENT_PAIRS = [
-    { elements: ['darkness', 'fire'], trait: 'eyeColor' },
-    { elements: ['light', 'nature'], trait: 'hairColor' },
-    { elements: ['stone', 'psychic'], trait: 'zodiac' },
-    { elements: ['water', 'sun'], trait: 'position' },
-];
-// Position penalty factor (position trait reduces attack stats via equipment)
-const POSITION_TRAIT_PENALTY = 0.80;
-// Rarities allowed for team selection (both modes)
-const HIGH_RARITIES = new Set(['mythic', 'legendary']);
-// Tier 3 bonus per matching teammate: 1.0% for Mythic, 0.8% for Legendary
-const TIER3_BONUS_MYTHIC = 0.01;
-const TIER3_BONUS_LEGENDARY = 0.008;
-class TeamScoringService {
+// Position images don't have human-readable names server-side.
+// The game presents them via window.GT.design.figures[1..12], which
+// returns localized labels (e.g. "Doggy", "69", "Cowgirl"). When the
+// runtime lookup fails we keep the bare number which is always accurate.
+const POSITION_FALLBACK_PREFIX = 'Pose ';
+class TraitMappings {
     /**
-     * Get the raw stat sum for a girl (carac1 + carac2 + carac3).
-     * Uses caracs sub-object if available, falls back to direct fields.
+     * Look up the runtime color map from window.GT.design.colors.
+     * Returns null if the structure is not available (e.g. spec tests).
      */
-    /**
-     * Get the BASE stat sum for a girl, EXCLUDING equipment (armor) bonuses.
-     * The game API includes armor stats in carac1/2/3, which must be subtracted
-     * to get the true girl power for fair comparison across differently-equipped girls.
-     */
-    static getStatSum(girl) {
-        let total;
-        if (girl.caracs) {
-            total = girl.caracs.carac1 + girl.caracs.carac2 + girl.caracs.carac3;
+    static getRuntimeColorMap() {
+        var _a, _b;
+        try {
+            const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : (typeof window !== 'undefined' ? window : null);
+            if (!w)
+                return null;
+            const map = (_b = (_a = w.GT) === null || _a === void 0 ? void 0 : _a.design) === null || _b === void 0 ? void 0 : _b.colors;
+            return (map && typeof map === 'object') ? map : null;
         }
-        else {
-            total = girl.carac1 + girl.carac2 + girl.carac3;
+        catch (_c) {
+            return null;
         }
-        // Subtract armor/equipment bonuses if present
-        if (girl.armor && Array.isArray(girl.armor)) {
-            for (const piece of girl.armor) {
-                if (piece.caracs) {
-                    total -= (piece.caracs.carac1 || 0) + (piece.caracs.carac2 || 0) + (piece.caracs.carac3 || 0);
-                }
-            }
+    }
+    /**
+     * Look up the runtime figure map from window.GT.design.figures.
+     */
+    static getRuntimeFigureMap() {
+        var _a, _b;
+        try {
+            const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : (typeof window !== 'undefined' ? window : null);
+            if (!w)
+                return null;
+            const map = (_b = (_a = w.GT) === null || _a === void 0 ? void 0 : _a.design) === null || _b === void 0 ? void 0 : _b.figures;
+            return (map && typeof map === 'object') ? map : null;
         }
-        return total;
+        catch (_c) {
+            return null;
+        }
     }
     /**
-     * Get the blessing multiplier for a girl from her blessing_bonuses.
-     * The pvp_v3 field contains an array of bonus percentages (one per active blessing).
-     * E.g. pvp_v3: { carac1: [30, 40] } means +30% from one blessing and +40% from another.
-     * These are additive: total = 1 + (30 + 40) / 100 = 1.70
+     * Resolve a hex color code (eye or hair) to its readable name.
+     * Tries window.GT.design.colors first, falls back to English.
      */
-    static getBlessingMultiplier(girl) {
-        if (!girl.blessingBonuses || typeof girl.blessingBonuses !== 'object')
-            return 1;
-        if (Array.isArray(girl.blessingBonuses) && girl.blessingBonuses.length === 0)
-            return 1;
-        const pvp3 = girl.blessingBonuses.pvp_v3;
-        if (!pvp3 || !pvp3.carac1 || !Array.isArray(pvp3.carac1))
-            return 1;
-        const totalPct = pvp3.carac1.reduce((sum, pct) => sum + pct, 0);
-        return 1 + totalPct / 100;
+    static resolveColor(hex) {
+        if (!hex)
+            return { label: '?', fromRuntime: false };
+        const upper = String(hex).toUpperCase();
+        const runtime = TraitMappings.getRuntimeColorMap();
+        if (runtime && typeof runtime[upper] === 'string') {
+            return { label: runtime[upper], fromRuntime: true };
+        }
+        if (COLOR_FALLBACK_EN[upper]) {
+            return { label: COLOR_FALLBACK_EN[upper], fromRuntime: false };
+        }
+        return { label: '#' + upper, fromRuntime: false };
     }
     /**
-     * Score a girl for "Current Best" mode.
-     * Base stats from the API do NOT include blessing bonuses.
-     * We must apply the blessing multiplier manually.
+     * Resolve a position image (e.g. "2.png" or "2") to a readable label.
+     * Falls back to "Pose N" when runtime map is unavailable.
      */
-    static scoreCurrentBest(girl) {
-        const baseStats = TeamScoringService.getStatSum(girl);
-        const blessingMultiplier = TeamScoringService.getBlessingMultiplier(girl);
-        return baseStats * blessingMultiplier;
+    static resolvePosition(value) {
+        if (!value)
+            return { label: '?', fromRuntime: false };
+        const num = String(value).replace(/\.png$/i, '').trim();
+        const runtime = TraitMappings.getRuntimeFigureMap();
+        if (runtime && typeof runtime[num] === 'string') {
+            return { label: runtime[num], fromRuntime: true };
+        }
+        return { label: POSITION_FALLBACK_PREFIX + num, fromRuntime: false };
     }
     /**
-     * Score a girl for "Best Possible" mode.
-     * Projects stats to max level and full grades, then applies blessing bonus.
-     *
-     * Formula:
-     *   potential = baseStats / level x playerLevel / (1 + 0.3 x currentGrades) x (1 + 0.3 x maxGrades)
-     *   final = potential x blessingMultiplier
+     * Resolve a zodiac string (e.g. unicode-glyph + " Aries") to a readable name.
+     * Strips the unicode glyph prefix and returns just the English name.
      */
-    static scoreBestPossible(girl, playerLevel) {
-        const currentStats = TeamScoringService.getStatSum(girl);
-        const level = girl.level || 1;
-        const currentGrades = girl.graded || 0;
-        const maxGrades = girl.nb_grades || 0;
-        const levelFactor = playerLevel / Math.max(level, 1);
-        const gradeDeflator = 1 + 0.3 * currentGrades;
-        const gradeInflator = 1 + 0.3 * maxGrades;
-        const projected = (currentStats * levelFactor / gradeDeflator) * gradeInflator;
-        const blessingMultiplier = TeamScoringService.getBlessingMultiplier(girl);
-        return Math.max(projected * blessingMultiplier, currentStats * blessingMultiplier);
+    static resolveZodiac(value) {
+        if (!value)
+            return { label: '?', fromRuntime: false };
+        // Strip leading non-letter characters (glyph + variation selector + space)
+        const cleaned = String(value).replace(/^[^A-Za-z]+/, '').trim();
+        return { label: cleaned || String(value), fromRuntime: false };
     }
     /**
-     * Filter girls: only Mythic and Legendary (both modes).
+     * Generic resolver: dispatch by trait category.
      */
-    static filterHighRarity(girls) {
-        return girls.filter(g => {
-            if (g.rarity === 'mythic')
-                return true;
-            if (g.rarity === 'legendary')
-                return g.nb_grades >= 5;
-            return false;
-        });
-    }
-    /**
-     * Get the Tier-5 skill info for a given element.
-     */
-    static getTier5Skill(element) {
-        return ELEMENT_TO_TIER5[element];
-    }
-    // ─── Trait / Tier 3 Logic ─────────────────────────────────────────
-    /**
-     * Get the trait category for a girl based on her element.
-     */
-    static getTraitCategory(element) {
-        return ELEMENT_TO_TRAIT_CATEGORY[element];
-    }
-    /**
-     * Get the trait value for a girl based on her element's trait category.
-     * Returns undefined if the trait data is not available.
-     */
-    static getTraitValue(girl) {
-        const category = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
+    static resolve(category, value) {
         switch (category) {
-            case 'eyeColor': return girl.eyeColor;
-            case 'hairColor': return girl.hairColor;
-            case 'zodiac': return girl.zodiac;
-            case 'position': return girl.position;
+            case 'eyeColor':
+            case 'hairColor':
+                return TraitMappings.resolveColor(value);
+            case 'zodiac':
+                return TraitMappings.resolveZodiac(value);
+            case 'position':
+                return TraitMappings.resolvePosition(value);
         }
-    }
-    /**
-     * Calculate the total Tier 3 bonus percentage for a team.
-     *
-     * Each girl checks how many teammates share her element pair's trait value.
-     * Mythic: 1.0% per matching teammate, Legendary: 0.8% per matching teammate.
-     * The bonus is calculated per girl and summed for the team total.
-     */
-    static calculateTier3TeamBonus(team) {
-        let totalBonus = 0;
-        for (const girl of team) {
-            const category = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
-            const myValue = TeamScoringService.getTraitValue(girl);
-            if (!myValue)
-                continue;
-            let matchCount = 0;
-            for (const teammate of team) {
-                if (teammate.id_girl === girl.id_girl)
-                    continue;
-                const teammateCategory = ELEMENT_TO_TRAIT_CATEGORY[teammate.element];
-                if (teammateCategory !== category)
-                    continue;
-                const teammateValue = TeamScoringService.getTraitValue(teammate);
-                if (teammateValue === myValue) {
-                    matchCount++;
-                }
-            }
-            const bonusPerMatch = girl.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
-            totalBonus += matchCount * bonusPerMatch;
-        }
-        return totalBonus;
-    }
-    /**
-     * Detect which trait categories are currently blessed by analyzing
-     * blessing_bonuses across all girls. Returns a set of blessed TraitCategories.
-     */
-    static detectBlessedTraits(girls) {
-        const blessedCategories = new Set();
-        let blessedGirlCount = 0;
-        for (const girl of girls) {
-            if (!girl.blessingBonuses)
-                continue;
-            const bonuses = girl.blessingBonuses;
-            if (typeof bonuses !== 'object')
-                continue;
-            let hasBlessing = false;
-            for (const key of Object.keys(bonuses)) {
-                const lk = key.toLowerCase();
-                if (lk.includes('zodiac') || lk.includes('sign') || lk.includes('astro')) {
-                    blessedCategories.add('zodiac');
-                    hasBlessing = true;
-                }
-                if (lk.includes('hair') || lk.includes('cheveu')) {
-                    blessedCategories.add('hairColor');
-                    hasBlessing = true;
-                }
-                if (lk.includes('eye') || lk.includes('yeux') || lk.includes('oeil')) {
-                    blessedCategories.add('eyeColor');
-                    hasBlessing = true;
-                }
-                if (lk.includes('position') || lk.includes('pose') || lk.includes('favourite_position')) {
-                    blessedCategories.add('position');
-                    hasBlessing = true;
-                }
-            }
-            if (!hasBlessing) {
-                for (const val of Object.values(bonuses)) {
-                    if (typeof val === 'number' && val > 0) {
-                        hasBlessing = true;
-                        break;
-                    }
-                }
-            }
-            if (hasBlessing)
-                blessedGirlCount++;
-        }
-        return { blessedCategories, blessedGirlCount };
-    }
-    /**
-     * Find all possible trait groups from a pool of girls.
-     *
-     * For each element pair, groups girls by their shared trait value
-     * and scores each group. Position groups receive a penalty.
-     * Groups matching a currently blessed trait receive a bonus.
-     *
-     * Returns groups sorted by score descending.
-     */
-    static findTraitGroups(girls, blessedCategories, blessedValues) {
-        const results = [];
-        for (const pair of ELEMENT_PAIRS) {
-            const pairGirls = girls.filter(g => pair.elements.includes(g.element));
-            if (pairGirls.length === 0)
-                continue;
-            // Group by trait value
-            const groups = new Map();
-            for (const girl of pairGirls) {
-                const value = TeamScoringService.getTraitValue(girl);
-                if (!value)
-                    continue;
-                if (!groups.has(value))
-                    groups.set(value, []);
-                groups.get(value).push(girl);
-            }
-            for (const [traitValue, groupGirls] of groups) {
-                // Use blessed stats (includes blessing multiplier) for fair comparison
-                const avgStats = groupGirls.reduce((sum, g) => sum + TeamScoringService.scoreCurrentBest(g), 0) / groupGirls.length;
-                let score = groupGirls.length * avgStats;
-                // Position trait penalty (reduces attack stats via equipment)
-                if (pair.trait === 'position') {
-                    score *= POSITION_TRAIT_PENALTY;
-                }
-                // Blessing boost: only boost the specific group that matches the blessed value.
-                // blessedValues maps category -> hex code (resolved at runtime from girl data).
-                if (blessedCategories && blessedCategories.has(pair.trait)) {
-                    const blessedHex = blessedValues === null || blessedValues === void 0 ? void 0 : blessedValues[pair.trait];
-                    if (blessedHex && traitValue === blessedHex) {
-                        // Exact match: this is THE blessed group
-                        score *= 2.0;
-                    }
-                    else if (!blessedHex) {
-                        // Fallback: could not resolve hex, boost entire category (old behavior)
-                        score *= 1.5;
-                    }
-                    // If blessedHex exists but doesn't match: no boost (intentional)
-                }
-                results.push({
-                    traitCategory: pair.trait,
-                    traitValue,
-                    girls: groupGirls,
-                    score,
-                });
-            }
-        }
-        return results.sort((a, b) => b.score - a.score);
-    }
-    // ─── Synergy Calculations (secondary factor) ─────────────────────
-    /**
-     * Calculate synergy bonuses for a set of elements (one per team member).
-     */
-    static calculateSynergies(elements) {
-        const synergies = {
-            critDamage: 0,
-            healOnHit: 0,
-            ego: 0,
-            critChance: 0,
-            defReduce: 0,
-            damage: 0,
-            defense: 0,
-            harmony: 0,
-        };
-        for (const element of elements) {
-            const mapping = ELEMENT_SYNERGY_PER_GIRL[element];
-            if (mapping) {
-                synergies[mapping.field] += mapping.bonus;
-            }
-        }
-        return synergies;
-    }
-    /**
-     * Calculate a numeric "synergy value" for a team composition.
-     * Weighs each synergy type by its combat impact.
-     */
-    static calculateSynergyValue(elements) {
-        const syn = TeamScoringService.calculateSynergies(elements);
-        return (syn.critDamage * 1.0 +
-            syn.critChance * 2.0 +
-            syn.defReduce * 2.0 +
-            syn.healOnHit * 1.5 +
-            syn.damage * 1.5 +
-            syn.ego * 1.0 +
-            syn.defense * 1.0 +
-            syn.harmony * 1.0);
-    }
-    /**
-     * Score a girl's contribution to a team, considering both stats and
-     * the synergy bonus she adds. Used as tiebreaker when filling remaining slots.
-     */
-    static scoreWithSynergy(girl, teamElements, statScore, maxStatInPool, synergyWeight = 0.05) {
-        const currentSynergyValue = TeamScoringService.calculateSynergyValue(teamElements);
-        const newSynergyValue = TeamScoringService.calculateSynergyValue([...teamElements, girl.element]);
-        const synergyDelta = newSynergyValue - currentSynergyValue;
-        const normalizedSynergyBonus = maxStatInPool > 0
-            ? (synergyDelta / maxStatInPool) * maxStatInPool
-            : 0;
-        return statScore + synergyWeight * normalizedSynergyBonus;
-    }
-    // ─── Tier 3 Delta Estimation ────────────────────────────────────
-    /**
-     * Estimate the stat-equivalent value of adding a candidate to the team,
-     * considering the marginal Tier 3 bonus she would provide.
-     *
-     * Returns 0 if the candidate does not match the target trait.
-     * Otherwise returns marginalPct × teamStatTotal, where marginalPct
-     * accounts for both the new girl's bonus and the boost to existing
-     * trait teammates.
-     */
-    static estimateTier3Delta(candidate, currentTeam, traitCategory, traitValue, teamStatTotal) {
-        const candidateCategory = ELEMENT_TO_TRAIT_CATEGORY[candidate.element];
-        if (candidateCategory !== traitCategory)
-            return 0;
-        const candidateValue = TeamScoringService.getTraitValue(candidate);
-        if (candidateValue !== traitValue)
-            return 0;
-        // Count existing trait-matching teammates and sum their bonus rates
-        let existingTraitCount = 0;
-        let existingBoostSum = 0;
-        for (const member of currentTeam) {
-            const memberCategory = ELEMENT_TO_TRAIT_CATEGORY[member.element];
-            if (memberCategory !== traitCategory)
-                continue;
-            const memberValue = TeamScoringService.getTraitValue(member);
-            if (memberValue !== traitValue)
-                continue;
-            existingTraitCount++;
-            existingBoostSum += member.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
-        }
-        // New girl sees existingTraitCount matches
-        const candidateBonusRate = candidate.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
-        const newGirlBonus = existingTraitCount * candidateBonusRate;
-        // Each existing trait teammate gains +1 match from this girl
-        const existingBoost = existingBoostSum;
-        const marginalPct = newGirlBonus + existingBoost;
-        return marginalPct * teamStatTotal;
-    }
-    // ─── Leader Selection ────────────────────────────────────────────
-    /**
-     * Rank leader candidates by element priority (Shield > Stun > Execute > Reflect).
-     * Leader must be Mythic. Among same priority: prefer trait match, then highest stats.
-     *
-     * @param traitCategory - The team's chosen trait category
-     * @param traitValue    - The team's chosen trait value
-     */
-    static rankLeaderCandidates(girls, statScores, traitCategory, traitValue) {
-        // Only Mythic girls can be leaders
-        const mythicGirls = girls.filter(g => g.rarity === 'mythic');
-        if (mythicGirls.length === 0) {
-            // Fallback: allow all girls if no mythics available
-            return TeamScoringService._sortLeaderCandidates(girls, statScores, traitCategory, traitValue);
-        }
-        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue);
-    }
-    static _sortLeaderCandidates(girls, statScores, traitCategory, traitValue) {
-        return [...girls].sort((a, b) => {
-            // Primary: trait match (does the leader match the team's trait?)
-            if (traitCategory && traitValue) {
-                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
-                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
-                if (aMatches !== bMatches) {
-                    return aMatches ? -1 : 1;
-                }
-            }
-            // Secondary: stat score (includes blessing multiplier)
-            const scoreA = statScores.get(a.id_girl) || 0;
-            const scoreB = statScores.get(b.id_girl) || 0;
-            return scoreB - scoreA;
-        });
-    }
-    /**
-     * Check if a leader candidate matches the team's trait.
-     * The leader's own element determines her trait category —
-     * she only matches if her element uses the same trait category as the team.
-     */
-    static _leaderMatchesTrait(girl, teamTraitCategory, teamTraitValue) {
-        const girlCategory = ELEMENT_TO_TRAIT_CATEGORY[girl.element];
-        if (girlCategory !== teamTraitCategory)
-            return false;
-        const girlValue = TeamScoringService.getTraitValue(girl);
-        return girlValue === teamTraitValue;
-    }
-}
-
-;// CONCATENATED MODULE: ./src/Service/TeamBuilderService.ts
-// TeamBuilderService.ts -- Builds optimal 7-girl teams.
-//
-// Simple logic:
-//   1. Score all girls (base stats * blessing multiplier - equipment)
-//   2. Take top 7 by score
-//   3. Tiebreaker: prefer element clusters (Tier-3 bonus)
-//   4. Leader: highest-score Mythic girl
-
-
-
-const TEAM_SIZE = 7;
-const SAME_STAT_THRESHOLD = 100; // Girls within 100 points are considered equal
-class TeamBuilderService {
-    /**
-     * Build the optimal team: simply the 7 strongest girls.
-     * At equal stats, prefer element clusters for Tier-3 bonus.
-     */
-    static buildTeam(allGirls, mode, playerLevel) {
-        // Phase 1: Filter to Mythic + Legendary only
-        const candidates = TeamScoringService.filterHighRarity(allGirls);
-        if (candidates.length < TEAM_SIZE)
-            return null;
-        // Phase 2: Score all candidates (stats * blessing multiplier - equipment)
-        const scoreMap = new Map();
-        for (const girl of candidates) {
-            const score = mode === 1
-                ? TeamScoringService.scoreCurrentBest(girl)
-                : TeamScoringService.scoreBestPossible(girl, playerLevel);
-            scoreMap.set(girl.id_girl, score);
-        }
-        // Sort by score descending
-        const sorted = [...candidates].sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-        // Log top girls
-        if (sorted.length >= 10) {
-            LogUtils_logHHAuto('TeamBuilder: top 10 by score: ' + sorted.slice(0, 10).map(g => g.name + '(' + Math.round(scoreMap.get(g.id_girl) || 0) + ',' + g.element + ',bls=' + TeamScoringService.getBlessingMultiplier(g).toFixed(2) + ')').join(', '));
-        }
-        // Phase 3: Select top 7 with element-cluster tiebreaker
-        const team = TeamBuilderService._selectWithCluster(sorted, scoreMap);
-        if (team.length < TEAM_SIZE)
-            return null;
-        // Phase 4: Choose leader (highest-score Mythic in team)
-        const leaderIdx = TeamBuilderService._pickLeader(team, scoreMap);
-        if (leaderIdx > 0) {
-            // Move leader to position 0
-            const leader = team.splice(leaderIdx, 1)[0];
-            team.unshift(leader);
-        }
-        // Phase 5: Build result
-        const teamElements = team.map(g => g.element);
-        const statScores = team.map(g => scoreMap.get(g.id_girl) || 0);
-        const power = Math.round(statScores.reduce((s, v) => s + v, 0));
-        const synergyValue = TeamScoringService.calculateSynergyValue(teamElements);
-        const leaderTier5 = TeamScoringService.getTier5Skill(team[0].element);
-        const tier3Bonus = TeamScoringService.calculateTier3TeamBonus(team);
-        // Detect blessed info for display
-        const cachedBlessing = BlessingService.getCached();
-        const blessedTraits = (cachedBlessing === null || cachedBlessing === void 0 ? void 0 : cachedBlessing.blessedTraits) || [];
-        const blessedGirlCount = candidates.filter(g => { var _a, _b, _c; return ((_c = (_b = (_a = g.blessingBonuses) === null || _a === void 0 ? void 0 : _a.pvp_v3) === null || _b === void 0 ? void 0 : _b.carac1) === null || _c === void 0 ? void 0 : _c.length) > 0; }).length;
-        // Find dominant trait in team for display
-        const { traitCategory, traitValue, traitMatchCount } = TeamBuilderService._findDominantTrait(team);
-        LogUtils_logHHAuto('TeamBuilder: team power = ' + power + ', leader = ' + team[0].name +
-            ' (' + team[0].element + '), elements: ' + teamElements.join(',') +
-            ', tier3 = ' + (tier3Bonus * 100).toFixed(1) + '%');
-        LogUtils_logHHAuto('TeamBuilder: team: ' + team.map(g => g.name + '(' + Math.round(scoreMap.get(g.id_girl) || 0) + ',' + g.element + ')').join(', '));
-        return {
-            girls: team,
-            statScores,
-            synergyValue,
-            leaderTier5,
-            elements: teamElements,
-            traitCategory,
-            traitValue,
-            tier3Bonus,
-            traitMatchCount,
-            blessedCategories: blessedTraits,
-            blessedGirlCount,
-            effectivePower: power,
-            alternatives: [],
-        };
-    }
-    /**
-     * Select top 7 girls with element-cluster optimization at equal stats.
-     * Girls with clearly higher stats always win. Among equal-stat girls,
-     * prefer those that form the largest element cluster.
-     */
-    static _selectWithCluster(sorted, scoreMap) {
-        if (sorted.length <= TEAM_SIZE)
-            return sorted.slice(0, TEAM_SIZE);
-        const topScore = scoreMap.get(sorted[0].id_girl) || 0;
-        const team = [];
-        // Separate into tiers: girls clearly above others go in first
-        let i = 0;
-        while (i < sorted.length && team.length < TEAM_SIZE) {
-            // Find the end of this stat tier (all girls within SAME_STAT_THRESHOLD)
-            const tierScore = scoreMap.get(sorted[i].id_girl) || 0;
-            let tierEnd = i;
-            while (tierEnd < sorted.length &&
-                Math.abs((scoreMap.get(sorted[tierEnd].id_girl) || 0) - tierScore) < SAME_STAT_THRESHOLD) {
-                tierEnd++;
-            }
-            const tierGirls = sorted.slice(i, tierEnd);
-            const slotsLeft = TEAM_SIZE - team.length;
-            if (tierGirls.length <= slotsLeft) {
-                // All girls in this tier fit, take them all
-                team.push(...tierGirls);
-            }
-            else {
-                // More girls than slots: pick by element cluster
-                const picked = TeamBuilderService._pickByCluster(tierGirls, slotsLeft, team);
-                team.push(...picked);
-            }
-            i = tierEnd;
-        }
-        return team;
-    }
-    /**
-     * From a group of equal-stat girls, pick the ones that maximize element clusters.
-     * Consider already-selected team members for cluster building.
-     */
-    static _pickByCluster(candidates, slots, currentTeam) {
-        // Count elements already in team
-        const elementCounts = new Map();
-        for (const g of currentTeam) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-        // Count elements available in candidates
-        const candidateElements = new Map();
-        for (const g of candidates) {
-            if (!candidateElements.has(g.element))
-                candidateElements.set(g.element, []);
-            candidateElements.get(g.element).push(g);
-        }
-        // Score each candidate by how much they contribute to a cluster
-        const scored = candidates.map(g => {
-            var _a;
-            const currentCount = elementCounts.get(g.element) || 0;
-            // Prefer elements that already have members (builds cluster)
-            // or elements with many candidates available (can build new cluster)
-            const availableCount = ((_a = candidateElements.get(g.element)) === null || _a === void 0 ? void 0 : _a.length) || 0;
-            const clusterScore = currentCount * 10 + availableCount;
-            // Mythic tiebreaker
-            const rarityBonus = g.rarity === 'mythic' ? 1000 : 0;
-            return { girl: g, score: clusterScore + rarityBonus };
-        });
-        // Sort by cluster score descending, pick top N
-        scored.sort((a, b) => b.score - a.score);
-        return scored.slice(0, slots).map(s => s.girl);
-    }
-    /**
-     * Pick the leader: highest-score Mythic girl in the team.
-     * Among equal Mythics, prefer the one in the largest element cluster.
-     */
-    static _pickLeader(team, scoreMap) {
-        let bestIdx = 0;
-        let bestScore = -1;
-        const elementCounts = new Map();
-        for (const g of team) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-        for (let i = 0; i < team.length; i++) {
-            const g = team[i];
-            if (g.rarity !== 'mythic')
-                continue;
-            const score = scoreMap.get(g.id_girl) || 0;
-            const clusterSize = elementCounts.get(g.element) || 0;
-            // Compare: higher stats win, then larger cluster
-            const composite = score * 1000 + clusterSize;
-            if (composite > bestScore) {
-                bestScore = composite;
-                bestIdx = i;
-            }
-        }
-        return bestIdx;
-    }
-    /**
-     * Find the dominant trait in the team for display purposes.
-     */
-    static _findDominantTrait(team) {
-        // Count element occurrences to find dominant element pair
-        const elementCounts = new Map();
-        for (const g of team) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-        // Find most common element
-        let bestElement = team[0].element;
-        let bestCount = 0;
-        for (const [el, count] of elementCounts) {
-            if (count > bestCount) {
-                bestCount = count;
-                bestElement = el;
-            }
-        }
-        const traitCategory = TeamScoringService.getTraitCategory(bestElement);
-        // Find most common trait value among team members of that category
-        const traitValues = new Map();
-        for (const g of team) {
-            if (TeamScoringService.getTraitCategory(g.element) === traitCategory) {
-                const val = TeamScoringService.getTraitValue(g);
-                if (val)
-                    traitValues.set(val, (traitValues.get(val) || 0) + 1);
-            }
-        }
-        let traitValue = '';
-        let traitMatchCount = 0;
-        for (const [val, count] of traitValues) {
-            if (count > traitMatchCount) {
-                traitMatchCount = count;
-                traitValue = val;
-            }
-        }
-        return { traitCategory, traitValue, traitMatchCount };
-    }
-    /**
-     * Get a summary of element distribution in the team.
-     */
-    static getElementDistribution(team) {
-        const counts = new Map();
-        for (const el of team.elements) {
-            counts.set(el, (counts.get(el) || 0) + 1);
-        }
-        return Array.from(counts.entries())
-            .map(([element, count]) => ({ element, count }))
-            .sort((a, b) => b.count - a.count);
     }
 }
 
@@ -17884,6 +17822,7 @@ class TeamBuilderService {
 //
 // Used by: League.ts, Troll.ts, Labyrinth.ts, Season.ts, and other fight modules
 //
+
 
 
 
@@ -18283,6 +18222,8 @@ class TeamModule {
     }
     static setTopTeamV2(mode, availableGirls) {
         const playerLevel = Number(HeroHelper.getLevel());
+        const rawClass = Number(HeroHelper.getClass());
+        const playerClass = (rawClass === 1 || rawClass === 2 || rawClass === 3) ? rawClass : 1;
         // Map availableGirls to GirlData interface
         const girls = availableGirls.map(g => {
             var _a;
@@ -18293,6 +18234,7 @@ class TeamModule {
                 carac2: Number(g.carac2 || 0),
                 carac3: Number(g.carac3 || 0),
                 level: Number(g.level || 1),
+                class: typeof g.class === 'number' ? g.class : undefined,
                 element: (((_a = g.element_data) === null || _a === void 0 ? void 0 : _a.type) || g.element || 'fire'),
                 rarity: (g.rarity || 'common'),
                 graded: Number(g.graded || 0),
@@ -18303,15 +18245,15 @@ class TeamModule {
                     carac3: Number(g.caracs.carac3 || 0),
                 } : undefined,
                 skill_tiers_info: g.skill_tiers_info,
-                zodiac: g.zodiac ? g.zodiac.substring(3).trim() : undefined,
+                // Keep raw zodiac glyph; TraitMappings.resolveZodiac strips it for display
+                zodiac: g.zodiac || undefined,
                 hairColor: g.hair_color1 || undefined,
                 eyeColor: g.eye_color1 || undefined,
                 position: g.position_img ? String(g.position_img).replace('.png', '') : undefined,
                 blessingBonuses: g.blessing_bonuses || undefined,
-                armor: g.armor || undefined,
             });
         });
-        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel);
+        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel, playerClass);
         if (!result) {
             LogUtils_logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
             TeamModule.setTopTeamLegacy(mode);
@@ -18385,7 +18327,7 @@ class TeamModule {
         TeamModule.updateTeamUI(deckID);
     }
     static updateTeamUI(deckID, teamResult) {
-        var _a, _b;
+        var _a;
         const arr = $('div[id_girl]');
         // Remove all existing topNumber elements to prevent stale entries
         // from a previous team calculation (e.g. Current Best) interfering
@@ -18431,7 +18373,7 @@ class TeamModule {
             newDiv.setAttribute("ondblclick", "window.location.href='/characters/" + deckID[j] + "'");
             mainTeamPanel.append(arrSort[0]);
         }
-        // Show team synergy info panel
+        // Show team selection info panel
         $('.hhTeamSynergyInfo').remove();
         if (teamResult) {
             const dist = TeamBuilderService.getElementDistribution(teamResult);
@@ -18441,40 +18383,53 @@ class TeamModule {
             }).join(', ');
             const traitEmoji = TeamModule.TRAIT_EMOJI[teamResult.traitCategory] || '';
             const tier3Pct = (teamResult.tier3Bonus * 100).toFixed(1);
+            const playerClassName = TeamModule.PLAYER_CLASS_NAME[teamResult.playerClass] || ('class ' + teamResult.playerClass);
+            // Resolve trait value to a human label
+            const traitResolved = TraitMappings.resolve(teamResult.traitCategory, teamResult.traitValue);
+            const traitDisplay = traitResolved.label;
+            const traitFromRuntime = traitResolved.fromRuntime;
             // Use cached blessings from BlessingService (loaded on Home page)
             let cachedBlessings = null;
             try {
                 cachedBlessings = BlessingService.getCached();
             }
-            catch ( /* cache not ready */_c) { /* cache not ready */ }
+            catch ( /* cache not ready */_b) { /* cache not ready */ }
             const blessedVals = (cachedBlessings === null || cachedBlessings === void 0 ? void 0 : cachedBlessings.blessedValues) || {};
             const blessedStr = cachedBlessings && cachedBlessings.blessedTraits.length > 0
-                ? cachedBlessings.blessedTraits.map(c => (TeamModule.TRAIT_EMOJI[c] || '') + ' ' + c + (blessedVals[c] ? '=' + blessedVals[c] : '')).join(', ')
+                ? cachedBlessings.blessedTraits.map((c) => (TeamModule.TRAIT_EMOJI[c] || '') + ' ' + c + (blessedVals[c] ? '=' + blessedVals[c] : '')).join(', ')
                     + (cachedBlessings.blessedElement ? ' + ' + (TeamModule.CLASS_NAME[cachedBlessings.blessedElement] || cachedBlessings.blessedElement) : '')
                 : (cachedBlessings ? 'none parsed (check logs)' : 'not loaded yet (visit Home)');
             const blessedIsActive = cachedBlessings && cachedBlessings.blessedTraits.includes(teamResult.traitCategory);
-            const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && (teamResult.traitValue.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase() ||
-                teamResult.traitValue === (((_a = cachedBlessings === null || cachedBlessings === void 0 ? void 0 : cachedBlessings.blessedValues) === null || _a === void 0 ? void 0 : _a[teamResult.traitCategory]) || ''));
+            const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
+            const altsHtml = teamResult.alternatives && teamResult.alternatives.length > 1
+                ? '<b>Compared:</b> ' + teamResult.alternatives.map((a) => {
+                    const r = TraitMappings.resolve(a.traitCategory, a.traitValue);
+                    return a.traitCategory + '=' + r.label + ' (' + a.effectivePower.toLocaleString() + ')';
+                }).join(' | ')
+                : '';
+            const fallbackNote = traitFromRuntime ? '' : '<div style="color:#fc6; font-size:10px;">Trait label uses fallback dictionary (game runtime not yet loaded -- may be inaccurate for new color codes).</div>';
             const synergyInfo = $(`<div class="hhTeamSynergyInfo" style="
-                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 280px; z-index: 10;
+                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 300px; z-index: 10;
                 background: rgba(0,0,0,0.85); color: #fff; padding: 6px 10px;
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
-                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Why this team was chosen:</div>
-                <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${teamResult.traitValue}" (${teamResult.traitMatchCount}/7 girls match)</div>
+                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+                <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${traitDisplay}" (${teamResult.traitMatchCount}/7 girls match)</div>
                 <div style="color:#aaa; font-size:10px;">Tier 3 gives +stat% per teammate sharing this trait</div>
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Leader:</b> ${teamResult.girls[0].name} (${teamResult.leaderTier5.name} / ${TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element})</div>
                 <div><b>Elements:</b> ${distHtml}</div>
-                <div><b>Effective Power:</b> ${((_b = teamResult.effectivePower) === null || _b === void 0 ? void 0 : _b.toLocaleString()) || 'N/A'}</div>
+                <div><b>Effective Power:</b> ${((_a = teamResult.effectivePower) === null || _a === void 0 ? void 0 : _a.toLocaleString()) || 'N/A'}</div>
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>
                 <div style="color:#aaa; font-size:10px;">${cachedBlessings ? "Cache: " + new Date(cachedBlessings.timestamp).toLocaleString() : "No cache - go to Home page to load"}</div>
-                <div style="color:#aaa; font-size:10px; margin-top:2px;">${teamResult.alternatives && teamResult.alternatives.length > 1 ? '<b>Compared:</b> ' + teamResult.alternatives.map(a => a.traitCategory + '=' + a.traitValue + ' (' + a.effectivePower.toLocaleString() + ')').join(' | ') : ''}</div>
-                <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best): stats already include blessings</div>
-                <div style="color:#aaa; font-size:10px;">Mode 2 (Best Possible): projects to max level/grades</div>
+                ${altsHtml ? `<div style="color:#aaa; font-size:10px; margin-top:2px;">${altsHtml}</div>` : ''}
+                ${fallbackNote}
+                <hr style="border-color:#555; margin:4px 0"/>
+                <div style="color:#fc6; font-size:10px;"><b>Note:</b> Stats are equipment-free. Hit "Stuff Team" after applying.</div>
+                <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best) uses today's stats, Mode 2 (Best Possible) projects to max level / grades.</div>
             </div>`);
             $("#contains_all section").append(synergyInfo);
         }
@@ -18498,6 +18453,11 @@ TeamModule.TRAIT_EMOJI = {
 TeamModule.CLASS_NAME = {
     fire: 'Eccentric', water: 'Sensual', nature: 'Exhibitionist', stone: 'Physical',
     sun: 'Playful', darkness: 'Dominatrix', psychic: 'Submissive', light: 'Voyeur',
+};
+TeamModule.PLAYER_CLASS_NAME = {
+    1: 'Hardcore',
+    2: 'Charm',
+    3: 'Know-how',
 };
 
 ;// CONCATENATED MODULE: ./src/Module/index.ts
@@ -24682,28 +24642,27 @@ const FEATURE_POPUP_CLOSE_LABEL = "OK";
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION = "7.35.20";
+const FEATURE_POPUP_VERSION = "7.35.21";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.20";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.21";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.
  */
 const FEATURE_POPUP_CONTENT = `
   <div style="padding:10px; max-width:520px; color:#333;">
-    <p style="font-size:15px; font-weight:bold; margin-bottom:10px; color:#090;">Repository transfer complete</p>
-    <p style="margin-bottom:10px;">HHAuto now lives at <b style="color:#090;">github.com/OldRon1977/HHauto</b>.</p>
-    <p style="margin-bottom:10px;">The old Roukys/HHauto URL redirects automatically &mdash; no action needed on your side. Tampermonkey picks up updates from the new location. Your settings remain untouched.</p>
-    <p style="margin-bottom:6px;"><b>What's new in v7.35.20:</b></p>
+    <p style="font-size:15px; font-weight:bold; margin-bottom:10px; color:#090;">League team algorithm rebuilt</p>
+    <p style="margin-bottom:6px;"><b>What's new in v7.35.21:</b></p>
     <ul style="margin-bottom:10px; font-size:12px;">
-      <li>Team selection: blessing boost now works correctly (hex color codes no longer break matching)</li>
-      <li>Info box shows "#A55" instead of raw hex when no blessing name is available</li>
+      <li>Team selection now scores by your <b>main class stat</b> (HC=carac1, Charm=carac2, KH=carac3) instead of the raw stat sum</li>
+      <li>Hard class filter: only girls of your own class are considered &mdash; cross-class never wins</li>
+      <li>Trait clusters are compared by main_sum &times; (1 + tier3 bonus) &mdash; the actual game power, not heuristics</li>
+      <li>Position-trait penalty and synergy tiebreaker are gone &mdash; the new scoring captures it correctly</li>
+      <li>Info box shows readable trait names ("Blue", "Doggy") instead of hex codes ("00F", "2.png"), pulled live from the game UI</li>
+      <li>New note: stats are equipment-free &mdash; hit "Stuff Team" after applying</li>
     </ul>
-    <p style="margin-bottom:15px; font-size:13px;">
-      Thanks to <b>Roukys</b> for hosting HHAuto for so many years, and to <b>deuxge</b> for maintaining it!
-    </p>
     <p style="margin-bottom:0; font-size:11px; color:#888;">This popup will be deactivated in the next version.</p>
   </div>
 `;

--- a/HHAuto_debug_inspector.user.js
+++ b/HHAuto_debug_inspector.user.js
@@ -1,0 +1,1012 @@
+// ==UserScript==
+// @name         HHAuto Debug - Full Data Inspector
+// @namespace    HHAuto_Debug
+// @version      4.5.0
+// @description  Full game data dumper. Works in both iframe and top-window mode. Auto-tour with persistent state across page reloads. Manual phase for protected pages.
+// @match        http*://*.haremheroes.com/*
+// @match        http*://*.hentaiheroes.com/*
+// @match        http*://*.gayharem.com/*
+// @match        http*://*.comixharem.com/*
+// @match        http*://*.hornyheroes.com/*
+// @match        http*://*.pornstarharem.com/*
+// @match        http*://*.transpornstarharem.com/*
+// @match        http*://*.gaypornstarharem.com/*
+// @match        http*://*.mangarpg.com/*
+// @match        http*://*.amouragent.com/*
+// @grant        unsafeWindow
+// @grant        GM_xmlhttpRequest
+// @run-at       document-idle
+// @noframes
+// ==/UserScript==
+
+(function() {
+    'use strict';
+
+    const VERSION = '4.5.0';
+    const LOG_PREFIX = '[Inspector v' + VERSION + ']';
+
+    // ==================== CONFIGURATION ====================
+
+    const AUTO_TOUR = [
+        { path: '/home.html',               label: 'Home',              expected: 'home' },
+        { path: '/leagues.html',            label: 'League',            expected: 'leaderboard' },
+        { path: '/season-arena.html',       label: 'SeasonArena',       expected: 'season_arena' },
+        { path: '/penta-drill-arena.html',  label: 'PentaDrillArena',   expected: 'penta_drill_arena' },
+        { path: '/penta-drill.html',        label: 'PentaDrill',        expected: 'penta_drill' },
+        { path: '/labyrinth.html',          label: 'Labyrinth',         expected: 'labyrinth' },
+        { path: '/labyrinth-entrance.html', label: 'LabyrinthEntrance', expected: 'labyrinth-entrance' },
+        { path: '/club-champion.html',      label: 'ClubChampion',      expected: 'club_champion' },
+        { path: '/champions-map.html',      label: 'ChampionsMap',      expected: 'champions_map' },
+        { path: '/shop.html',               label: 'Shop',              expected: 'shop' },
+        { path: '/clubs.html',              label: 'Clubs',             expected: 'clubs' },
+        { path: '/pantheon.html',           label: 'Pantheon',          expected: 'pantheon' },
+        { path: '/season.html',             label: 'Season',            expected: 'season' },
+        { path: '/event.html',              label: 'Event',             expected: 'event' },
+        { path: '/seasonal.html',           label: 'Seasonal',          expected: 'seasonal' },
+        { path: '/path-of-glory.html',      label: 'PathOfGlory',       expected: 'path-of-glory' },
+        { path: '/path-of-valor.html',      label: 'PathOfValor',       expected: 'path-of-valor' },
+        { path: '/pachinko.html',           label: 'Pachinko',          expected: 'pachinko' },
+        { path: '/map.html',                label: 'Map',               expected: 'map' },
+        { path: '/waifu.html',              label: 'Waifu',             expected: 'waifu' },
+        { path: '/activities.html',                  label: 'Activities',          expected: 'activities' },
+        { path: '/activities.html?tab=contests',     label: 'ActContests',         expected: 'activities' },
+        { path: '/activities.html?tab=missions',     label: 'ActMissions',         expected: 'activities' },
+        { path: '/activities.html?tab=daily_goals',  label: 'ActDailyGoals',       expected: 'activities' },
+        { path: '/activities.html?tab=pop',          label: 'ActPoP',              expected: 'activities' },
+        { path: '/hero/profile.html',       label: 'HeroProfile',       expected: 'hero_pages' },
+        { path: '/member-progression.html', label: 'MemberProgression', expected: 'member-progression' }
+    ];
+
+    const MANUAL_TOUR = [
+        { path: '/teams.html',              label: 'BattleTeams',       expected: 'teams' },
+        { path: '/edit-team.html',          label: 'EditTeam',          expected: 'edit-team' },
+        { path: '/characters.html',         label: 'Harem',             expected: 'harem' },
+        { path: '/path-of-attraction.html', label: 'PathOfAttraction',  expected: 'path_of_attraction' },
+        { path: '/sex-god-path.html',       label: 'SexGodPath',        expected: 'sex-god-path' },
+        { path: '/love-raids.html',         label: 'LoveRaids',         expected: 'love_raids' }
+    ];
+
+    const STATE_KEY = 'hhauto_inspector_state';
+    const RESULT_KEY_PREFIX = 'hhauto_inspector_result_';
+    const PAGE_LOAD_WAIT_MS = 8000;     // wait for body[page] to match
+    const POST_LOAD_SETTLE_MS = 1500;   // extra wait after match for late-binding JS
+    const PAGE_TRANSITION_DELAY_MS = 800;
+
+    // ==================== STORAGE ====================
+
+    function saveState(state) {
+        try { localStorage.setItem(STATE_KEY, JSON.stringify(state)); }
+        catch (e) { console.error(LOG_PREFIX, 'saveState failed:', e); }
+    }
+
+    function loadState() {
+        try {
+            const raw = localStorage.getItem(STATE_KEY);
+            return raw ? JSON.parse(raw) : null;
+        } catch (e) { return null; }
+    }
+
+    function clearState() {
+        // Remove inspector state and any leftover result entries (including from old versions
+        // that stored full dumps in localStorage - they can fill up the quota).
+        try { localStorage.removeItem(STATE_KEY); } catch (e) {}
+        // Clean up by prefix to also remove orphaned keys from previous tour runs
+        try {
+            const keysToRemove = [];
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k && (k.startsWith(RESULT_KEY_PREFIX) || k === 'hhauto_last_tour' || k === 'hhauto_inspector_overlay')) {
+                    keysToRemove.push(k);
+                }
+            }
+            for (const k of keysToRemove) {
+                try { localStorage.removeItem(k); } catch (e) {}
+            }
+            console.log(LOG_PREFIX, 'Cleared', keysToRemove.length, 'inspector storage keys');
+        } catch (e) { console.warn(LOG_PREFIX, 'clearState scan failed:', e); }
+    }
+
+    // No localStorage results - each step downloads its own file immediately.
+    // Only the tour state (current index, started timestamp) is persisted.
+    async function saveResult(idx, dump, step) {
+        try {
+            // Serialize through safeStringify (drops DOM/Window/circular refs) so that
+            // IndexedDB's structured clone never sees an unsupported object.
+            const text = safeStringify(dump);
+            const cleanDump = JSON.parse(text);
+            await idbPut(idx, cleanDump);
+            return { ok: true, size: text.length };
+        } catch (e) {
+            console.error(LOG_PREFIX, 'idbPut failed at idx ' + idx + ':', e);
+            return { ok: false, size: 0, error: e.message || String(e) };
+        }
+    }
+
+    function loadAllResults() {
+        return [];
+    }
+
+    // ==================== IndexedDB result store ====================
+    // Each step writes its dump to IndexedDB. Quota is per-origin and ~50% of free disk
+    // space - effectively unlimited for our 5-50 MB tour bundles.
+
+    const IDB_NAME = 'hhauto_inspector';
+    const IDB_VERSION = 1;
+    const IDB_STORE = 'tour_results';
+
+    function idbOpen() {
+        return new Promise(function(resolve, reject) {
+            try {
+                const req = indexedDB.open(IDB_NAME, IDB_VERSION);
+                req.onupgradeneeded = function(e) {
+                    const db = e.target.result;
+                    if (!db.objectStoreNames.contains(IDB_STORE)) {
+                        db.createObjectStore(IDB_STORE, { keyPath: 'idx' });
+                    }
+                };
+                req.onsuccess = function(e) { resolve(e.target.result); };
+                req.onerror = function(e) { reject(e.target.error); };
+            } catch (e) { reject(e); }
+        });
+    }
+
+    function idbPut(idx, dump) {
+        return idbOpen().then(function(db) {
+            return new Promise(function(resolve, reject) {
+                const tx = db.transaction(IDB_STORE, 'readwrite');
+                const store = tx.objectStore(IDB_STORE);
+                const req = store.put({ idx: idx, dump: dump });
+                req.onsuccess = function() { resolve(); };
+                req.onerror = function(e) { reject(e.target.error); };
+            }).finally(function() { db.close(); });
+        });
+    }
+
+    function idbGetAll() {
+        return idbOpen().then(function(db) {
+            return new Promise(function(resolve, reject) {
+                const tx = db.transaction(IDB_STORE, 'readonly');
+                const store = tx.objectStore(IDB_STORE);
+                const req = store.getAll();
+                req.onsuccess = function(e) {
+                    const rows = e.target.result || [];
+                    rows.sort(function(a, b) { return a.idx - b.idx; });
+                    resolve(rows);
+                };
+                req.onerror = function(e) { reject(e.target.error); };
+            }).finally(function() { db.close(); });
+        });
+    }
+
+    function idbClear() {
+        return idbOpen().then(function(db) {
+            return new Promise(function(resolve, reject) {
+                const tx = db.transaction(IDB_STORE, 'readwrite');
+                const store = tx.objectStore(IDB_STORE);
+                const req = store.clear();
+                req.onsuccess = function() { resolve(); };
+                req.onerror = function(e) { reject(e.target.error); };
+            }).finally(function() { db.close(); });
+        });
+    }
+
+        // ==================== HELPERS ====================
+
+    function safeStringify(obj) {
+        const seen = new WeakSet();
+        function replacer(key, value) {
+            if (typeof value === 'function') return '[function]';
+            if (typeof value === 'undefined') return '[undefined]';
+            if (value instanceof Error) return '[Error: ' + value.message + ']';
+            if (value && typeof value === 'object') {
+                if (seen.has(value)) return '[circular]';
+                seen.add(value);
+                if (value.nodeType !== undefined && value.nodeName !== undefined) return '[DOM:' + value.nodeName + ']';
+                try {
+                    if (typeof Window !== 'undefined' && value instanceof Window) return '[Window]';
+                    if (typeof Document !== 'undefined' && value instanceof Document) return '[Document]';
+                } catch (e) {}
+            }
+            return value;
+        }
+        try { return JSON.stringify(obj, replacer, 2); }
+        catch (e) { return '[stringify error: ' + e.message + ']'; }
+    }
+
+    function tryGet(fn, fallback) {
+        try { return fn(); } catch (e) { return fallback === undefined ? null : fallback; }
+    }
+
+    function isPlainObject(v) { return v && typeof v === 'object' && !Array.isArray(v); }
+
+    function sleep(ms) { return new Promise(function(r) { setTimeout(r, ms); }); }
+
+    // ==================== GAME CONTEXT (iframe or top-window) ====================
+
+    function findGameIframe() {
+        const knownIds = ['hh_hentai','hh_comix','hh_star','hh_stargay','hh_startrans','hh_gay','hh_amour','hh_mangarpg','hh_sexy','hh_game'];
+        for (const id of knownIds) {
+            try {
+                const f = document.getElementById(id);
+                if (f && f.tagName === 'IFRAME') return f;
+            } catch (e) {}
+        }
+        // Generic scan: any iframe with same-origin contentWindow exposing game globals
+        try {
+            const frames = document.querySelectorAll('iframe');
+            for (const f of frames) {
+                try {
+                    const w = f.contentWindow;
+                    if (!w) continue;
+                    if (w.shared || w.Hero || w.availableGirls || w.hh_ajax) return f;
+                } catch (e) { /* cross-origin */ }
+            }
+        } catch (e) {}
+        return null;
+    }
+
+    function detectMode() {
+        // top-window mode: game globals directly on unsafeWindow
+        try {
+            if (unsafeWindow.shared || unsafeWindow.Hero || unsafeWindow.availableGirls || unsafeWindow.hh_ajax) {
+                return { mode: 'top-window', win: unsafeWindow, doc: document, iframe: null };
+            }
+        } catch (e) {}
+        // iframe mode
+        const iframe = findGameIframe();
+        if (iframe) {
+            try {
+                const w = iframe.contentWindow;
+                const d = iframe.contentDocument || (w && w.document);
+                if (w) return { mode: 'iframe', win: w, doc: d, iframe: iframe };
+            } catch (e) {}
+        }
+        // Nothing found - default to top-window (game might still be loading)
+        return { mode: 'unknown', win: unsafeWindow, doc: document, iframe: null };
+    }
+
+    function getCurrentBodyPage(ctx) {
+        try {
+            const d = ctx.doc || document;
+            const body = d.querySelector('body[page]');
+            return body ? body.getAttribute('page') : null;
+        } catch (e) { return null; }
+    }
+
+    async function waitForBodyPage(expected, maxWaitMs) {
+        const interval = 250;
+        const deadline = Date.now() + maxWaitMs;
+        while (Date.now() < deadline) {
+            const ctx = detectMode();
+            const cur = getCurrentBodyPage(ctx);
+            if (cur === expected) return { matched: true, actual: cur, ctx: ctx };
+            await sleep(interval);
+        }
+        const ctx = detectMode();
+        return { matched: false, actual: getCurrentBodyPage(ctx), ctx: ctx };
+    }
+
+    function navigateTo(path, ctx) {
+        const target = location.origin + path;
+        if (ctx.iframe) {
+            // iframe mode: change src - script keeps running
+            try { ctx.iframe.src = target; return 'iframe'; }
+            catch (e) {}
+        }
+        // top-window mode: full reload
+        location.href = target;
+        return 'top-window';
+    }
+
+    // ==================== DATA COLLECTION ====================
+
+    function findGameGlobals(ctx) {
+        const builtins = new Set([
+            'window','self','document','location','navigator','history','localStorage','sessionStorage',
+            'console','screen','performance','crypto','caches','indexedDB','fetch','XMLHttpRequest','WebSocket',
+            'setTimeout','setInterval','clearTimeout','clearInterval','requestAnimationFrame','cancelAnimationFrame',
+            'alert','confirm','prompt','open','close','print','focus','blur','scroll','scrollTo','scrollBy',
+            'addEventListener','removeEventListener','dispatchEvent','postMessage','atob','btoa',
+            'innerWidth','innerHeight','outerWidth','outerHeight','scrollX','scrollY','pageXOffset','pageYOffset',
+            'devicePixelRatio','screenX','screenY','screenLeft','screenTop','origin','name','status','frames',
+            'parent','top','opener','frameElement','length','closed','locationbar','menubar','personalbar',
+            'scrollbars','statusbar','toolbar','external','applicationCache','sidebar','speechSynthesis',
+            'Worker','SharedWorker','Notification','File','FileReader','Blob','FormData','URL','URLSearchParams',
+            'Image','Audio','Video','HTMLElement','Element','Node','Event','CustomEvent','MouseEvent','KeyboardEvent',
+            'Promise','Symbol','Proxy','Reflect','Map','Set','WeakMap','WeakSet','ArrayBuffer','DataView',
+            'Int8Array','Uint8Array','Int16Array','Uint16Array','Int32Array','Uint32Array','Float32Array','Float64Array',
+            'Array','Object','String','Number','Boolean','Date','RegExp','Math','JSON','Function','Error','TypeError',
+            'RangeError','SyntaxError','ReferenceError','EvalError','URIError','encodeURIComponent','decodeURIComponent',
+            'encodeURI','decodeURI','escape','unescape','isNaN','isFinite','parseInt','parseFloat','NaN','Infinity',
+            'globalThis','undefined','null','true','false','eval','arguments',
+            '_','moment','ga','gtag','dataLayer','fbq','_fbq','google_tag_manager','__cfWaitingOnAnchor',
+            'regeneratorRuntime','webpackChunk','webpackJsonp','__REACT_DEVTOOLS_GLOBAL_HOOK__','__VUE_DEVTOOLS_GLOBAL_HOOK__'
+        ]);
+        const result = [];
+        try {
+            const win = ctx.win;
+            for (const k of Object.getOwnPropertyNames(win)) {
+                if (builtins.has(k)) continue;
+                if (k.startsWith('webkit') || k.startsWith('moz') || k.startsWith('ms') || k.startsWith('on')) continue;
+                try {
+                    const v = win[k];
+                    if (v === null || v === undefined || typeof v === 'function') continue;
+                    if (typeof v === 'string' && v.length < 2) continue;
+                    if (typeof v === 'number' || typeof v === 'boolean') {
+                        result.push({ name: k, type: typeof v, sample: v });
+                        continue;
+                    }
+                    if (typeof v === 'object') {
+                        const isArr = Array.isArray(v);
+                        result.push({ name: k, type: isArr ? 'array' : 'object', len: isArr ? v.length : Object.keys(v).length });
+                    }
+                } catch (e) {}
+            }
+        } catch (e) {}
+        return result;
+    }
+
+    function findGirlSources(ctx) {
+        const sources = [];
+        const visited = new WeakSet();
+        function isGirlLike(obj) {
+            if (!obj || typeof obj !== 'object') return false;
+            return (obj.id_girl !== undefined) || (obj.carac1 !== undefined && obj.name !== undefined);
+        }
+        function scan(root, path, depth) {
+            if (depth > 4) return;
+            if (!root || typeof root !== 'object' || visited.has(root)) return;
+            visited.add(root);
+            try {
+                const keys = Array.isArray(root) ? [] : Object.keys(root);
+                for (const k of keys) {
+                    let v;
+                    try { v = root[k]; } catch (e) { continue; }
+                    if (v === null || v === undefined) continue;
+                    if (Array.isArray(v) && v.length > 0 && isGirlLike(v[0])) {
+                        sources.push({ path: path + '.' + k, count: v.length, ref: v });
+                    } else if (isPlainObject(v) && depth < 3) {
+                        const innerKeys = Object.keys(v);
+                        if (innerKeys.length > 0) {
+                            const sample = v[innerKeys[0]];
+                            if (isGirlLike(sample)) sources.push({ path: path + '.' + k, count: innerKeys.length, ref: v, isMap: true });
+                            else scan(v, path + '.' + k, depth + 1);
+                        }
+                    }
+                }
+            } catch (e) {}
+        }
+        const w = ctx.win;
+        scan(w, 'game', 0);
+        try { if (w.shared) scan(w.shared, 'game.shared', 0); } catch (e) {}
+        try { if (w.hh_nutaku) scan(w.hh_nutaku, 'game.hh_nutaku', 0); } catch (e) {}
+        try { if (w.hero_data) scan(w.hero_data, 'game.hero_data', 0); } catch (e) {}
+        return sources;
+    }
+
+    // Extract primitive (non-DOM, non-circular) fields from a possibly-circular object.
+    function extractPrimitives(obj, depth, seen) {
+        if (depth === undefined) depth = 0;
+        if (!seen) seen = new WeakSet();
+        if (obj === null || obj === undefined) return obj;
+        const t = typeof obj;
+        if (t === 'number' || t === 'string' || t === 'boolean') return obj;
+        if (t === 'function') return undefined;
+        if (depth > 4) return '[depth-limit]';
+        if (t === 'object') {
+            if (seen.has(obj)) return '[circular]';
+            seen.add(obj);
+        }
+        if (Array.isArray(obj)) {
+            const out = [];
+            for (let i = 0; i < obj.length && i < 100; i++) {
+                try {
+                    const v = obj[i];
+                    if (v && typeof v === 'object' && v.nodeType !== undefined) continue;
+                    out.push(extractPrimitives(v, depth + 1, seen));
+                } catch (e) {}
+            }
+            return out;
+        }
+        if (t === 'object') {
+            const out = {};
+            try {
+                for (const k of Object.keys(obj)) {
+                    try {
+                        const v = obj[k];
+                        if (v === null || v === undefined) { out[k] = v; continue; }
+                        const vt = typeof v;
+                        if (vt === 'function') continue;
+                        if (vt === 'number' || vt === 'string' || vt === 'boolean') { out[k] = v; continue; }
+                        if (v instanceof Date) { out[k] = v.toISOString(); continue; }
+                        if (v.nodeType !== undefined && v.nodeName !== undefined) continue;
+                        try { if (typeof Window !== 'undefined' && v instanceof Window) continue; } catch (e) {}
+                        try { if (typeof Document !== 'undefined' && v instanceof Document) continue; } catch (e) {}
+                        out[k] = extractPrimitives(v, depth + 1, seen);
+                    } catch (e) {}
+                }
+            } catch (e) {}
+            return out;
+        }
+        return undefined;
+    }
+
+    function dumpHeroInfos(ctx) {
+        const out = {};
+        try {
+            const w = ctx.win;
+            const h = w.shared && w.shared.Hero;
+            if (!h) return out;
+            for (const key of ['infos', 'caracs', 'currencies', 'energies', 'club', 'mc_level']) {
+                try {
+                    if (h[key] !== undefined) {
+                        out[key] = extractPrimitives(h[key], 0, new WeakSet());
+                    }
+                } catch (e) {}
+            }
+        } catch (e) {}
+        return out;
+    }
+
+    function dumpEverything(ctx) {
+        const t0 = Date.now();
+        const w = ctx.win;
+        const d = ctx.doc;
+
+        const heroData = {};
+        for (const k of ['hero','Hero','hero_data','heroData','player_data','PlayerData','playerStats']) {
+            try { if (w[k] !== undefined) heroData[k] = w[k]; } catch (e) {}
+        }
+        try { if (w.shared && w.shared.Hero) heroData['shared.Hero'] = w.shared.Hero; } catch (e) {}
+        try { if (w.shared && w.shared.general) heroData['shared.general'] = w.shared.general; } catch (e) {}
+
+        const teamsData = {};
+        for (const k of [
+            'teams_data','teamsData','teams','selected_team','selectedTeam',
+            'team_data','teamData','battle_team','battleTeam',
+            'availableGirls','girlsDataList','girls_data_list',
+            'leaguesPlayersData','leagues_players_data','opponents_list','opponentsList',
+            'season_opponents','seasonOpponents','penta_opponents','tower_opponents',
+            'girl_squad','teamGirls','opponents','season_girls'
+        ]) {
+            try { if (w[k] !== undefined) teamsData[k] = w[k]; } catch (e) {}
+        }
+
+        const battleData = {};
+        for (const k of [
+            'battle_data','fight_data','current_battle','battle_result',
+            'synergies','element_synergies','theme_elements',
+            'boosters_data','boosters','mythicBoosters','equippedBoosters',
+            'league_data','season_data','league_rewards',
+            'tower_data','champion_data','championData',
+            'labyrinth_data','penta_drill','penta_drill_data',
+            'club_data','arena_data','game_data',
+            'current_tier_number','league_tag','event_data','current_event',
+            'seasonal_event_active','mega_event_active','mega_event_data',
+            'season_sec_untill_event_end','seasonal_time_remaining','mega_event_time_remaining',
+            'has_contests_datas','contests_timer','daily_goals_list',
+            'love_raids','pop_list','pop_index','player_gems_amount'
+        ]) {
+            try { if (w[k] !== undefined) battleData[k] = w[k]; } catch (e) {}
+        }
+
+        const marketData = {};
+        for (const k of [
+            'market_data','shop_data','items','items_data','shop',
+            'girl_armor','equipment','inventory','girl_skills',
+            'skill_tiers','awakening_data',
+            'mythic_boosters','classBoosters','specialBoosters','hh_prices'
+        ]) {
+            try { if (w[k] !== undefined) marketData[k] = w[k]; } catch (e) {}
+        }
+
+        const hhNamespace = {};
+        try {
+            for (const k of Object.getOwnPropertyNames(w)) {
+                if (k.startsWith('HH_') || k.startsWith('hh_') || k.startsWith('Hh_')) {
+                    try {
+                        const v = w[k];
+                        if (v !== null && v !== undefined && typeof v !== 'function') hhNamespace[k] = v;
+                    } catch (e) {}
+                }
+            }
+        } catch (e) {}
+
+        const sharedNs = {};
+        try {
+            if (w.shared) {
+                for (const k of Object.keys(w.shared)) {
+                    try {
+                        const v = w.shared[k];
+                        if (v !== null && v !== undefined && typeof v !== 'function') sharedNs[k] = v;
+                    } catch (e) {}
+                }
+            }
+        } catch (e) {}
+
+        const localStorageData = { top: {}, game: {} };
+        function scanStorage(storage, target) {
+            if (!storage) return;
+            try {
+                for (const key of Object.keys(storage)) {
+                    const lk = key.toLowerCase();
+                    if (lk.includes('hhauto') || lk.includes('hh_') || lk.includes('hentai') ||
+                        lk.includes('harem') || lk.includes('comix') || lk.includes('pornstar') ||
+                        lk.includes('blessing') || lk.includes('girl') || lk.includes('team') ||
+                        lk.includes('league') || lk.includes('season') || lk.includes('kinkoid') ||
+                        lk.includes('ocd') || lk.includes('trainer') || lk.includes('hero') ||
+                        lk.includes('booster') || lk.includes('market')) {
+                        try {
+                            const raw = storage.getItem(key);
+                            try { target[key] = JSON.parse(raw); }
+                            catch (e) { target[key] = raw; }
+                        } catch (e) {}
+                    }
+                }
+            } catch (e) {}
+        }
+        scanStorage(localStorage, localStorageData.top);
+        try {
+            if (ctx.win !== unsafeWindow && ctx.win.localStorage) scanStorage(ctx.win.localStorage, localStorageData.game);
+        } catch (e) {}
+
+        const domAttrs = [];
+        try {
+            const candidates = (d || document).querySelectorAll(
+                '[data-new-girl-tooltip], [data-team], [data-girl-id], [data-blessing], [data-opponent], ' +
+                '[data-team-index], [data-team-member-position], [data-id-girl-armor], [data-id-skill], ' +
+                '[data-d], [data-rewards], [data-power], [data-time-stamp], [data-nc-reward-id], ' +
+                '[data-pantheon-id], [data-battles], [data-tab], [data-href], [data-select-girl-id]'
+            );
+            for (let i = 0; i < candidates.length && i < 1000; i++) {
+                const el = candidates[i];
+                const entry = { tag: el.tagName, id: el.id || null, class: el.className || null, attrs: {} };
+                for (const a of el.attributes) {
+                    if (a.name.startsWith('data-')) entry.attrs[a.name] = a.value;
+                }
+                domAttrs.push(entry);
+            }
+        } catch (e) {}
+
+        const gameContext = { mode: ctx.mode };
+        try {
+            const body = (d || document).querySelector('body[page]');
+            if (body) {
+                gameContext.body_id = body.id || null;
+                gameContext.body_page = body.getAttribute('page');
+            }
+            gameContext.location = {
+                href: (w.location && w.location.href) || null,
+                pathname: (w.location && w.location.pathname) || null,
+                search: (w.location && w.location.search) || null
+            };
+        } catch (e) {}
+
+        const dump = {
+            meta: {
+                timestamp: new Date().toISOString(),
+                host: location.hostname,
+                pathname: location.pathname,
+                search: location.search,
+                href: location.href,
+                inspectorVersion: VERSION,
+                mode: ctx.mode
+            },
+            game_context: gameContext,
+            globals_overview: tryGet(function() { return findGameGlobals(ctx); }, []),
+            girl_sources: tryGet(function() {
+                return findGirlSources(ctx).map(function(s) { return { path: s.path, count: s.count, isMap: !!s.isMap }; });
+            }, []),
+            girls_full: {},
+            hero: heroData,
+            hero_infos: tryGet(function() { return dumpHeroInfos(ctx); }, {}),
+            teams: teamsData,
+            battle: battleData,
+            market_equipment: marketData,
+            hh_namespace: hhNamespace,
+            shared_namespace: sharedNs,
+            local_storage: localStorageData,
+            dom_data_attributes: domAttrs
+        };
+
+        try {
+            const sources = findGirlSources(ctx);
+            for (const s of sources) {
+                try {
+                    if (s.isMap) dump.girls_full[s.path] = Object.values(s.ref);
+                    else dump.girls_full[s.path] = s.ref;
+                } catch (e) { dump.girls_full[s.path] = '[error: ' + e.message + ']'; }
+            }
+        } catch (e) {}
+
+        dump.meta.dump_duration_ms = Date.now() - t0;
+        return dump;
+    }
+
+    function fetchBlessings(ctx, callback) {
+        try {
+            const w = ctx.win;
+            const ajax = (w.shared && w.shared.general && w.shared.general.hh_ajax) || w.hh_ajax || w.ajax;
+            if (typeof ajax === 'function') {
+                let done = false;
+                const timer = setTimeout(function() { if (!done) { done = true; callback({ live: null, error: 'timeout' }); } }, 3000);
+                ajax({ action: 'get_girls_blessings' }, function(response) {
+                    if (done) return;
+                    done = true;
+                    clearTimeout(timer);
+                    callback({ live: response, error: null });
+                });
+                return;
+            }
+        } catch (e) {}
+        callback({ live: null, error: 'ajax not available' });
+    }
+
+    // ==================== UI ====================
+
+    function mkBtn(text, color, onclick) {
+        const b = document.createElement('button');
+        b.textContent = text;
+        b.style.cssText = 'padding:6px 14px;font-size:12px;cursor:pointer;background:' + color + ';color:white;border:none;border-radius:4px;font-weight:bold;';
+        b.onclick = onclick;
+        return b;
+    }
+
+    function downloadJson(text, suffix) {
+        const blob = new Blob([text], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+        const host = location.hostname.replace(/[^a-z0-9]/gi, '_');
+        a.download = 'hhauto_dump_' + host + '_' + (suffix || 'all') + '_' + stamp + '.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+    }
+
+    function ensureStatusBar() {
+        let bar = document.getElementById('hhauto_status_bar');
+        if (bar) return bar;
+        bar = document.createElement('div');
+        bar.id = 'hhauto_status_bar';
+        bar.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#1a1a1a;color:#0f0;font:13px monospace;padding:8px 14px;z-index:1000000;box-shadow:0 4px 14px rgba(0,0,0,0.7);border-bottom:3px solid #ffb827;display:flex;align-items:center;gap:10px;flex-wrap:wrap;min-height:24px;';
+        document.body.appendChild(bar);
+        return bar;
+    }
+
+    function setStatusBar(html, buttons) {
+        const bar = ensureStatusBar();
+        bar.innerHTML = '';
+        const msg = document.createElement('div');
+        msg.style.cssText = 'flex:1;min-width:240px';
+        msg.innerHTML = html;
+        bar.appendChild(msg);
+        if (buttons) {
+            for (const btn of buttons) bar.appendChild(btn);
+        }
+    }
+
+    function clearStatusBar() {
+        const bar = document.getElementById('hhauto_status_bar');
+        if (bar) bar.remove();
+    }
+
+    function showSingleDumpOverlay(text, suffix) {
+        const old = document.getElementById('hhauto_overlay');
+        if (old) old.remove();
+        const ov = document.createElement('div');
+        ov.id = 'hhauto_overlay';
+        ov.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.92);z-index:999999;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:20px;box-sizing:border-box;';
+        const info = document.createElement('div');
+        info.style.cssText = 'color:#0f0;font:14px monospace;margin-bottom:10px;';
+        info.textContent = 'Dump: ' + text.length.toLocaleString() + ' chars (' + Math.round(text.length/1024) + ' KB) | ' + (suffix || '');
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.cssText = 'width:100%;flex:1;font:11px monospace;padding:10px;border-radius:5px;background:#1a1a1a;color:#0f0;resize:none;';
+        const row = document.createElement('div');
+        row.style.cssText = 'margin-top:10px;display:flex;gap:10px;flex-wrap:wrap;';
+        const cp = mkBtn('COPY ALL', '#4CAF50', function() {
+            ta.select();
+            try { navigator.clipboard.writeText(text).then(function() { cp.textContent = 'COPIED!'; }); }
+            catch (e) { document.execCommand('copy'); cp.textContent = 'COPIED!'; }
+        });
+        const dl = mkBtn('DOWNLOAD JSON', '#2196F3', function() { downloadJson(text, suffix); });
+        const cl = mkBtn('CLOSE', '#f44336', function() { ov.remove(); });
+        row.appendChild(cp); row.appendChild(dl); row.appendChild(cl);
+        ov.appendChild(info); ov.appendChild(ta); ov.appendChild(row);
+        document.body.appendChild(ov);
+        ta.select();
+    }
+
+    // ==================== TOUR DRIVER ====================
+
+    async function performStep(globalIdx, step, isManual) {
+        console.log(LOG_PREFIX, 'Step', globalIdx + 1, ':', step.label, 'expected=' + step.expected);
+        let waited;
+        if (!isManual) {
+            // Auto step - wait for body[page] to match expected
+            setStatusBar('<b style=\"color:#ffb827\">' + (globalIdx+1) + '. ' + step.label + '</b> &mdash; waiting for page to load...');
+            waited = await waitForBodyPage(step.expected, PAGE_LOAD_WAIT_MS);
+        } else {
+            waited = { matched: true, actual: getCurrentBodyPage(detectMode()), ctx: detectMode() };
+        }
+        await sleep(POST_LOAD_SETTLE_MS);
+
+        const ctx = detectMode();
+        setStatusBar('<b style=\"color:#ffb827\">' + (globalIdx+1) + '. ' + step.label + '</b> &mdash; dumping data...');
+        const dump = dumpEverything(ctx);
+
+        await new Promise(function(resolve) {
+            fetchBlessings(ctx, function(blessings) {
+                dump.live_blessings_api = blessings;
+                resolve();
+            });
+        });
+
+        const actualPage = getCurrentBodyPage(ctx);
+        dump.tour_meta = {
+            label: step.label,
+            requested_path: step.path,
+            expected_page: step.expected,
+            actual_page: actualPage,
+            match: actualPage === step.expected,
+            manual: !!isManual,
+            global_index: globalIdx
+        };
+
+        const saveInfo = await saveResult(globalIdx, dump, step);
+        console.log(LOG_PREFIX, 'Step', globalIdx + 1, 'done:', step.label, 'match=' + dump.tour_meta.match, 'size=' + Math.round(saveInfo.size/1024) + 'KB');
+        return { dump: dump, saveInfo: saveInfo };
+    }
+
+    async function continueAutoTour(state) {
+        const totalAuto = AUTO_TOUR.length;
+        const totalManual = MANUAL_TOUR.length;
+        // Current step:
+        const idx = state.index;
+        if (idx < totalAuto) {
+            // Auto phase
+            const step = AUTO_TOUR[idx];
+            let stepOk = false;
+            try {
+                const res = await performStep(idx, step, false);
+                stepOk = !!(res && res.saveInfo && res.saveInfo.ok);
+            } catch (e) {
+                console.error(LOG_PREFIX, 'Step error at auto idx', idx, ':', e);
+            }
+            // Advance
+            state.index = idx + 1;
+            if (stepOk) state.completedSteps = (state.completedSteps || 0) + 1;
+            saveState(state);
+            if (state.index >= totalAuto) {
+                // Auto phase done, switch to manual
+                setStatusBar('<b style=\"color:#4CAF50\">Auto phase done.</b> &mdash; Manual phase: navigate via game UI then click DUMP NOW.', []);
+                console.log(LOG_PREFIX, 'Auto phase done, entering manual phase.');
+                await sleep(1500);
+                await showManualPrompt(state);
+                return;
+            }
+            // Navigate to next auto step
+            const next = AUTO_TOUR[state.index];
+            const ctx = detectMode();
+            setStatusBar('<b style=\"color:#ffb827\">Step ' + (state.index+1) + '/' + (totalAuto+totalManual) + ': ' + next.label + '</b> &mdash; navigating...');
+            await sleep(PAGE_TRANSITION_DELAY_MS);
+            navigateTo(next.path, ctx);
+            // If iframe mode: continue running. If top-window: page reloads, init() resumes.
+            if (ctx.mode === 'iframe' || ctx.mode === 'unknown') {
+                // wait a bit then loop
+                await sleep(500);
+                await continueAutoTour(loadState());
+            }
+            return;
+        }
+        // Should not reach here in auto phase
+    }
+
+    async function showManualPrompt(state) {
+        const totalAuto = AUTO_TOUR.length;
+        const manualIdx = state.index - totalAuto;
+        if (manualIdx >= MANUAL_TOUR.length) {
+            await finishTour(state);
+            return;
+        }
+        const step = MANUAL_TOUR[manualIdx];
+        const ctx = detectMode();
+        const cur = getCurrentBodyPage(ctx) || '?';
+
+        // If user already navigated to expected page, give them a quick dump button
+        const dumpBtn = mkBtn('DUMP NOW', '#4CAF50', async function() {
+            dumpBtn.disabled = true;
+            let stepOk = false;
+            try {
+                const res = await performStep(state.index, step, true);
+                stepOk = !!(res && res.saveInfo && res.saveInfo.ok);
+            } catch (e) {
+                console.error(LOG_PREFIX, 'Manual step failed:', e);
+            }
+            state.index++;
+            if (stepOk) state.completedSteps = (state.completedSteps || 0) + 1;
+            saveState(state);
+            if (state.index >= totalAuto + MANUAL_TOUR.length) {
+                await finishTour(state);
+            } else {
+                await showManualPrompt(state);
+            }
+        });
+        const skipBtn = mkBtn('SKIP', '#ff9800', async function() {
+            console.log(LOG_PREFIX, 'Manual skip:', step.label);
+            state.index++;
+            saveState(state);
+            if (state.index >= totalAuto + MANUAL_TOUR.length) await finishTour(state);
+            else await showManualPrompt(state);
+        });
+        const abortBtn = mkBtn('ABORT', '#f44336', async function() {
+            console.log(LOG_PREFIX, 'Manual abort');
+            await finishTour(state);
+        });
+
+        setStatusBar(
+            'Manual ' + (manualIdx+1) + '/' + MANUAL_TOUR.length + ': open <b style=\"color:#ffb827\">' + step.label + '</b> in game ' +
+            '<span style=\"color:#888\">(want body[page]=' + step.expected + ', currently=' + cur + ')</span>',
+            [dumpBtn, skipBtn, abortBtn]
+        );
+    }
+
+    async function finishTour(state) {
+        const totalDur = state.startedAt ? Math.round((Date.now() - state.startedAt) / 1000) : 0;
+        const completed = state.completedSteps || 0;
+        const total = AUTO_TOUR.length + MANUAL_TOUR.length;
+
+        setStatusBar('Tour finished. Assembling bundle from IndexedDB...', []);
+        let rows = [];
+        try {
+            rows = await idbGetAll();
+        } catch (e) {
+            console.error(LOG_PREFIX, 'idbGetAll failed:', e);
+        }
+        const pages = rows.map(function(r) { return r.dump; });
+        const bundle = {
+            meta: {
+                timestamp: new Date().toISOString(),
+                host: location.hostname,
+                href: location.href,
+                inspectorVersion: VERSION,
+                tour_pages: total,
+                tour_completed_pages: pages.length,
+                tour_duration_sec: totalDur
+            },
+            pages: pages
+        };
+        const text = safeStringify(bundle);
+        const sizeKb = Math.round(text.length / 1024);
+        downloadJson(text, 'tour');
+        try { await idbClear(); } catch (e) {}
+        clearState();
+        setStatusBar(
+            'Tour finished: ' + pages.length + '/' + total + ' pages, ' + sizeKb + ' KB, ' + totalDur + 's. Bundle downloaded.',
+            [
+                mkBtn('REVIEW BUNDLE', '#2196F3', function() { showSingleDumpOverlay(text, 'tour'); }),
+                mkBtn('CLOSE', '#888', function() { clearStatusBar(); makeButtons(); })
+            ]
+        );
+        console.log(LOG_PREFIX, 'Tour finished:', pages.length, 'pages,', sizeKb, 'KB,', totalDur, 's');
+    }
+
+        async function startTour() {
+        if (loadState()) {
+            if (!confirm('A tour is already in progress. Restart from scratch?')) return;
+        }
+        clearState();
+        try { await idbClear(); } catch (e) { console.warn(LOG_PREFIX, 'idbClear before start failed:', e); }
+        const state = {
+            running: true,
+            index: 0,
+            startedAt: Date.now()
+        };
+        saveState(state);
+        console.log(LOG_PREFIX, 'Tour started.');
+        const ctx = detectMode();
+        navigateTo(AUTO_TOUR[0].path, ctx);
+        if (ctx.mode === 'iframe' || ctx.mode === 'unknown') {
+            // iframe mode: stay in same JS run, drive tour from here
+            (async function() {
+                await sleep(PAGE_TRANSITION_DELAY_MS);
+                await continueAutoTour(loadState());
+            })();
+        }
+        // top-window mode: page reloads, init() picks up state and continues
+    }
+
+    function abortTour() {
+        if (!loadState()) return;
+        if (!confirm('Abort current tour?')) return;
+        const state = loadState();
+        finishTour(state);
+    }
+
+    // ==================== INIT ====================
+
+    function makeButtons() {
+        const old = document.getElementById('hhauto_buttons');
+        if (old) old.remove();
+        const wrap = document.createElement('div');
+        wrap.id = 'hhauto_buttons';
+        wrap.style.cssText = 'position:fixed;top:10px;right:10px;z-index:99999;display:flex;flex-direction:column;gap:6px;font-family:monospace;';
+
+        const single = document.createElement('div');
+        single.textContent = 'DUMP THIS PAGE';
+        single.style.cssText = 'background:#ff4444;color:white;padding:14px 20px;border-radius:5px;cursor:pointer;font-weight:bold;font-size:14px;box-shadow:0 2px 10px rgba(0,0,0,0.5);text-align:center;';
+        single.onclick = function() {
+            const ctx = detectMode();
+            const dump = dumpEverything(ctx);
+            fetchBlessings(ctx, function(blessings) {
+                dump.live_blessings_api = blessings;
+                const text = safeStringify(dump);
+                const body = (ctx.doc || document).querySelector('body[page]');
+                const suffix = body ? body.getAttribute('page').replace(/[^a-z0-9]/gi, '_') : 'page';
+                showSingleDumpOverlay(text, suffix);
+            });
+        };
+
+        const tour = document.createElement('div');
+        tour.textContent = 'AUTO TOUR';
+        tour.style.cssText = 'background:#2196F3;color:white;padding:14px 20px;border-radius:5px;cursor:pointer;font-weight:bold;font-size:14px;box-shadow:0 2px 10px rgba(0,0,0,0.5);text-align:center;';
+        tour.onclick = function() { startTour(); };
+        tour.title = AUTO_TOUR.length + ' auto pages, then ' + MANUAL_TOUR.length + ' manual pages, then bundle download.';
+
+        wrap.appendChild(single);
+        wrap.appendChild(tour);
+        document.body.appendChild(wrap);
+    }
+
+    function startupCleanup() {
+        // Clean any orphaned result entries from prior runs/versions BEFORE we check tour state.
+        // This frees localStorage quota that may have been blocking saves.
+        try {
+            const keysToRemove = [];
+            for (let i = 0; i < localStorage.length; i++) {
+                const k = localStorage.key(i);
+                if (k && k.startsWith(RESULT_KEY_PREFIX)) {
+                    keysToRemove.push(k);
+                }
+            }
+            for (const k of keysToRemove) {
+                try { localStorage.removeItem(k); } catch (e) {}
+            }
+            // Also remove the legacy bundle key if present.
+            try { localStorage.removeItem('hhauto_last_tour'); } catch (e) {}
+            if (keysToRemove.length > 0) {
+                console.log(LOG_PREFIX, 'Startup cleanup removed', keysToRemove.length, 'orphaned result keys');
+            }
+        } catch (e) { console.warn(LOG_PREFIX, 'startupCleanup failed:', e); }
+    }
+
+    function init() {
+        console.log(LOG_PREFIX, 'init, location:', location.href);
+        startupCleanup();
+        const state = loadState();
+        if (state && state.running) {
+            console.log(LOG_PREFIX, 'Resuming tour at index', state.index);
+            const totalAuto = AUTO_TOUR.length;
+            const totalManual = MANUAL_TOUR.length;
+            // Add abort button to overlay
+            const abortBtn = mkBtn('ABORT TOUR', '#f44336', abortTour);
+            setStatusBar('Resuming tour at step ' + (state.index+1) + '/' + (totalAuto+totalManual) + '...', [abortBtn]);
+            (async function() {
+                await sleep(1000); // give game JS time to settle
+                if (state.index < totalAuto) {
+                    await continueAutoTour(state);
+                } else {
+                    await showManualPrompt(state);
+                }
+            })();
+        } else {
+            makeButtons();
+        }
+    }
+
+    setTimeout(init, 2000);
+
+})();

--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.21 - League team selection rebuilt
+
+The "Current Best" and "Best Possible" buttons now pick teams using a wider community-knowledge base (Kinkoid forum performance and elements topics, HH Wiki, Tom-208 userscript, plus Frank's input on issues #1340 and #1573).
+
+**Key changes:**
+- Selection is driven by your main class stat alone (HC=carac1, Charm=carac2, KH=carac3) instead of the raw stat sum.
+- Cross-class girls are filtered out -- they would always lose against own-class top tier in combat.
+- Trait clusters are compared by effective power (main_sum * (1 + tier-3 bonus)). The cluster that maximises real combat power wins, not the one with the most matching traits.
+- The leader (slot 1) is picked for tier-5 skill priority (Shield > Stun > Execute > Reflect), not for highest stats. A Shield leader anchors a defensive skill the whole team uses.
+- The info box now shows readable trait names ("Blue", "Doggy") instead of internal codes ("00F", "2.png"), and tells you which class, which cluster, and which alternative clusters were compared.
+- Stats are equipment-free (verified against the game data). The info box reminds you to hit "Stuff Team" after applying.
+
+Two modes: **Current Best** uses today's stats, **Best Possible** projects each girl to your level cap with all grades applied.
+
+---
+
 ### v7.35.20 - Team selection rewrite: blessing-aware top-7
 
 The team selection algorithm has been completely rewritten. The previous version tried to find the best "trait group" (eye color, hair color, position, zodiac) and build a team around it. This often selected the wrong girls because it prioritized trait matching over raw power.

--- a/docs-internal/data-sources-inventory.md
+++ b/docs-internal/data-sources-inventory.md
@@ -1,0 +1,932 @@
+---
+last-verified: 2026-05-05
+verified-against-version: 7.35.20
+status: new
+---
+
+# HHAuto - Data Sources Inventory
+
+Vollstaendige Inventarisierung aller Datenquellen, auf die das HHAuto-Skript zugreift.
+Quelle: systematischer grep durch alle 132 TypeScript-Dateien unter `src/`.
+
+> Konventionen
+>
+> - "Datei" wird ohne `src/`-Praefix angegeben.
+> - "Page-ID" entspricht den Konstanten aus `ConfigHelper.getHHScriptVars("pagesIDXxx")` bzw. dem `<body page="...">`-Attribut.
+> - "Verfuegbar auf" ist - wenn nicht im Source eindeutig nachweisbar - mit *unklar* gekennzeichnet (Tag `(?)`).
+> - localStorage/sessionStorage Keys sind mit dem Default-Praefix `HHAuto_` versehen (siehe `HHStoredVarPrefixKey`).
+
+## 1. unsafeWindow-Globals (direkter Zugriff)
+
+Direkte `unsafeWindow.XXX`-Zugriffe (ohne `getHHVars`-Wrapper). Reads & Writes.
+Siehe auch `src/index.ts` fuer die `Window`-Interface-Erweiterung, die alle hier genutzten Properties typed.
+
+| Variablen-Pfad | Datentyp | Verfuegbar auf | Datei | Zweck |
+|---|---|---|---|---|
+| `unsafeWindow.shared` | Objekt (root container) | jede Page nach Game-JS-Load | `Helper/HHHelper.ts:17` | Existenz-Check fuer `prefixIfNeeded()` (legt fest, ob `Hero.x` zu `shared.Hero.x` umgeschrieben wird) |
+| `unsafeWindow.shared.Hero` | Objekt (Hero-Daten) | jede Page nach Game-JS-Load | `Helper/HeroHelper.ts:27,32`, `Service/StartService.ts:198` | Existenz-Check; `getHero()` liefert dieses Objekt; Startup-Retry-Loop |
+| `unsafeWindow.shared.general.hh_ajax` | Function `(params, onSuccess, onError) => void` | jede Page nach Game-JS-Load | `Utils/Utils.ts:20` | `getHHAjax()` - Bruecke zur internen AJAX-Funktion des Spiels |
+| `unsafeWindow.shared.general.is_cheat_click` | Function (Cheat-Detector) | jede Page nach Game-JS-Load | `Utils/Utils.ts:112` (auskommentiert) | Vorbereitete Override-Stelle - aktuell deaktiviert (siehe Sektion 12) |
+| `unsafeWindow.shared.animations.loadingAnimation.start` | Function | Shop-Page (`pagesIDShop`) | `Module/Shop.ts:393,520,585` | Save/Replace/Restore: Loading-Animation waehrend Bulk-Sell-Aktion unterdruecken |
+| `unsafeWindow.shared.animations.loadingAnimation.stop` | Function | Shop-Page | `Module/Shop.ts:394,521,586` | Save/Replace/Restore (analog) |
+| `unsafeWindow.is_cheat_click` | Function (Cheat-Detector) | jede Page (alte Pfad-Variante) | `Utils/Utils.ts:109` (auskommentiert) | Veraltete Override-Stelle |
+| `unsafeWindow.hh_nutaku` | Boolean/Truthy | NHH/NPH Nutaku-Build | `Service/PageNavigationService.ts:191`, `Service/StartService.ts:462` | Nutaku-Spezialfall: Session-Token via `?sess=` injizieren; postMessage("ImAlive") an parent |
+| `unsafeWindow.hh_prices` | Objekt (Preis-Map z.B. `fight_cost_per_minute`) | jede Page (?) | `Module/Troll.ts:760,845` | Berechnung von `pricePerFight` fuer Auto-Buy von Combats |
+| `unsafeWindow.has_contests_datas` | Boolean | Activities-Tab `contests` (Contests-Page) | `Service/AutoLoopActions.ts:420` | Indikator dass Contest-Claims abholbar sind |
+| `unsafeWindow.contests_timer.next_contest` | Number (sec) | Contests-Page | `Module/Contest.ts:78,85` | Naechster Contest-Wechsel |
+| `unsafeWindow.contests_timer.duration` | Number (sec) | Contests-Page | `Module/Contest.ts:79` | Contest-Dauer |
+| `unsafeWindow.contests_timer.remaining_time` | Number (sec) | Contests-Page | `Module/Contest.ts:80,89` | Restzeit aktueller Contest |
+| `unsafeWindow.daily_goals_list` | Array (KKDailyGoal) | DailyGoals-Tab | `Module/DailyGoals.ts:189,190,192` | Iteration ueber Daily-Goal-Tiers |
+| `unsafeWindow.event_data` | Objekt (HHEventData) | Event-Page (`pagesIDEvent`) | `Module/Events/EventModule.ts:263,516` | Event-Girls und Event-Metadaten |
+| `unsafeWindow.event_data.girls` | Array (KKEventGirl) | Event-Page | `Module/Events/EventModule.ts:516` | Liste der Event-Girls fuer Prioritaeten-UI |
+| `unsafeWindow.current_event` | Objekt (HHEventData) | Event-Page (Fallback) | `Module/Events/EventModule.ts:263` | Fallback wenn `event_data` nicht gesetzt |
+| `unsafeWindow.season_sec_untill_event_end` | Number (sec) | Season/SeasonArena-Page | `Module/Events/Season.ts:51` | Restzeit Season-Event |
+| `unsafeWindow.hero_data` | Objekt | SeasonArena-Page | `Module/Events/Season.ts:138` | Hero-Block fuer Arena-Reload |
+| `unsafeWindow.opponents` | Array | SeasonArena-Page | `Module/Events/Season.ts:139` | Aktuelle Arena-Gegner-Liste |
+| `unsafeWindow.seasonal_event_active` | Boolean | jede Page (?) | `Module/Events/Seasonal.ts:41` | Indikator: Seasonal-Event laeuft |
+| `unsafeWindow.seasonal_time_remaining` | Number (sec) | jede Page (?) | `Module/Events/Seasonal.ts:41` | Restzeit Seasonal |
+| `unsafeWindow.mega_event_active` | Boolean | jede Page (?) | `Module/Events/Seasonal.ts:41` | Indikator: Mega-Event laeuft |
+| `unsafeWindow.mega_event_time_remaining` | Number (sec) | jede Page (?) | `Module/Events/Seasonal.ts:41` | Restzeit Mega-Event |
+| `unsafeWindow.mega_event_data` (via `getHHVars`) | Objekt mit `cards` | Seasonal-Page | `Module/Events/Seasonal.ts:390` (`getHHVars('mega_event_data.cards')`) | Owned Mega-Event-Karten |
+| `unsafeWindow.current_tier_number` | Number | League-Page | `Module/League.ts:74,78` | Aktuelles League-Tier |
+| `unsafeWindow.opponents_list` (typed `KKPentaDrillOpponents[]`) | Array | PentaDrill-Page | `Module/PentaDrill.ts:109` | Penta-Drill-Gegner-Liste |
+| `unsafeWindow.penta_drill_data.cycle_data.seconds_until_event_end` | Number (sec) | PentaDrill-Page | `Module/PentaDrill.ts:43` | Restzeit Penta-Drill-Event |
+| `unsafeWindow.girl_squad` | Array (Labyrinth-Squad-Girls mit `remaining_ego_percent`) | Labyrinth-Pre-Battle / Labyrinth-Page | `Module/Labyrinth.ts:449` | Erkennt verletzte Squad-Girls |
+| `unsafeWindow.teams_data` | Array (Teams) | Battle-Teams-Page (`pagesIDBattleTeams`) | `Module/TeamModule.ts:394,409` | Team-Definitionen (girls_ids, girls) |
+| `unsafeWindow.pop_list` | Boolean | Activities-Tab `pop` (Powerplace-Liste sichtbar) | `Helper/PageHelper.ts:72` | Erkennt: Sind wir auf der Pop-Listen-Page |
+| `unsafeWindow.pop_index` | Number | Activities-Tab `pop` (Pop selektiert) | `Helper/PageHelper.ts:79` | Aktuell selektierte Pop-Instanz |
+| `unsafeWindow.harem` (impliziert via Kommentaren) | Objekt mit `preselectedGirlId` | Harem-Page | `Module/harem/Harem.ts:476,503,513,528` (Kommentar-Hint - effektiv via DOM gelesen) | Im Code wird via `$('#harem_right .opened').attr('girl')` ersatzweise gelesen, der Kommentar dokumentiert die zugehoerige unsafeWindow-Variable |
+| `unsafeWindow.girl` | Objekt (KKHaremGirl) | GirlPage (`pagesIDGirlPage`) | `Module/harem/HaremGirl.ts:66` (`HaremGirl.getCurrentGirl()`) | Aktuell angezeigtes Harem-Girl |
+| `unsafeWindow.id_girl` | Number/String | GirlPage | `Module/harem/HaremGirl.ts:237` | ID des Girls (fuer Navigation zurueck) |
+| `unsafeWindow.player_gems_amount` | Map `{element: {amount: number}}` | GirlPage | `Module/harem/HaremGirl.ts:176,498,512` | Gem-Bestand pro Element fuer Awakening-Pruefung |
+| `unsafeWindow.Hero.currencies.soft_currency` | Number | jede Page (auskommentiert) | `Module/Market.ts:266` (Kommentar) | Veralteter Direktzugriff (heute via `Hero.update`) |
+
+Zusaetzlich werden in `src/index.ts` (Window-Interface) folgende Properties typed - manche werden aktuell noch nicht ausgelesen, sind aber Teil der Bridge-Vertraege:
+`championData`, `Collect`, `HHTimers`, `league_tag`, `server_now_ts`, `love_raids`.
+
+`server_now_ts` wird ueber `getHHVars('server_now_ts')` (siehe Sektion 2) gelesen, nicht direkt ueber `unsafeWindow`.
+
+## 2. shared-Namespace (Reads via `getHHVars`)
+
+`getHHVars(path)` ruft `prefixIfNeeded(path)` auf: wenn `unsafeWindow.shared` existiert UND der Pfad mit `Hero.` beginnt, wird automatisch `shared.` davorgehaengt.
+Daraus folgt: jeder `Hero.x`-Read erreicht effektiv `unsafeWindow.shared.Hero.x`.
+Andere Pfade muessen explizit `shared.` angeben.
+Zusaetzlich kann `ConfigHelper.getHHScriptVars(path,false)` einen Pfad-Override liefern (selten genutzt).
+
+| Pfad (Input fuer getHHVars) | Effektiv resolved als | Inhalt | Datei | Zweck |
+|---|---|---|---|---|
+| `Hero.infos.id` | `shared.Hero.infos.id` | Player-ID | `Helper/HeroHelper.ts:88` | `HeroHelper.getPlayerId()` |
+| `Hero.infos.class` | `shared.Hero.infos.class` | Hero-Klasse 1-3 | `Helper/HeroHelper.ts:92` | `HeroHelper.getClass()` |
+| `Hero.infos.level` | `shared.Hero.infos.level` | Level | `Helper/HeroHelper.ts:96` | `HeroHelper.getLevel()` |
+| `Hero.infos.carac1` | `shared.Hero.infos.carac1` | Stat 1 (Hardcore) | `Helper/HeroHelper.ts:40` | Stat-Upgrade-Berechnung |
+| `Hero.infos.carac2` | `shared.Hero.infos.carac2` | Stat 2 (Charm) | `Helper/HeroHelper.ts:40` | Stat-Upgrade |
+| `Hero.infos.carac3` | `shared.Hero.infos.carac3` | Stat 3 (Knowhow) | `Helper/HeroHelper.ts:40` | Stat-Upgrade |
+| `Hero.infos.hc_confirm` | `shared.Hero.infos.hc_confirm` | Hardcore-Bestaetigung an/aus | `Module/Troll.ts:439,737` | Verhindert versehentliche Koban-Spends |
+| `Hero.infos.questing.id_world` | `shared.Hero.infos.questing.id_world` | Aktuelle Welt | `Service/StartService.ts:229`, `Module/Quest.ts:55`, `Module/Troll.ts:103,120,123`, `Module/PlaceOfPower.ts:46`, `Service/ParanoiaService.ts:170`, `Module/GenericBattle.ts:49` | Welt-ID fuer Quest/Troll/POP-Logik |
+| `Hero.infos.questing.id_quest` | `shared.Hero.infos.questing.id_quest` | Aktuelle Quest | `Module/Quest.ts:56` | Quest-Fortschritt |
+| `Hero.infos.questing.current_url` | `shared.Hero.infos.questing.current_url` | URL der aktuellen Quest | `Module/Quest.ts:54` | Direkt-Navigation |
+| `Hero.infos.questing.choices_adventure` | `shared.Hero.infos.questing.choices_adventure` | 0 = Main, sonst Side | `Service/StartService.ts:228`, `Module/Troll.ts:118,174` | Erkennt Main vs Side Adventure |
+| `Hero.currencies.soft_currency` | `shared.Hero.currencies.soft_currency` | Ymens | `Helper/HeroHelper.ts:100` | `HeroHelper.getMoney()` |
+| `Hero.currencies.hard_currency` | `shared.Hero.currencies.hard_currency` | Kobans | `Helper/HeroHelper.ts:104` | `HeroHelper.getKoban()` |
+| `Hero.energies.kiss.amount` | `shared.Hero.energies.kiss.amount` | Aktuelle Kisses | `Module/Events/Season.ts:65` | Season-Energy |
+| `Hero.energies.kiss.max_regen_amount` | `shared.Hero.energies.kiss.max_regen_amount` | Max Kisses | `Module/Events/Season.ts:69` | Season-Energy-Cap |
+| `Hero.energies.kiss.next_refresh_ts` | `shared.Hero.energies.kiss.next_refresh_ts` | Naechster Refresh | `Module/Events/Season.ts:434`, `Service/AutoLoopActions.ts:613,619`, `Service/ParanoiaService.ts:190` | Timer fuer Energy-Refill |
+| `Hero.energies.kiss.seconds_per_point` | `shared.Hero.energies.kiss.seconds_per_point` | Regen-Rate | `Service/ParanoiaService.ts:190` | Berechnung "Punkte vor Switch" |
+| `Hero.energies.fight.amount` | `shared.Hero.energies.fight.amount` | Aktuelle Combats | `Module/Troll.ts:42` | Troll-Battles |
+| `Hero.energies.fight.max_regen_amount` | `shared.Hero.energies.fight.max_regen_amount` | Max Combats | `Module/Troll.ts:46` | Troll-Cap |
+| `Hero.energies.fight.next_refresh_ts` | `shared.Hero.energies.fight.next_refresh_ts` | Naechster Combat-Refresh | `Service/ParanoiaService.ts:171` | Paranoia-Berechnung |
+| `Hero.energies.fight.seconds_per_point` | `shared.Hero.energies.fight.seconds_per_point` | Combat-Regen-Rate | `Service/ParanoiaService.ts:171` | Paranoia-Berechnung |
+| `Hero.energies.challenge.amount` | `shared.Hero.energies.challenge.amount` | Aktuelle Challenges (League) | `Module/League.ts:174` | League-Energy |
+| `Hero.energies.challenge.max_regen_amount` | `shared.Hero.energies.challenge.max_regen_amount` | Max Challenges | `Module/League.ts:178` | League-Cap |
+| `Hero.energies.challenge.next_refresh_ts` | `shared.Hero.energies.challenge.next_refresh_ts` | League-Refresh | `Module/League.ts:685`, `Service/ParanoiaService.ts:136` | Timer |
+| `Hero.energies.challenge.seconds_per_point` | `shared.Hero.energies.challenge.seconds_per_point` | League-Regen | `Service/ParanoiaService.ts:136` | Paranoia |
+| `Hero.energies.quest.amount` | `shared.Hero.energies.quest.amount` | Aktuelle Quest-Energy | `Module/Quest.ts:31` | Quest-Trigger |
+| `Hero.energies.quest.max_regen_amount` | `shared.Hero.energies.quest.max_regen_amount` | Max Quest-Energy | `Module/Quest.ts:35` | Quest-Cap |
+| `Hero.energies.quest.next_refresh_ts` | `shared.Hero.energies.quest.next_refresh_ts` | Quest-Refresh | `Service/ParanoiaService.ts:154` | Paranoia |
+| `Hero.energies.quest.seconds_per_point` | `shared.Hero.energies.quest.seconds_per_point` | Quest-Regen | `Service/ParanoiaService.ts:154` | Paranoia |
+| `Hero.energies.worship.amount` | `shared.Hero.energies.worship.amount` | Aktuelle Worship (Pantheon) | `Module/Pantheon.ts:34` | Pantheon-Energy |
+| `Hero.energies.worship.max_regen_amount` | `shared.Hero.energies.worship.max_regen_amount` | Max Worship | `Module/Pantheon.ts:38` | Pantheon-Cap |
+| `Hero.energies.worship.next_refresh_ts` | `shared.Hero.energies.worship.next_refresh_ts` | Worship-Refresh | `Module/Pantheon.ts:125,131,172,178`, `Service/AutoLoopActions.ts:677,683`, `Service/ParanoiaService.ts:207` | Timer |
+| `Hero.energies.worship.seconds_per_point` | `shared.Hero.energies.worship.seconds_per_point` | Worship-Regen | `Service/ParanoiaService.ts:207` | Paranoia |
+| `Hero.energies.drill.amount` | `shared.Hero.energies.drill.amount` | Drill-Energy (PentaDrill) | `Module/PentaDrill.ts:52` | PentaDrill |
+| `Hero.energies.drill.max_regen_amount` | `shared.Hero.energies.drill.max_regen_amount` | Max Drill | `Module/PentaDrill.ts:56` | PentaDrill-Cap |
+| `Hero.energies.drill.next_refresh_ts` | `shared.Hero.energies.drill.next_refresh_ts` | Drill-Refresh | `Module/PentaDrill.ts:194`, `Service/AutoLoopActions.ts:645,651` | Timer |
+| `server_now_ts` | `unsafeWindow.server_now_ts` (kein Hero-Praefix - keine `shared.` Umschreibung) | Server-Zeitstempel (sec) | `Module/Booster.ts:310,327,423,670` | Booster-Endzeit-Berechnung |
+| `championData.team` | `unsafeWindow.championData.team` | Aktuell selektiertes Champ-Team | `Module/Champion.ts:76,312` | Champion-Battle-Team-Logik |
+| `championData.champion.id` | `unsafeWindow.championData.champion.id` | ID des aktuellen Champions | `Module/Champion.ts:313,398` | Team-Save-Slot |
+| `championData.champion.poses` | `unsafeWindow.championData.champion.poses` | Erforderliche Posen-Liste | `Module/Champion.ts:83` | Team-Auswahl |
+| `championData.freeDrafts` | `unsafeWindow.championData.freeDrafts` | Free-Reroll-Counter | `Module/Champion.ts:78` | Champion-Reroll |
+| `championData.hero_damage` | `unsafeWindow.championData.hero_damage` | Schaden des Heroes | `Module/Champion.ts:175` | Champion-Battle-Resultat |
+| `championData.fight.active` | `unsafeWindow.championData.fight.active` | Club-Champ-Fight aktiv | `Module/ClubChampion.ts:139` | ClubChamp-State |
+| `championData.fight.participants` | `unsafeWindow.championData.fight.participants` | Liste Club-Champ-Teilnehmer | `Module/ClubChampion.ts:140` | ClubChamp-Logik |
+| `Chat_vars.CLUB_INFO.id_club` | `unsafeWindow.Chat_vars.CLUB_INFO.id_club` | Club-ID des Spielers | `Module/Club.ts:27` | Club-Status |
+| `opponents_list` | `unsafeWindow.opponents_list` | League-Gegner-Liste | `Module/League.ts:270,543,810` | League-Battle |
+| `availableGirls` | `unsafeWindow.availableGirls` | Map aller Girls (Variante 1) | `Module/TeamModule.ts:458`, `Module/harem/Harem.ts:99,179,641` | Girl-Daten-Quelle |
+| `girlsDataList` | `unsafeWindow.girlsDataList` | Map aller Girls (Variante 2) | `Module/harem/Harem.ts:105,135,241,265` | Girl-Daten-Quelle |
+| `girls_data_list` | `unsafeWindow.girls_data_list` | Map aller Girls (Variante 3 - PSH) | `Module/harem/Harem.ts:102,179,289,641` | Girl-Daten-Quelle (psh-Build) |
+| `shared.GirlSalaryManager.girlsMap` | `unsafeWindow.shared.GirlSalaryManager.girlsMap` | Live-Girl-Map des Salary-Managers | `Module/harem/Harem.ts:64,240,339` | Salary-Manager-Bridge |
+| `shared.GirlSalaryManager.girlsListSec` | `unsafeWindow.shared.GirlSalaryManager.girlsListSec` | Sekundaere Girl-Liste | `Module/harem/Harem.ts:242,266` | Salary-Manager-Bridge |
+| `salary_collect` | `unsafeWindow.salary_collect` | Aufsummierte Salary | `Module/harem/HaremSalary.ts:33` | Salary-Tag |
+| `current_event.event_data.puzzle_pieces` | `unsafeWindow.current_event.event_data.puzzle_pieces` | LivelyScene-Puzzle-Pieces | `Module/Events/LivelyScene.ts:65,158` | LivelyScene-Loesung |
+| `mega_event_data.cards` | `unsafeWindow.mega_event_data.cards` | Owned Mega-Event-Karten | `Module/Events/Seasonal.ts:390` | Seasonal-Event-Status |
+
+Hinweis: `getHHVars` liefert bei Nichtexistenz `null` und loggt (auf Wunsch unterdrueckbar via 2. Parameter `logging=false`). Beispiele dafuer im Code: `getHHVars("availableGirls", false)`, `getHHVars("Chat_vars.CLUB_INFO.id_club", false)`, `getHHVars("girlsDataList", false)`, `getHHVars("girls_data_list", false)`.
+
+## 3. AJAX-Actions (Request-seitig)
+
+Alle `action: "..."` Strings, die der Skript-Code aktiv versendet (via `getHHAjax()` oder gleichwertigen Wrappern).
+Es ist NICHT Liste der von der Webseite selbst gesendeten Actions - dafuer siehe Sektion 4.
+
+| action-String | Weitere Parameter | Datei | Wofuer |
+|---|---|---|---|
+| `hero_update_stats` | `carac: "carac1"\|"carac2"\|"carac3"`, `nb: <mult>` (1/10/30/60) | `Helper/HeroHelper.ts:69-73` | Stat-Punkt-Upgrade |
+| `market_equip_booster` | `id_item: <num>`, `type: "booster"` | `Helper/HeroHelper.ts:126-128` | Booster equippen (normal oder mythic) |
+| `champion_team_reorder` | `champion_id`, weitere Team-Felder (siehe `setChampionTeam()`) | `Module/Champion.ts:319-321` | Champion-Team neu setzen |
+| `do_battles_leagues` | `opponent_id`, `number_of_battles` | `Module/League.ts:830-834` | League-Battle starten (Mehrfach) |
+| `market_buy` | `id_item`, `quantity`, `currency` | `Module/Market.ts:84,165,240` | Item kaufen (gift/potion/booster) |
+| `market_auto_buy` | `id_item`, `quantity` | `Module/Market.ts:133,208` | Auto-Buy (Mass) |
+| `girl_equipment_unequip_all_girls` | (kein Body) | `Module/TeamModule.ts:103` | Bei "Stuff Team" alle Girls vor Equip leeren |
+| `girl_equipment_equip_all` | `id_team` (selektiert) | `Module/TeamModule.ts:351-353` | Equipment fuer alle Girls eines Teams |
+| `loveraid` | (Submit-Wrapper - exakte Felder aus `LoveRaid.start()`) | `Service/AutoLoopActions.ts:254` | LoveRaid auslosen |
+| `contest` | (Wrapper - Claim-Loop) | `Service/AutoLoopActions.ts:417` | Contest claim |
+| `mission` | (Wrapper) | `Service/AutoLoopActions.ts:429` | Mission claim |
+| `champion_buy_ticket` | `cost`/`quantity` (siehe `Champion.buyTicket()`) | `Service/AutoLoopActions.ts:702-704` | Champion-Ticket kaufen |
+| `champion` | (Wrapper) | `Service/AutoLoopActions.ts:726` | Champion-Action |
+| `clubChampion` | (Wrapper) | `Service/AutoLoopActions.ts:738` | Club-Champ-Action |
+| `seasonal` | (Wrapper - Buy/Free-Card und Collect getrennt; siehe Sektion `pipeline`) | `Service/AutoLoopActions.ts:785,815` | Seasonal-Event-Aktionen |
+| `bundle` | (Wrapper) | `Service/AutoLoopActions.ts:864` | Free-Bundles claim |
+| `dailyGoals` | (Wrapper) | `Service/AutoLoopActions.ts:877` | DailyGoals claim |
+| `labyrinth` | (Wrapper) | `Service/AutoLoopActions.ts:890` | Labyrinth-Action |
+| `get_girls_blessings` | (kein Body) | `Service/BlessingService.ts:41` | Blessing-Daten anfragen + cachen |
+| `arena_reload` | `opponent_id` (chosenID) | `Module/Events/Season.ts:368` | Season-Arena-Reload (Reroll) |
+| `girl_skills_reset` | `id_girl` | `Module/harem/Harem.ts:432` | Skill-Reset eines Girls |
+| `girl_equipment_equip` | `id_girl_equipment`, `id_girl` | `Module/harem/HaremGirl.ts:834` | Einzelnes Equipment auf Girl |
+
+Zusaetzlich werden viele weitere Game-Actions vom Spiel selbst gesendet (z.B. `do_battles_trolls`, `do_battles_seasons`, `start` (TempPlaceOfPower), `market_equip_booster` ohne unsere Initiierung). Diese werden in Sektion 4 ueber `onAjaxResponse`-Hooks abgegriffen.
+
+## 4. AJAX-Response-Interceptors (`onAjaxResponse`)
+
+`onAjaxResponse(pattern, callback)` aus `Utils/Utils.ts:25-37` haengt sich global an `$(document).ajaxComplete`.
+Trigger: `opt.data` (Request-Body) matched die uebergebene Regex.
+Skip-Bedingungen: kein `xhr.responseText`, oder `responseData.success !== true`.
+Definition: einziger Aufruf in `Utils/Utils.ts:26`.
+
+| Regex | Was wird getan | Wo gespeichert | Datei |
+|---|---|---|---|
+| `/(action\|class)/` | Praktisch jede Game-AJAX-Antwort. Parsed `equipped_booster` bei `action='market_equip_booster'`, dekrementiert Sandalwood `usages_remaining` bei `action='do_battles_trolls'`, filtert auslaufende Mythic-Booster, triggert `notifyBattleResponseProcessed()`. Bei beendetem Sandalwood + aktivierter SandalWood-Option: navigiert zu Shop. | `HHAuto_Temp_boosterStatus` (`{normal:[], mythic:[]}` JSON-stringified) und `HHAuto_Temp_sandalwoodMaxUsages` | `Module/Booster.ts:113-289` (`Booster.collectBoostersFromAjaxResponses`) |
+| `/action=get_girls_blessings/i` | Wartet 200 ms, dann injiziert externen Spreadsheet-Link `<a class="hhauto-spreadsheet-link">` in `#blessings_popup .blessings_wrapper` | DOM-Injection (kein Storage) | `Module/Spreadsheet.ts:34-45` |
+| Beliebig (Definition) | (Implementation) - gibt Pattern + Callback ans `ajaxComplete`-Hook | - | `Utils/Utils.ts:26` |
+
+Hinweis: `Booster.collectBoostersFromAjaxResponses()` wird einmalig in `StartService.start()` (Zeile mit `Booster.collectBoostersFromAjaxResponses();`) registriert; der Listener bleibt fuer alle nachfolgenden AJAX-Calls aktiv.
+
+## 5. DOM-Quellen mit `data-d`-Attribut (JSON-Inhalt)
+
+`data-d` ist die zentrale Konvention der Spielseite, JSON-Item-Daten direkt am DOM-Knoten zu speichern.
+Felder im JSON: `quantity`, `item.{id_item, type, identifier, rarity, price, currency, value, carac1..3, endurance, chance, ego, damage, duration, skin, name, ico, display_price, name_add, subtype, ...}`.
+
+| jQuery-Selector | Inhalt-Schema (Felder) | Page | Datei |
+|---|---|---|---|
+| `#shops div.armor.merchant-inventory-item .slot` | `{quantity, item:{id_item, type:"armor", identifier, rarity, name_add, subtype, carac1..3, ...}}` | Shop (`pagesIDShop`) | `Module/Shop.ts:52` |
+| `#shops div.booster.merchant-inventory-item .slot` | `{quantity, item:{id_item, type:"booster", identifier, rarity, value, name, ...}}` | Shop | `Module/Shop.ts:53` |
+| `#shops div.gift.merchant-inventory-item .slot` | `{quantity, item:{id_item, type:"gift", value, ...}}` | Shop | `Module/Shop.ts:54` |
+| `#shops div.potion.merchant-inventory-item .slot` | `{quantity, item:{id_item, type:"potion", value, ...}}` | Shop | `Module/Shop.ts:55` |
+| `#shops div.gift.player-inventory-content .slot` | `{quantity, item:{value, ...}}` | Shop | `Module/Shop.ts:60` |
+| `#shops div.potion.player-inventory-content .slot` | `{quantity, item:{value, ...}}` | Shop | `Module/Shop.ts:61` |
+| `#shops div.booster.player-inventory-content .slot` | `{quantity, item:{id_item, identifier, name, rarity}}` | Shop | `Module/Shop.ts:64` |
+| `#equiped .booster .slot:not(.empty):not(.mythic)` (jQ `.data('d')`) | Normal-Booster-Slot (mit `expiration`) | Shop | `Module/Booster.ts:298` |
+| `#equiped .booster .slot:not(.empty).mythic` (jQ `.data('d')`) | Mythic-Booster-Slot (mit `usages_remaining`, `lifetime`) | Shop | `Module/Booster.ts:299` |
+| `#player-inventory.armor .slot:not(.empty)[data-d*='"rarity":"mythic"']` (Selector-Inhalts-Match) | Filter ueber Substring-Match in `data-d` | Shop | `Module/Shop.ts:171` |
+| `[data-d*='"name_add":<X>']` (dyn. Filter) | Filter nach Stat | Shop | `Module/Shop.ts:173,296` |
+| `[data-d*='"subtype":<X>']` (dyn. Filter) | Filter nach Item-Subtyp | Shop | `Module/Shop.ts:179,300` |
+| `[data-d*='"rarity":"<X>"']` (dyn. Filter) | Filter nach Rarity | Shop | `Module/Shop.ts:183,304` |
+| `#equiped .armor .slot[data-d*=<typesOfSets[idx]>]` | Equipped-Armor mit Set-Match | Shop (Sell-Loop) | `Module/Shop.ts:707` |
+| Sell-Loop: `availableItems.filter('.selected')[0].getAttribute('data-d')` | Selektiertes Item pruefen | Shop | `Module/Shop.ts:673,716` |
+| `.right-section .slot[data-d]` (Girl-Equipment-Liste) | `{item:{...}}` Equipment der Girl-Page | GirlPage / Girl-Equipment-Upgrade | `Module/harem/HaremGirl.ts:894,952,961,1017,1073` |
+| `inSlot.getAttribute("data-d")` (generisch in `RewardHelper.parseRewards`) | Reward-Item-JSON (`{item:{type, identifier, rarity, value, ...}, quantity}`) - Beispiel siehe Code-Kommentar | beliebige Page mit Reward-Slots | `Helper/RewardHelper.ts:78` |
+
+JSON-Schema-Beispiel aus `Helper/RewardHelper.ts:163` (Kommentar):
+```
+data-d='{"item":{"id_item":"323","type":"potion","identifier":"XP4","rarity":"legendary",
+  "price":"500000","currency":"sc","value":"2500","carac1":"0","carac2":"0","carac3":"0",
+  "endurance":"0","chance":"0.00","ego":"0","damage":"0","duration":"0",
+  "skin":"hentai,gay,sexy","name":"Spell book",
+  "ico":"https://hh.hh-content.com/pictures/items/XP4.png","display_price":500000},
+  "quantity":"1"}'
+```
+
+## 6. Sonstige DOM-Quellen
+
+Alle anderen relevanten DOM-Reads. Aufgeteilt nach Domain.
+
+### 6.1 Page-Detection / Tab-Switching
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `document.getElementById(gameID)` mit `.getAttribute('page')` | Page-ID (`pagesIDXxx`) | jede Page | `Helper/PageHelper.ts:21,27` |
+| `body[page][id]` `.attr('id')` | gameID fuer "unbekannte URL"-Popup | jede Page | `Helper/ConfigHelper.ts:23` (im Popup-Text) |
+| `#activities-tabs > div.switch-tab.underline-tab.tab-switcher-fade-in[data-tab='contests']` | Erkennt Activities-Tab "Contests" | Activities-Page | `Helper/PageHelper.ts:45` |
+| `[data-tab='missions']` (gleicher Container) | Erkennt Tab "Missions" | Activities-Page | `Helper/PageHelper.ts:49` |
+| `[data-tab='daily_goals']` | Erkennt Tab "DailyGoals" | Activities-Page | `Helper/PageHelper.ts:53` |
+| `[data-tab='pop']` | Erkennt Tab "PlaceOfPower" | Activities-Page | `Helper/PageHelper.ts:67` |
+| `div.pop_list:not([style*="display:none"])` | Sichtbare PoP-Liste vorhanden | Activities/PoP | `Helper/PageHelper.ts:69-70` |
+| `.pop_thumb_selected[pop_id]` `.attr('pop_id')` | Selektierte Pop-Instanz-ID | Activities/PoP | `Helper/PageHelper.ts:78` |
+
+### 6.2 Login / Forbidden / Pre-Start Checks
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `body[innerText='Forbidden']` | "Forbidden"-Errorpage erkennen | jede Page | `Service/StartService.ts:182` |
+| `a[rel='phoenix_member_login']` | Login-Link sichtbar -> nicht eingeloggt | jede Page | `Service/StartService.ts:217` |
+
+### 6.3 Team / Battle Teams
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `.team-member-container[data-team-member-position="0"]` `.attr('data-girl-id')` | ID des Girls auf Position 0 | EditTeam | `Module/TeamModule.ts:380,383` |
+| `.team-slot-container.selected-team` `.attr('data-team-index')` | Index des selektierten Teams | BattleTeams / EditTeam | `Module/TeamModule.ts:389,404` |
+| `.team-member-container[data-team-member-position=N]` (N=0..6) | Slot per Position | EditTeam | `Module/TeamModule.ts:443` |
+| `.team-member-container[data-girl-id="${girlId}"]` (addClass `selected`) | Girl per ID selektieren | EditTeam | `Module/TeamModule.ts:348` |
+
+### 6.4 Labyrinth
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `.player-panel .team-hexagon .team-member-container[data-girl-id="${girlId}"][data-team-member-position="${pos}"]` | Pruefung "Girl X auf Position Y" | EditLabyrinthTeam / Labyrinth | `Module/Labyrinth.ts:172` |
+| `.player-panel .team-hexagon .team-member-container[data-girl-id="${girlId}"]` | Pruefung "Girl X im Squad" | Labyrinth | `Module/Labyrinth.ts:174` |
+| `.team-hexagon .team-member-container.selectable[data-team-member-position="${pos}"]` | Selektierbarer Squad-Slot | EditLabyrinthTeam | `Module/Labyrinth.ts:179` |
+| `(...)[data-girl-id]` `.attr('data-girl-id')` vergleichen mit `.attr('id_girl')` | Aktuelle Position vs Ziel | EditLabyrinthTeam | `Module/Labyrinth.ts:180` |
+| `.opponent-power .opponent-power-text[data-power]` `.attr('data-power')` | Gegner-Power (Hex) | LabyrinthPreBattle | `Module/Labyrinth.ts:550` |
+| `.player-panel .team-hexagon .team-member-container[data-girl-id]` `.length` | Squad-Groesse | Labyrinth | `Module/LabyrinthAuto.ts:219` |
+
+### 6.5 League
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `.league_content .data-list .data-column[sorting]` | Sortierbare Spalten-Header | Leaderboard | `Module/League.ts:240` |
+| `.league_content .data-list` | League-Tabelle Container | Leaderboard | `Module/League.ts:364` |
+| `.data-row.body-row:visible` (in League-Tabelle) | Sichtbare Gegner-Zeilen | Leaderboard | `Module/League.ts:370` |
+| `getElementsByClassName("data-list")[0]` | Tabellen-Root (DOM-API) | Leaderboard | `Module/League.ts:420,439` |
+| `.data-row body-row` (innerhalb) | Gegner-Liste | Leaderboard | `Module/League.ts:422,441` |
+| `.data-column.head-column` (querySelectorAll) | Header-Zellen | Leaderboard | `Module/League.ts:488` |
+| `.body-row .data-column[column="power"]` `.first().html()/.text()` | Power-Spalte (matchRating-Erkennung) | Leaderboard | `Module/League.ts:511` |
+| `.data-list .data-row.body-row` | Alle Body-Rows | Leaderboard | `Module/League.ts:528` |
+| `.data-column[column="power"] .matchRating-expected .matchRating-value` `.text()` | Erwartete Power | Leaderboard | `Module/League.ts:535` |
+| `.data-column[column="power"]` `.text()` (mit `parsePrice`) | Plain-Power | Leaderboard | `Module/League.ts:537` |
+| `.data-list .data-row.body-row a` `.length` | Noch zu kaempfende Gegner | Leaderboard | `Module/League.ts:541` |
+| `.data-list .data-row.body-row.player-row .data-column[column="place"]` `.text()` | Eigener Rank | Leaderboard | `Module/League.ts:714` |
+| `.data-list .data-row.body-row.player-row .data-column[column="player_league_points"]` `.text()` | Eigener Score | Leaderboard | `Module/League.ts:715` |
+| `.data-list .data-row.body-row` `.length+1` | Total Players | Leaderboard | `Module/League.ts:719` |
+| `.data-column[column="place"]:contains(N)` (filter) | Spezifischer Rang-Selector | Leaderboard | `Module/League.ts:731,777` |
+| `.data-column[column="player_league_points"]` (parent.text) | Score zu Rang | Leaderboard | `Module/League.ts:737,783` |
+
+### 6.6 Pantheon / Champion / Club Champion
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `#pre-battle .battle-buttons .green_button_L.battle-action-button.pantheon-single-battle-button[data-pantheon-id='${id}']` | Pantheon-Single-Battle-Button | PantheonPreBattle | `Module/Pantheon.ts:143` |
+| `.champions-over__champion-info.champions-animation .champion-pose` | Champion-Pose-Bilder fuer `getPoses()` | ChampionsPage / ChampionsMap | `Module/Champion.ts:83` |
+| `div.club-champion-members-challenges .player-row .data-column:nth-of-type(3)` | Tickets-used pro Club-Member | ClubChampion | `Module/ClubChampion.ts:209` |
+
+### 6.7 Pachinko
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `#playzone-replace-info button[data-free="true"].blue_button_L` | Free-Pachinko-Button | Pachinko | `Module/Pachinko.ts:66` |
+| `[girlsRewards].attr("data-rewards")` (JSON) | Anzahl Girls als Reward | Pachinko | `Module/Pachinko.ts:121` |
+
+### 6.8 Troll-Battle / Pre-Battle
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `#pre-battle .battle-buttons button.autofight[data-battles="10"]` | x10-Fight-Button | TrollPreBattle / generisch | `Module/Troll.ts:434` |
+| `#pre-battle .battle-buttons button.autofight[data-battles="50"]` | x50-Fight-Button | TrollPreBattle | `Module/Troll.ts:435` |
+| `#pre-battle .oponnent-panel .opponent_rewards .rewards_list .slot.girl_ico[data-rewards]` | Girl-Reward-Slots | TrollPreBattle | `Module/Troll.ts:458` |
+| `[rewardGirlz].attr('data-rewards')` (JSON) | JSON-Liste Girl-Shards | TrollPreBattle | `Module/Troll.ts:459` |
+
+### 6.9 Season / Seasonal / Events
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `.season_arena_opponent_container[data-opponent=${id_fighter}]` | Block des selektierten Arena-Gegners | SeasonArena | `Module/Events/Season.ts:154,205,391` |
+| `.slot.girl_ico[data-rewards]` (im Opponent-Block) | Girl-Shards-Reward | SeasonArena | `Module/Events/Season.ts:393` |
+| `[data-select-girl-id=${id_girl}]` (in Daily-Mission/Event-Page) | Girl-Tile | Event-Page / Mission | `Module/Events/EventModule.ts:523,563,576` |
+| `.hard-objective .redirect-buttons:has(button[data-href="/champions-map.html"])` | Champion-Goal-Block (Hard) | DoublePenetration-Event | `Module/Events/DoublePenetration.ts:163` |
+| `.easy-objective .redirect-buttons:has(button[data-href="/champions-map.html"])` | Champion-Goal-Block (Easy) | DP-Event | `Module/Events/DoublePenetration.ts:167` |
+| `#poa-content .buttons:has(button[data-href="/champions-map.html"])` | Champion-Goal-Block in PoA | PoA | `Module/Events/PathOfAttraction.ts:102` |
+| `listPoATiersToClaim[i].getAttribute("data-nc-reward-id")` | PoA-Tier-Reward-ID | PoA | `Module/Events/PathOfAttraction.ts:168` |
+
+### 6.10 Harem / Girl
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `#harem_right .opened` `.attr('girl')` | Aktuell ausgewaehltes Girl-ID (Side-Panel) | Harem | `Module/harem/Harem.ts:476,503,513,528` |
+| `#harem_right .opened .avatar-box:visible` `.length` | Girl ist ownership-bestaetigt | Harem | `Module/harem/Harem.ts:505,530` |
+| `.select-group.${selector} .selectric-items li[data-index="${index}"]` (trigger click) | Selectric-Filter-Element | Harem | `Module/harem/HaremFilter.ts:35` |
+| `#girl-leveler-tabs .switch-tab[data-tab="${haremItem}"]` | Girl-Leveler-Tab | GirlPage | `Module/harem/HaremGirl.ts:78` |
+| `.hhava` `.length` | Eigene Avatar-Marker bereits gerendert | Harem | `Module/harem/Harem.ts:527` |
+
+### 6.11 Markt / Shop / Inventory (Timer + Toolbar)
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `.shop div.shop_count span[rel="expires"]` `.first().text()` | Shop-Refresh-Timer (HH:MM:SS) | Shop | `Module/Shop.ts:81` (siehe `convertTimeToInt`) |
+| `#girls_list .g1 .nav_placement span:not([contenteditable])` | Shop-Girl-Count | Shop | `HHEnvVariables.ts:62` (`shopGirlCountRequest`) |
+| `#girls_list .g1 .nav_placement span[contenteditable]` | Aktueller Shop-Girl-Index | Shop | `HHEnvVariables.ts:63` (`shopGirlCurrentRequest`) |
+
+### 6.12 Sonstige UI-Lookups (Timer, Reward-Banner, etc.)
+
+| Selector | Was extrahiert | Page | Datei |
+|---|---|---|---|
+| `#contains_all header .currency .daily-reward-notif` | Daily-Reward-Notification | jede Page | `HHEnvVariables.ts:57` (`dailyRewardNotifRequest`) |
+| `#edit-team-page` (id-Selector) | EditTeam-Panel-Container | EditTeam | `HHEnvVariables.ts:60` (`IDpanelEditTeam`) |
+| `#claim-all:not([disabled]):visible:not([style*='visibility: hidden;'])` | "Claim All"-Button | beliebig | `HHEnvVariables.ts:65` (`selectorClaimAllRewards`) |
+| `[PoVPoG-Slot].attr('data-time-stamp')` | Timestamp eines PoV/PoG-Tier-Slots | PoV / PoG | `HHEnvVariables.ts:73` (`PoVPoGTimestampAttributeName`) |
+| `[girl-tile].attr('data-new-girl-tooltip')` | New-Girl-Tooltip-Daten | beliebige Page mit Girl-Slots | `HHEnvVariables.ts:58` (`girlToolTipData`) |
+| `:not([style*="display:none"]):not([style*="display: none"])` | Filter "nicht versteckt" (generisches Suffix) | jede Page | `HHEnvVariables.ts:64` (`selectorFilterNotDisplayNone`) |
+
+## 7. localStorage / Storage-Keys
+
+ `getStoredValue` / `getStoredJSON` lesen, `setStoredValue` schreibt, `deleteStoredValue` loescht.
+  Alle Keys sind mit `HHStoredVarPrefixKey` (Default: `HHAuto_`) praefixiert; das Praefix wird in den Tabellen unten weggelassen.
+  Wichtig: Nicht in `HHStoredVars.ts` registrierte Keys werden lautlos verworfen - siehe Hinweis im File.
+
+  Storage-Backing (siehe `HHStoredVars.ts`): `localStorage` direkt, `sessionStorage` direkt, oder `Storage()` (gating ueber `SK.settPerTab` -> sessionStorage, sonst localStorage). Settings sind in der Regel `Storage()`, Temp-Vars meist `sessionStorage`.
+
+  | Key (SK.x oder TK.x) | Inhalt / Zweck | Wo geschrieben (set) | Wo geloescht (delete) | Wo gelesen (get) |
+  |---|---|---|---|---|
+| `SK.AllMaskRewards` | Master-Toggle: alle Reward-Masken (PoA/PoG/PoV/Season/Seasonal) global an/aus | Service/StartService.ts | - | Module/Events/PathOfAttraction.ts, Module/Events/Season.ts, Module/Events/Seasonal.ts, Module/PentaDrill.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.PoAMaskRewards` | Veraltet (vor 7.26.0). Wird beim Migrieren in AllMaskRewards aufgeloest. | (nur init/storage-Helper) | Service/StartService.ts | Service/StartService.ts |
+| `SK.PoGMaskRewards` | Veraltet (vor 7.26.0). | (nur init/storage-Helper) | Service/StartService.ts | Service/StartService.ts |
+| `SK.PoVMaskRewards` | Veraltet (vor 7.26.0). | (nur init/storage-Helper) | Service/StartService.ts | Service/StartService.ts |
+| `SK.SeasonMaskRewards` | Veraltet (vor 7.26.0). | (nur init/storage-Helper) | Service/StartService.ts | Service/StartService.ts |
+| `SK.SeasonalEventMaskRewards` | Veraltet (vor 7.26.0). | (nur init/storage-Helper) | Service/StartService.ts | Service/StartService.ts |
+| `SK.autoAff` | Schwelle Affection-Auto-Use (Ymen-Limit) | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoAffW` | Auto-Aff-Switch (an/aus) | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoBuildChampsTeam` | Champion-Team automatisch aufbauen | (nur init/storage-Helper) | - | Module/Champion.ts, Module/ClubChampion.ts |
+| `SK.autoBuyBoosters` | Auto-Buy normale Booster | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoBuyBoostersFilter` | Filter, welche Booster-Typen gekauft werden duerfen | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoBuyLoveRaidTrollNumber` | Anzahl LoveRaid-Combats pro Buy | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.autoBuyMythicTrollNumber` | Anzahl Mythic-Combats pro Buy | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.autoBuyTrollNumber` | Anzahl normale Combats pro Buy | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.autoChampAlignTimer` | Champion-Timer mit Battle-Timer ausrichten | (nur init/storage-Helper) | - | Module/Champion.ts, Module/ClubChampion.ts |
+| `SK.autoChamps` | Auto-Champions aktiviert | (nur init/storage-Helper) | - | Module/ClubChampion.ts, Service/AutoLoopActions.ts, Service/AutoLoopPageHandlers.ts, Service/InfoService.ts |
+| `SK.autoChampsFilter` | Champion-Filter (welche Champs) | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsForceStart` | Champion-Force-Start ohne Timer | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsForceStartEventGirl` | Force-Start nur bei Event-Girl | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsGirlThreshold` | Mindest-Girl-Threshold fuer Champ-Run | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsTeamKeepSecondLine` | 2. Team-Line beibehalten | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsTeamLoop` | Team-Loop-Anzahl | (nur init/storage-Helper) | - | Module/Champion.ts |
+| `SK.autoChampsUseEne` | Energy verwenden | (nur init/storage-Helper) | - | Module/Champion.ts, Service/AutoLoopActions.ts |
+| `SK.autoClubChamp` | Auto-Club-Champ aktiviert | (nur init/storage-Helper) | - | Module/Champion.ts, Module/ClubChampion.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoClubChampMax` | Max Tickets pro Run | (nur init/storage-Helper) | - | Module/ClubChampion.ts |
+| `SK.autoClubForceStart` | Force-Start Club-Champ | (nur init/storage-Helper) | - | Module/ClubChampion.ts |
+| `SK.autoContest` | Auto-Contest aktiviert | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoDailyGoals` | Auto-DailyGoals aktiviert | (nur init/storage-Helper) | - | Module/DailyGoals.ts |
+| `SK.autoDailyGoalsCollect` | DailyGoals-Rewards einsammeln | (nur init/storage-Helper) | - | Module/DailyGoals.ts, Service/AutoLoopActions.ts |
+| `SK.autoDailyGoalsCollectablesList` | Welche Reward-Typen einsammeln (JSON-Array) | (nur init/storage-Helper) | - | Module/DailyGoals.ts |
+| `SK.autoEquipBoosters` | Boosters automatisch ausruesten | (nur init/storage-Helper) | - | Module/Booster.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoEquipBoostersSlots` | Slot-Reihenfolge (z.B. B1;B2;B3;B4) | (nur init/storage-Helper) | - | Module/Booster.ts |
+| `SK.autoExp` | Schwelle XP-Auto-Use | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoExpW` | Auto-XP-Switch | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.autoFreeBundlesCollect` | Freie Bundles einsammeln | (nur init/storage-Helper) | - | Module/Bundles.ts, Service/AutoLoopActions.ts |
+| `SK.autoFreePachinko` | Auto-Free-Pachinko | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoLabyCustomTeamBuilder` | Labyrinth-Custom-Team-Builder verwenden | (nur init/storage-Helper) | - | Module/Labyrinth.ts, Module/LabyrinthAuto.ts |
+| `SK.autoLabyDifficultyIndex` | Labyrinth-Schwierigkeit (selectedIndex) | (nur init/storage-Helper) | - | Module/LabyrinthAuto.ts |
+| `SK.autoLabyHard` | Labyrinth-Hard-Mode (Reward-Wahl haerter) | (nur init/storage-Helper) | - | Module/Labyrinth.ts |
+| `SK.autoLabySweep` | Labyrinth-Sweep-Mode | (nur init/storage-Helper) | - | Module/LabyrinthAuto.ts |
+| `SK.autoLabyrinth` | Auto-Labyrinth aktiviert | Module/LabyrinthAuto.ts | - | Module/GenericBattle.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoLeagues` | Auto-Leagues aktiviert | (nur init/storage-Helper) | - | Module/GenericBattle.ts, Module/League.ts, Service/InfoService.ts |
+| `SK.autoLeaguesAllowWinCurrent` | Sieg im aktuellen Tier zulassen | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesBoostedOnly` | Nur mit Boostern kaempfen | (nur init/storage-Helper) | - | Module/Booster.ts, Module/League.ts |
+| `SK.autoLeaguesCollect` | League-Reward einsammeln | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesForceOneFight` | Mindestens 1 Fight erzwingen | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesRunThreshold` | Run-Threshold Leagues | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesSecurityThreshold` | Security-Threshold Leagues | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesSelectedIndex` | Selektierter Tier-Index | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLeaguesSortIndex` | League-Sort-Mode (Index) | (nur init/storage-Helper) | - | Module/League.ts, Service/StartService.ts |
+| `SK.autoLeaguesThreshold` | Threshold Leagues | (nur init/storage-Helper) | - | Module/League.ts |
+| `SK.autoLivelySceneEventCollect` | LivelyScene Reward sammeln | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/LivelyScene.ts |
+| `SK.autoLivelySceneEventCollectAll` | LivelyScene Alle Rewards | (nur init/storage-Helper) | - | Module/Events/LivelyScene.ts |
+| `SK.autoLivelySceneEventCollectablesList` | Welche LivelyScene-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/LivelyScene.ts |
+| `SK.autoLoveRaidSelectedIndex` | Selektierte LoveRaid-Variante | Module/Events/LoveRaidManager.ts, Module/Troll.ts | config/HHStoredVars.ts | Module/Events/LoveRaidManager.ts |
+| `SK.autoMission` | Auto-Mission aktiviert | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoMissionCollect` | Mission-Rewards einsammeln | (nur init/storage-Helper) | - | Module/Missions.ts |
+| `SK.autoMissionKFirst` | KFirst-Mission-Mode | (nur init/storage-Helper) | - | Module/Missions.ts |
+| `SK.autoPantheon` | Auto-Pantheon aktiviert | Module/Pantheon.ts | - | Module/GenericBattle.ts, Service/AutoLoopActions.ts, Service/InfoService.ts, Service/ParanoiaService.ts |
+| `SK.autoPantheonBoostedOnly` | Nur mit Booster | (nur init/storage-Helper) | - | Module/Booster.ts, Module/Pantheon.ts |
+| `SK.autoPantheonRunThreshold` | Pantheon Run-Threshold | (nur init/storage-Helper) | - | Module/Pantheon.ts |
+| `SK.autoPantheonThreshold` | Pantheon Threshold | (nur init/storage-Helper) | - | Module/Pantheon.ts |
+| `SK.autoPentaDrill` | Auto-PentaDrill aktiviert | (nur init/storage-Helper) | - | Module/GenericBattle.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoPentaDrillBoostedOnly` | Nur mit Booster | (nur init/storage-Helper) | - | Module/PentaDrill.ts |
+| `SK.autoPentaDrillCollect` | PentaDrill-Rewards einsammeln | (nur init/storage-Helper) | - | Module/PentaDrill.ts, Service/AutoLoopActions.ts |
+| `SK.autoPentaDrillCollectAll` | PentaDrill alle Rewards | (nur init/storage-Helper) | - | Module/PentaDrill.ts, Service/AutoLoopActions.ts |
+| `SK.autoPentaDrillCollectablesList` | Welche PentaDrill-Rewards (JSON) | (nur init/storage-Helper) | - | Module/PentaDrill.ts |
+| `SK.autoPentaDrillRunThreshold` | PentaDrill Run-Threshold | (nur init/storage-Helper) | - | Module/PentaDrill.ts |
+| `SK.autoPentaDrillThreshold` | PentaDrill Threshold | (nur init/storage-Helper) | - | Module/PentaDrill.ts |
+| `SK.autoPoACollect` | PoA Rewards einsammeln | (nur init/storage-Helper) | - | Module/Events/PathOfAttraction.ts |
+| `SK.autoPoACollectAll` | PoA alle Rewards | (nur init/storage-Helper) | - | Module/Events/PathOfAttraction.ts |
+| `SK.autoPoACollectablesList` | Welche PoA-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/PathOfAttraction.ts |
+| `SK.autoPoGCollect` | PoG Rewards einsammeln | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/PathOfGlory.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoPoGCollectAll` | PoG alle Rewards | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/PathOfGlory.ts, Service/AutoLoopActions.ts |
+| `SK.autoPoGCollectablesList` | Welche PoG-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/PathOfGlory.ts |
+| `SK.autoPoVCollect` | PoV Rewards einsammeln | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/PathOfValue.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoPoVCollectAll` | PoV alle Rewards | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/PathOfValue.ts, Service/AutoLoopActions.ts |
+| `SK.autoPoVCollectablesList` | Welche PoV-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/PathOfValue.ts |
+| `SK.autoPowerPlaces` | Auto-PoP aktiviert | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts, Service/InfoService.ts |
+| `SK.autoPowerPlacesAll` | Alle Pops automatisch starten | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts |
+| `SK.autoPowerPlacesIndexFilter` | Pop-Filter (Index-Liste, semicolon) | Module/PlaceOfPower.ts | - | Module/PlaceOfPower.ts, Service/AutoLoopActions.ts |
+| `SK.autoPowerPlacesInverted` | Filter-Logik invertiert | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts |
+| `SK.autoPowerPlacesPrecision` | Praezisions-Modus | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts |
+| `SK.autoPowerPlacesWaitMax` | Auf max. Wartezeit warten | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts |
+| `SK.autoQuest` | Auto-Quest aktiviert | Module/Troll.ts, Service/AutoLoopActions.ts | - | Module/Quest.ts, Service/AutoLoopActions.ts, Service/ParanoiaService.ts |
+| `SK.autoQuestThreshold` | Quest-Threshold | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts |
+| `SK.autoSalary` | Auto-Salary aktiviert | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.autoSalaryMinSalary` | Minimal-Salary fuer Auto-Run | (nur init/storage-Helper) | - | Module/harem/HaremSalary.ts |
+| `SK.autoSeason` | Auto-Season aktiviert | (nur init/storage-Helper) | - | Module/GenericBattle.ts, Service/AutoLoopActions.ts, Service/InfoService.ts, Service/ParanoiaService.ts |
+| `SK.autoSeasonBoostedOnly` | Season nur mit Booster | (nur init/storage-Helper) | - | Module/Booster.ts, Module/Events/Season.ts |
+| `SK.autoSeasonCollect` | Season-Reward sammeln | (nur init/storage-Helper) | - | Module/Events/Season.ts, Service/AutoLoopActions.ts |
+| `SK.autoSeasonCollectAll` | Season alle Rewards | (nur init/storage-Helper) | - | Module/Events/Season.ts, Service/AutoLoopActions.ts |
+| `SK.autoSeasonCollectablesList` | Welche Season-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonIgnoreNoGirls` | Season-Gegner ohne Girls ignorieren | (nur init/storage-Helper) | - | Module/Events/Season.ts, Service/ParanoiaService.ts |
+| `SK.autoSeasonMaxTier` | Max-Tier-Stop verwenden | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonMaxTierNb` | Max-Tier-Wert | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonPassReds` | Rote (zu schwere) Gegner ueberspringen | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonRunThreshold` | Season Run-Threshold | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonSkipLowMojo` | Skip Gegner mit niedrigem Mojo | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonThreshold` | Season Threshold | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.autoSeasonalBuyFreeCard` | Seasonal: Free-Card kaufen | (nur init/storage-Helper) | - | Service/AutoLoopActions.ts |
+| `SK.autoSeasonalEventCollect` | Seasonal Reward sammeln | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/Seasonal.ts, Service/AutoLoopActions.ts |
+| `SK.autoSeasonalEventCollectAll` | Seasonal alle Rewards | Module/Events/EventModule.ts | - | Module/Events/EventModule.ts, Module/Events/Seasonal.ts, Service/AutoLoopActions.ts |
+| `SK.autoSeasonalEventCollectablesList` | Welche Seasonal-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/Seasonal.ts |
+| `SK.autoSideQuest` | Auto-SideQuest aktiviert | Service/AutoLoopActions.ts | - | Module/Quest.ts, Service/AutoLoopActions.ts, Service/ParanoiaService.ts |
+| `SK.autoStats` | Stat-Spend-Limit (Ymens) | (nur init/storage-Helper) | - | Helper/HeroHelper.ts |
+| `SK.autoStatsSwitch` | Auto-Stats an/aus | (nur init/storage-Helper) | - | Service/StartService.ts |
+| `SK.autoTrollBattle` | Auto-Troll aktiviert | Module/Troll.ts, Service/AutoLoopActions.ts | - | Module/Troll.ts, Service/AutoLoopActions.ts, Service/InfoService.ts, Service/ParanoiaService.ts, config/StorageKeys.ts |
+| `SK.autoTrollLoveRaidByPassThreshold` | Bypass-Threshold fuer LoveRaid | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.autoTrollMythicByPassParanoia` | Mythic-Bypass von Paranoia erlauben | (nur init/storage-Helper) | - | Service/ParanoiaService.ts |
+| `SK.autoTrollMythicByPassThreshold` | Mythic-Bypass-Threshold | (nur init/storage-Helper) | - | Service/ParanoiaService.ts |
+| `SK.autoTrollRunThreshold` | Troll Run-Threshold | (nur init/storage-Helper) | - | Module/Troll.ts, Service/AutoLoopActions.ts |
+| `SK.autoTrollSelectedIndex` | Selektierter Troll (Index) | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.autoTrollThreshold` | Troll Threshold | (nur init/storage-Helper) | - | Module/Troll.ts, Service/AutoLoopActions.ts, Service/ParanoiaService.ts |
+| `SK.autodpEventCollect` | DP-Event Reward sammeln | Module/Events/EventModule.ts | - | Module/Events/DoublePenetration.ts, Module/Events/EventModule.ts |
+| `SK.autodpEventCollectAll` | DP-Event alle Rewards | (nur init/storage-Helper) | - | Module/Events/DoublePenetration.ts |
+| `SK.autodpEventCollectablesList` | Welche DP-Event-Rewards (JSON) | (nur init/storage-Helper) | - | Module/Events/DoublePenetration.ts |
+| `SK.bossBangEvent` | BossBang Auto aktiviert | Module/Events/BossBang.ts | - | Module/Events/EventModule.ts, Service/AutoLoopActions.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.bossBangMinTeam` | Mindest-Team fuer BossBang | (nur init/storage-Helper) | - | Module/Events/BossBang.ts |
+| `SK.buyCombTimer` | Auto-Buy-Combat Timer | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.buyCombat` | Auto-Buy-Combat aktiviert | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.buyLoveRaidCombat` | Auto-Buy LoveRaid-Combat | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.buyMythicCombTimer` | Auto-Buy Mythic-Combat-Timer | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.buyMythicCombat` | Auto-Buy Mythic-Combat | (nur init/storage-Helper) | - | Module/Troll.ts, Service/ParanoiaService.ts |
+| `SK.collectAllTimer` | ClaimAll-Timer (Sekunden) | (nur init/storage-Helper) | - | Helper/TimeHelper.ts |
+| `SK.collectEventChest` | Event-Chest abholen | (nur init/storage-Helper) | - | Module/Events/EventModule.ts |
+| `SK.compactDailyGoals` | DailyGoals-UI kompakt | (nur init/storage-Helper) | - | Module/DailyGoals.ts |
+| `SK.compactEndedContests` | Beendete Contests kompakt | (nur init/storage-Helper) | - | Module/Contest.ts |
+| `SK.compactMissions` | Missions kompakt | (nur init/storage-Helper) | - | Module/Missions.ts |
+| `SK.compactPowerPlace` | PoP kompakt | (nur init/storage-Helper) | - | Module/PlaceOfPower.ts |
+| `SK.eventTrollOrder` | Reihenfolge der Event-Trolls | (nur init/storage-Helper) | - | Module/Events/EventModule.ts, Module/Events/MythicEvent.ts, Module/Events/PlusEvents.ts |
+| `SK.hideOwnedGirls` | Owned Girls in Event-UI verstecken | (nur init/storage-Helper) | - | Module/Events/EventModule.ts |
+| `SK.invertMissions` | Mission-Reihenfolge invertieren | (nur init/storage-Helper) | - | Module/Missions.ts |
+| `SK.kobanBank` | Koban-Bank-Threshold (was nicht ausgegeben werden darf) | (nur init/storage-Helper) | - | Module/Events/Season.ts, Module/Market.ts, Module/Troll.ts |
+| `SK.leagueListDisplayPowerCalc` | PowerCalc-Spalte in League-Liste anzeigen | (nur init/storage-Helper) | - | Module/League.ts, Service/StartService.ts |
+| `SK.master` | Globaler Master-Switch (alles an/aus) | Helper/PageHelper.ts, Service/InfoService.ts, Service/StartService.ts | - | Helper/HHMenuHelper.ts, Service/AutoLoop.ts, Service/InfoService.ts, Service/Scheduler.ts |
+| `SK.maxAff` | Max Aff Stack | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.maxBooster` | Max Booster im Storage | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.maxExp` | Max Exp Stack | (nur init/storage-Helper) | - | Module/Market.ts |
+| `SK.minShardsX10` | Mindest-Shards fuer x10-Fight | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.minShardsX50` | Mindest-Shards fuer x50-Fight | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.mousePause` | Maus-Pause aktivieren | (nur init/storage-Helper) | - | Service/StartService.ts |
+| `SK.mousePauseTimeout` | Maus-Pause-Timeout (ms) | (nur init/storage-Helper) | - | Service/MouseService.ts |
+| `SK.paranoia` | Paranoia-Mode aktiv | (nur init/storage-Helper) | - | Module/Shop.ts, Service/AutoLoop.ts, Service/AutoLoopActions.ts, Service/InfoService.ts |
+| `SK.paranoiaSettings` | Paranoia-Einstellungen JSON | (nur init/storage-Helper) | - | Service/ParanoiaService.ts |
+| `SK.paranoiaSpendsBefore` | Paranoia-Spend-Verzeichnis JSON | (nur init/storage-Helper) | - | Service/ParanoiaService.ts |
+| `SK.plusEvent` | +Event Bonus aktiv | (nur init/storage-Helper) | - | Module/Booster.ts, Module/Events/EventModule.ts, Module/GenericBattle.ts, Module/Troll.ts, Service/AutoLoopActions.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.plusEventLoveRaidSandalWood` | +LoveRaid Sandalwood-Modus | (nur init/storage-Helper) | - | Module/Booster.ts |
+| `SK.plusEventMythic` | +Event Mythic-Bonus | (nur init/storage-Helper) | - | Module/Booster.ts, Module/Events/EventModule.ts, Module/GenericBattle.ts, Module/Troll.ts, Service/AutoLoop.ts, Service/AutoLoopActions.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.plusEventMythicSandalWood` | +Mythic-Sandalwood | (nur init/storage-Helper) | - | Module/Booster.ts |
+| `SK.plusEventSandalWood` | +Event-Sandalwood | (nur init/storage-Helper) | - | Module/Booster.ts |
+| `SK.plusGirlSkins` | Girl-Skins-Pruefung in Events/Raids | (nur init/storage-Helper) | - | Module/Events/LoveRaidManager.ts |
+| `SK.plusLoveRaid` | +LoveRaid aktiv | (nur init/storage-Helper) | - | Module/Events/LoveRaidManager.ts |
+| `SK.plusLoveRaidMythic` | +LoveRaid Mythic-Mode (off/exact3/min3/exact5) | Service/StartService.ts | - | Module/Events/LoveRaidManager.ts, Service/StartService.ts |
+| `SK.safeSecondsForContest` | Sicherheits-Sekunden Contest-Submission | (nur init/storage-Helper) | - | Helper/TimeHelper.ts |
+| `SK.sandalwoodMinShardsThreshold` | Mindest-Shards um Sandalwood einzusetzen | (nur init/storage-Helper) | - | Module/Booster.ts |
+| `SK.saveDefaults` | Benutzer-Default-Werte fuer Settings (JSON-Map) | Helper/StorageHelper.ts | - | Helper/StorageHelper.ts |
+| `SK.seasonDisplayPowerCalc` | PowerCalc-Anzeige Season | (nur init/storage-Helper) | - | Module/Events/Season.ts |
+| `SK.settPerTab` | Settings pro Tab (sessionStorage statt localStorage) | (nur init/storage-Helper) | - | Helper/StorageHelper.ts |
+| `SK.showAdsBack` | Ads im Layout zeigen | (nur init/storage-Helper) | - | Service/AdsService.ts |
+| `SK.showCalculatePower` | Power-Calc-UI anzeigen | (nur init/storage-Helper) | - | Service/AutoLoopPageHandlers.ts |
+| `SK.showClubButtonInPoa` | Club-Button in PoA | (nur init/storage-Helper) | - | Module/Events/DoublePenetration.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.showHaremAvatarMissingGirls` | Avatar-Marker fuer fehlende Girls in Harem | (nur init/storage-Helper) | - | Module/harem/Harem.ts |
+| `SK.showHaremSkillsButtons` | Skill-Reset-Button in Harem | (nur init/storage-Helper) | - | Module/harem/HaremGirl.ts |
+| `SK.showHaremTools` | Harem-Tools UI | (nur init/storage-Helper) | - | Module/harem/Harem.ts, Module/harem/HaremGirl.ts |
+| `SK.showInfo` | Info-Overlay anzeigen | (nur init/storage-Helper) | - | Service/InfoService.ts |
+| `SK.showInfoLeft` | Info-Overlay links | (nur init/storage-Helper) | - | Service/InfoService.ts |
+| `SK.showMarketTools` | Markt-Tools | (nur init/storage-Helper) | - | Service/AutoLoopPageHandlers.ts |
+| `SK.showRewardsRecap` | Reward-Recap-Anzeige | (nur init/storage-Helper) | - | Module/Events/DoublePenetration.ts, Module/Events/LivelyScene.ts, Module/Events/PathOfAttraction.ts, Module/Events/Seasonal.ts, Service/AutoLoopPageHandlers.ts |
+| `SK.showTooltips` | Tooltips an | (nur init/storage-Helper) | - | Service/TooltipService.ts |
+| `SK.sultryMysteriesEventRefreshShop` | SultryMysteries: Shop-Refresh erlauben | (nur init/storage-Helper) | - | Module/Events/EventModule.ts |
+| `SK.updateMarket` | Markt aktiv updaten | (nur init/storage-Helper) | - | Module/Shop.ts, Service/InfoService.ts |
+| `SK.useX10Fights` | x10-Fights nutzen | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.useX10FightsAllowNormalEvent` | x10 auch in normalem Event | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.useX50Fights` | x50-Fights nutzen | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.useX50FightsAllowNormalEvent` | x50 auch in normalem Event | (nur init/storage-Helper) | - | Module/Troll.ts |
+| `SK.waitforContest` | Contest-Ende abwarten | (nur init/storage-Helper) | - | Helper/TimeHelper.ts, Module/Contest.ts, Service/AutoLoop.ts, Service/InfoService.ts |
+| `TK.CheckSpentPoints` | Marker: 'Punkte schon gespendet?' | Service/AutoLoop.ts | - | Service/AutoLoop.ts |
+| `TK.Debug` | Debug-Mode flag | (nur init/storage-Helper) | - | Helper/HHMenuHelper.ts, Module/Champion.ts, Module/Events/LoveRaidManager.ts, Module/Events/PathOfAttraction.ts, Module/Events/Season.ts, Module/Labyrinth.ts, Module/LabyrinthAuto.ts, Module/League.ts, Module/Missions.ts, Module/Pachinko.ts, Module/PentaDrill.ts, Module/PlaceOfPower.ts, Module/RelicManager.ts, Module/Troll.ts, Module/harem/Harem.ts, Module/harem/HaremGirl.ts |
+| `TK.EventFightsBeforeRefresh` | Counter Fights bis Event-Refresh | Module/Troll.ts | - | Helper/RewardHelper.ts, Module/Troll.ts |
+| `TK.HaremSize` | Aktuelle Harem-Groesse + Timestamp | Module/harem/Harem.ts | - | Helper/BDSMHelper.ts, Module/harem/Harem.ts, Service/AutoLoopActions.ts |
+| `TK.LastPageCalled` | Zuletzt aufgerufene Seite (Loop-Detection) | Service/PageNavigationService.ts, Service/StartService.ts | Service/AutoLoopActions.ts, Service/StartService.ts | Module/Shop.ts, Service/AutoLoopActions.ts, Service/StartService.ts |
+| `TK.LeagueHumanLikeRun` | League: Human-Like-Run-Daten | Module/League.ts | - | Module/League.ts |
+| `TK.LeagueOpponentList` | Cache der League-Gegner-Liste | Module/League.ts | Module/League.ts, Service/StartService.ts, Utils/LogUtils.ts, config/HHStoredVars.ts | (?) |
+| `TK.Logging` | In-Browser-Log-Buffer (sessionStorage) | Utils/LogUtils.ts | - | Utils/LogUtils.ts |
+| `TK.MainAdventureWorldID` | Welt-ID im Main-Adventure | Service/StartService.ts | - | Service/StartService.ts |
+| `TK.NextSwitch` | Naechster Paranoia-Switch-Zeitpunkt | Service/ParanoiaService.ts | - | Service/ParanoiaService.ts |
+| `TK.PantheonHumanLikeRun` | Pantheon HumanLike-State | Module/Pantheon.ts, Service/AutoLoopActions.ts | - | Module/Pantheon.ts, Service/AutoLoopActions.ts |
+| `TK.PentaDrillHumanLikeRun` | PentaDrill HumanLike-State | Module/PentaDrill.ts, Service/AutoLoopActions.ts | - | Module/PentaDrill.ts, Service/AutoLoopActions.ts |
+| `TK.PoAEndDate` | PoA Event-Endzeit | Module/Events/PathOfAttraction.ts | - | Module/Events/PathOfAttraction.ts |
+| `TK.PoGEndDate` | PoG Event-Endzeit | Module/Events/PathOfGlory.ts | - | Module/Events/PathOfGlory.ts |
+| `TK.PoVEndDate` | PoV Event-Endzeit | Module/Events/PathOfValue.ts | - | Module/Events/PathOfValue.ts |
+| `TK.PopTargeted` | Aktuell anvisierter Pop | Module/PlaceOfPower.ts | Module/PlaceOfPower.ts | Module/PlaceOfPower.ts |
+| `TK.PopToStart` | Liste der zu startenden Pops | Module/PlaceOfPower.ts | - | Module/PlaceOfPower.ts, Service/AutoLoopActions.ts |
+| `TK.PopUnableToStart` | Liste 'kann nicht starten' | Module/PlaceOfPower.ts | - | Module/PlaceOfPower.ts |
+| `TK.SeasonEndDate` | Season Event-Endzeit | Module/Events/Season.ts | - | Module/Events/Season.ts |
+| `TK.SeasonHumanLikeRun` | Season HumanLike-State | Module/Events/Season.ts, Service/AutoLoopActions.ts | - | Module/Events/Season.ts, Service/AutoLoopActions.ts |
+| `TK.SeasonalEventEndDate` | Seasonal-Endzeit | Module/Events/Seasonal.ts | - | Module/Events/Seasonal.ts |
+| `TK.SideAdventureWorldID` | Welt-ID Side-Adventure | Service/StartService.ts | - | (?) |
+| `TK.Timers` | Map aller laufenden HHAuto-Timer (JSON) | Helper/TimerHelper.ts | - | Service/StartService.ts |
+| `TK.Totalpops` | Gesamtzahl Pops | Module/PlaceOfPower.ts | - | Module/PlaceOfPower.ts |
+| `TK.TrollHumanLikeRun` | Troll HumanLike-State | Module/Troll.ts, Service/AutoLoopActions.ts | - | Service/AutoLoopActions.ts |
+| `TK.TrollInvalid` | Markierung: Troll-State ungueltig | Module/Troll.ts | - | Module/Troll.ts |
+| `TK.autoChampsEventGirls` | Liste Event-Girls fuer Champ-Force-Start | Module/Events/EventModule.ts | - | Module/Champion.ts |
+| `TK.autoLoop` | Globaler 'autoLoop laeuft' Switch | Helper/HeroHelper.ts, Helper/PageHelper.ts, Helper/RewardHelper.ts, Module/Bundles.ts, Module/Champion.ts, Module/DailyGoals.ts, Module/Events/BossBang.ts, Module/Events/DoublePenetration.ts, Module/Events/LivelyScene.ts, Module/Events/PathOfAttraction.ts, Module/Events/PathOfGlory.ts, Module/Events/PathOfValue.ts, Module/Events/Season.ts, Module/Events/Seasonal.ts, Module/Labyrinth.ts, Module/LabyrinthAuto.ts, Module/League.ts, Module/Pachinko.ts, Module/Pantheon.ts, Module/PentaDrill.ts, Module/PlaceOfPower.ts, Module/Quest.ts, Module/Shop.ts, Module/TeamModule.ts, Module/Troll.ts, Module/harem/Harem.ts, Module/harem/HaremGirl.ts, Service/AutoLoopActions.ts, Service/PageNavigationService.ts, Service/ParanoiaService.ts, Service/StartService.ts | - | Service/AutoLoop.ts, Service/InfoService.ts, Service/StartService.ts |
+| `TK.autoLoopTimeMili` | AutoLoop-Intervall in ms | (nur init/storage-Helper) | - | Helper/HeroHelper.ts, Module/Bundles.ts, Module/Events/DoublePenetration.ts, Module/Events/LivelyScene.ts, Module/Events/PathOfAttraction.ts, Module/League.ts, Module/Pachinko.ts, Module/PlaceOfPower.ts, Module/Shop.ts, Service/AutoLoop.ts, Service/StartService.ts |
+| `TK.autoTrollBattleSaveQuest` | Trolls vor Quest sichern | Module/GenericBattle.ts, Module/Troll.ts, Service/AutoLoopActions.ts | - | Module/GenericBattle.ts, Module/Troll.ts, Service/AutoLoopActions.ts |
+| `TK.battlePowerRequired` | Power-Anforderung fuer naechsten Kampf | Module/Troll.ts, Service/AutoLoop.ts, Service/AutoLoopActions.ts | - | Service/AutoLoop.ts, Service/AutoLoopActions.ts |
+| `TK.blessingsCache` | Blessing-Daten-Cache (von /get_girls_blessings) | Service/BlessingService.ts | - | Service/BlessingService.ts |
+| `TK.boosterIdMap` | Map identifier->id_item (vom Shop gescraped) | Module/Shop.ts | - | Module/Booster.ts |
+| `TK.boosterStatus` | JSON {normal:[], mythic:[]} der equippten Booster | Module/Booster.ts | - | Module/Booster.ts |
+| `TK.boosterStatusLastUpdate` | Timestamp der letzten Markt-Refresh fuer boosterStatus (TTL 10min) | Module/Booster.ts | Helper/HeroHelper.ts | Module/Booster.ts |
+| `TK.bossBangTeam` | BossBang Team-Snapshot | Module/Events/BossBang.ts | - | Module/Events/BossBang.ts |
+| `TK.burst` | Burst-Mode aktiv (kurzes High-Speed-Run-Window) | Service/ParanoiaService.ts | - | Service/AutoLoop.ts, Service/ParanoiaService.ts |
+| `TK.champBuildTeam` | Aktuell aufzubauendes Champ-Team | Module/Champion.ts, Module/ClubChampion.ts | Module/Champion.ts, Module/ClubChampion.ts | Module/Champion.ts, Module/ClubChampion.ts |
+| `TK.charLevel` | Letzter bekannter Hero-Level (fuer Shop-Refresh-Trigger) | Module/Market.ts, Module/Shop.ts, Service/AutoLoopActions.ts | - | Service/AutoLoopActions.ts |
+| `TK.clubChampLimitReached` | ClubChamp Limit erreicht | Module/ClubChampion.ts | Module/ClubChampion.ts | Module/Champion.ts |
+| `TK.currentlyAvailablePops` | Aktuell verfuegbare Pops (Schreib-only) | Module/PlaceOfPower.ts | - | (?) |
+| `TK.dailyGoalsList` | Geparste DailyGoals-Liste | Module/DailyGoals.ts | - | Module/DailyGoals.ts |
+| `TK.eventGirl` | Aktuell anvisiertes Event-Girl (Schreib-only) | Module/Events/EventModule.ts | - | (?) |
+| `TK.eventMythicGirl` | Aktuell anvisiertes Mythic-Event-Girl | Module/Events/EventModule.ts | - | (?) |
+| `TK.eventsGirlz` | Liste Event-Girls fuer Reward-Recap | Helper/RewardHelper.ts, Module/Events/EventModule.ts | - | Helper/RewardHelper.ts |
+| `TK.eventsList` | Liste aller laufenden Events | Module/Events/EventModule.ts, Service/ParanoiaService.ts | - | Module/Events/EventModule.ts, Service/ParanoiaService.ts, Service/Pipeline.config.ts |
+| `TK.featurePopupDismissCount` | Feature-Popup Dismiss-Zaehler | Service/FeaturePopupService.ts | - | Service/FeaturePopupService.ts |
+| `TK.featurePopupShown` | Feature-Popup wurde gezeigt | Service/FeaturePopupService.ts | - | Service/FeaturePopupService.ts |
+| `TK.filteredGirlsList` | Aktuell gefilterte Girls-Liste fuer Harem-Tools | Module/harem/Harem.ts | - | Module/harem/HaremGirl.ts |
+| `TK.freshStart` | Marker fuer ersten Start (kein Default-Reset) | (nur init/storage-Helper) | - | Service/StartService.ts |
+| `TK.haremGirlActions` | Action-Queue fuer Harem-Girl-Multi-Page-Flows | Module/TeamModule.ts, Module/harem/Harem.ts, Module/harem/HaremGirl.ts | Module/harem/Harem.ts | Module/harem/Harem.ts, Module/harem/HaremGirl.ts, Service/AutoLoopPageHandlers.ts |
+| `TK.haremGirlEnd` | Endzeitpunkt des Harem-Girl-Flows | Module/harem/Harem.ts, Module/harem/HaremGirl.ts | Module/harem/Harem.ts | Module/harem/HaremGirl.ts |
+| `TK.haremGirlLimit` | Limit fuer Harem-Girl-Flow | Module/harem/HaremGirl.ts | Module/harem/Harem.ts | Module/harem/HaremGirl.ts |
+| `TK.haremGirlMode` | Aktiver Harem-Girl-Mode (sperrt autoLoop) | Module/TeamModule.ts, Module/harem/Harem.ts, Module/harem/HaremGirl.ts | Module/harem/Harem.ts | Module/harem/Harem.ts, Module/harem/HaremGirl.ts, Service/AutoLoopPageHandlers.ts, Service/StartService.ts |
+| `TK.haremGirlPayLast` | Last-Pay-Marker | Module/harem/Harem.ts, Module/harem/HaremGirl.ts | Module/harem/Harem.ts | Module/harem/HaremGirl.ts |
+| `TK.haremGirlSpent` | Bisher ausgegeben (nur Delete in HHStoredVars) | (nur init/storage-Helper) | Module/harem/Harem.ts | (?) |
+| `TK.haremMoneyOnStart` | Geld zu Beginn des Harem-Flows | Module/harem/Harem.ts | Module/harem/Harem.ts | Module/harem/Harem.ts, Module/harem/HaremGirl.ts |
+| `TK.haremTeam` | Snapshot des Harem-Teams | Module/TeamModule.ts | Module/harem/Harem.ts | Module/harem/Harem.ts, Module/harem/HaremGirl.ts |
+| `TK.haremTeamScrolls` | Snapshot Team-Scrolls | Module/harem/Harem.ts | Module/harem/Harem.ts | Module/harem/Harem.ts |
+| `TK.haremTeamSettings` | Team-Settings Snapshot | Module/TeamModule.ts | Module/harem/Harem.ts | Module/harem/Harem.ts |
+| `TK.haveAff` | Aff-Vorrat (Sum) | Module/Shop.ts | - | Module/Market.ts, Module/Shop.ts, Service/InfoService.ts |
+| `TK.haveBooster` | Map identifier->Anzahl Booster im Inventory | Module/Market.ts, Module/Shop.ts | - | Helper/HeroHelper.ts, Module/Booster.ts, Module/Market.ts |
+| `TK.haveExp` | Exp-Vorrat (Sum) | Module/Shop.ts | - | Module/Market.ts, Module/Shop.ts, Service/InfoService.ts |
+| `TK.hideBeatenOppo` | Bereits besiegte League-Gegner verstecken | Module/League.ts | - | Module/League.ts |
+| `TK.lastActionPerformed` | Letzte ausgefuehrte Action | Module/TeamModule.ts, Module/harem/Harem.ts, Module/harem/HaremGirl.ts, Service/AutoLoop.ts | - | Module/harem/Harem.ts, Service/AutoLoop.ts |
+| `TK.loveRaids` | Aktive LoveRaids-Liste | Module/Events/LoveRaidManager.ts | config/HHStoredVars.ts | Module/Events/LoveRaidManager.ts |
+| `TK.lseManualCollectAll` | LivelyScene Manual-Collect-Marker | Module/Events/LivelyScene.ts | - | Module/Events/LivelyScene.ts |
+| `TK.paranoiaLeagueBlocked` | Paranoia: League blockiert | Module/League.ts | - | Service/ParanoiaService.ts |
+| `TK.paranoiaQuestBlocked` | Paranoia: Quest blockiert | Service/AutoLoopActions.ts | - | Service/ParanoiaService.ts |
+| `TK.paranoiaSpendings` | Paranoia: aktuelle Spendings | Service/ParanoiaService.ts | - | Service/ParanoiaService.ts |
+| `TK.pinfo` | PInfo-Overlay-Daten | Service/ParanoiaService.ts | - | Service/InfoService.ts |
+| `TK.poaManualCollectAll` | PoA Manual-Collect-Marker | Module/Events/PathOfAttraction.ts | - | Module/Events/PathOfAttraction.ts |
+| `TK.questRequirement` | Quest-Anforderung (next-step) | Module/Quest.ts, Module/Troll.ts, Service/AutoLoop.ts, Service/AutoLoopActions.ts | config/HHStoredVars.ts | Module/Troll.ts, Service/AutoLoop.ts, Service/AutoLoopActions.ts |
+| `TK.raidGirls` | Raid-Girls-Liste | (nur init/storage-Helper) | - | Module/Events/LoveRaidManager.ts |
+| `TK.sandalwoodFailure` | Counter fehlgeschlagene Sandalwood-Equip-Versuche | Helper/HeroHelper.ts, Module/Booster.ts | - | Helper/HeroHelper.ts |
+| `TK.sandalwoodMaxUsages` | Max-Usages des aktuellen Sandalwood (sessionStorage) | Module/Booster.ts | - | (?) |
+| `TK.scriptversion` | Letzte gespeicherte Skript-Version (fuer Migrations-Check) | Service/StartService.ts | - | Service/StartService.ts |
+| `TK.storeContents` | Cache des Shop-Inhalts (4-Listen-Tuple JSON) | Module/Market.ts, Module/Shop.ts | - | Module/Booster.ts, Module/Market.ts |
+| `TK.surveyDismissCount` | Survey Dismiss-Zaehler | Service/SurveyService.ts | - | Service/SurveyService.ts |
+| `TK.surveyLastHash` | Hash der zuletzt gezeigten Umfrage | Service/SurveyService.ts | - | Service/SurveyService.ts |
+| `TK.surveyShown` | Survey wurde gezeigt | Service/SurveyService.ts | - | Service/SurveyService.ts |
+| `TK.trollPoints` | Troll-Points-Snapshot | Module/Troll.ts | - | Module/Troll.ts |
+| `TK.trollWithGirls` | Trolls mit Girls (Snapshot) | Module/Troll.ts | - | Module/Troll.ts |
+| `TK.unkownPagesList` | Liste unbekannter Pages (Telemetrie fuer Skript-Updates) | Helper/PageHelper.ts | - | Helper/PageHelper.ts |
+
+Beobachtungen:
+
+- `TK.autoLoop` wird in 31 Dateien geschrieben (jeder, der den Loop kurz pausieren muss). Lesend nur in 3 Stellen.
+- `TK.autoLoopTimeMili` wird nirgendwo explizit gesetzt - kommt aus dem Default in `HHStoredVars.ts` (1500 ms).
+- `TK.HaremSize`, `TK.boosterStatus`, `TK.LeagueOpponentList` sind grosse JSON-Strukturen - bei storage-full fallen sie als erste in `cleanLogsInStorage()`.
+- `TK.unkownPagesList` ist ein Telemetrie-Map fuer noch nicht bekannte `pagesIDXxx` (siehe Sektion 6.1).
+
+## 8. sessionStorage (direkter Zugriff, ohne `getStoredValue`-Wrapper)
+
+Alle Stellen, an denen `sessionStorage` direkt verwendet wird (also nicht ueber `getStoredValue`/`setStoredValue`).
+Hintergrund: Der Wrapper sucht den Key in `HHStoredVars` und delegiert je nach `storage`-Feld an `localStorage` / `sessionStorage` / `Storage()`. Direkte Zugriffe umgehen diese Pruefung.
+
+| Datei:Zeile | Operation | Key (mit Praefix) | Zweck |
+|---|---|---|---|
+| `Helper/StorageHelper.ts:115` | read (`getItem`) | `HHAuto_Temp_Logging` (= `HHStoredVarPrefixKey + 'Temp_Logging'`) | Log-Buffer zum Export einlesen (Bypass HHStoredVars-Wrapper) |
+| `Helper/StorageHelper.ts:159-162` | read+write+remove | beliebige `oldVar`/`newVar` | Migration alter Praefixe (`HHAuto_` -> custom) - siehe `migrateHHVars` |
+| `Helper/StorageHelper.ts:280,287,294,301` | removeItem | alle Keys mit Praefix `HHAuto_Setting_*` und `HHAuto_Temp_*` | `debugDeleteAllVars()` Reset |
+| `Helper/StorageHelper.ts:393,398` | hasOwnProperty + Read (`localStorage[key]`/`sessionStorage[key]`) | beliebig | `getLocalStorageSize()` zaehlt total |
+| `Module/PlaceOfPower.ts:142,143,293` | removeItem | `Temp_PopUnableToStart`, `Temp_PopToStart` | Reset bei PoP-Setting-Change |
+| `Service/AutoLoopActions.ts:220` | removeItem | `Temp_PopToStart` | Reset wenn Pop-Run abgeschlossen |
+| `Service/ParanoiaService.ts:88-91` | removeItem | `Temp_paranoiaSpendings`, `Temp_NextSwitch`, `Temp_paranoiaQuestBlocked`, `Temp_paranoiaLeagueBlocked` | Reset bei Paranoia-Disable |
+| `Service/ParanoiaService.ts:347` | (auskommentiert) | `Temp_eventsList` | - |
+| `Module/Events/EventModule.ts:70` | (auskommentiert) | `Temp_EventFightsBeforeRefresh` | - |
+| `Module/Events/EventModule.ts:121-125` | removeItem | `Temp_eventsGirlz`, `Temp_eventGirl`, `Temp_eventMythicGirl`, `Temp_eventsList`, `Temp_autoChampsEventGirls` | Cleanup nach Event-Ende |
+| `Module/Events/EventModule.ts:143` | removeItem | `Temp_autoChampsEventGirls` | Reset wenn Event-Champ-Konfig wechselt |
+| `Module/Events/EventModule.ts:163,172,177,326` | removeItem | `Temp_eventsGirlz`, `Temp_eventGirl`, `Temp_eventMythicGirl`, `Temp_eventsList` | Diverse Event-Resets |
+
+Kein direkter Zugriff auf `sessionStorage` ausserhalb dieser Stellen.
+
+## 9. Spielzustands-Bridge-Funktionen
+
+### 9.1 `getHHVars(infoSearched, logging=true)` (`Helper/HHHelper.ts:21`)
+
+Ablauf:
+
+1. `returnValue = unsafeWindow`
+2. Wenn `ConfigHelper.getHHScriptVars(infoSearched, false) !== null`: ueberschreibe `infoSearched` mit dem Per-Game-Override (selten genutzt - kein aktueller Treffer in HHEnvVariables.ts).
+3. `infoSearched = prefixIfNeeded(infoSearched)`:
+   - **Trick**: Wenn `unsafeWindow.shared` existiert UND `infoSearched.indexOf('Hero.') == 0`, wird `'shared.' + infoSearched` davorgehaengt.
+   - Effekt: Code kann konsistent `'Hero.x'` schreiben, egal ob das Spiel auf Legacy-Build (`window.Hero.x`) oder neuem Build (`window.shared.Hero.x`) laeuft. Wenn `shared` fehlt, faellt der Pfad auf `unsafeWindow.Hero.x` zurueck.
+4. Loop ueber `infoSearched.split(".")`. Jeder Schritt: `returnValue = returnValue[part]`. Wenn ein Teil `undefined` ist: log + return `null`.
+
+Counterpart: `setHHVars(infoSearched, newValue)` (`Helper/HHHelper.ts:51`) - gleicher Lookup-Algorithmus, am letzten Pfadelement wird zugewiesen. Wenn ein Zwischenpfad fehlt, wird `-1` zurueckgegeben (kein Throw).
+
+### 9.2 `getHHAjax()` (`Utils/Utils.ts:19`)
+
+```ts
+return unsafeWindow.shared?.general?.hh_ajax;
+```
+
+Liefert die interne AJAX-Funktion des Spiels mit Signatur `(params, onSuccess, onError) => void`.
+`params.action` ist das spielinterne Action-Routing (siehe Sektion 3).
+`onSuccess(data)`, `onError(err)` sind die Callbacks.
+Wird in fast allen Modulen benutzt um Spielaktionen wie Stat-Upgrade, Booster-Equip, League-Battle, etc. zu triggern.
+
+### 9.3 `getHero()` (`Helper/HeroHelper.ts:23-30`)
+
+```ts
+if (unsafeWindow.shared?.Hero === undefined) {
+    setTimeout(autoLoop, Number(getStoredValue(HHStoredVarPrefixKey+TK.autoLoopTimeMili)) || 1000);
+}
+return unsafeWindow.shared?.Hero;
+```
+
+Liefert das Hero-Objekt direkt aus `shared`. Bei Nichtverfuegbarkeit: schedule autoLoop und gib `undefined` zurueck. Wird relativ selten direkt benutzt - die meisten Reads gehen ueber `getHHVars('Hero.x')`.
+
+Die Klasse `HeroHelper` (gleiches File) bietet getter-Wrapper:
+
+| Methode | Liefert |
+|---|---|
+| `HeroHelper.getPlayerId()` | `getHHVars('Hero.infos.id')` |
+| `HeroHelper.getClass()` | `getHHVars('Hero.infos.class')` |
+| `HeroHelper.getLevel()` | `getHHVars('Hero.infos.level')` |
+| `HeroHelper.getMoney()` | `getHHVars('Hero.currencies.soft_currency')` |
+| `HeroHelper.getKoban()` | `getHHVars('Hero.currencies.hard_currency')` |
+| `HeroHelper.haveBoosterInInventory(id)` | Lookup im `TK.haveBooster`-Storage-Cache |
+| `HeroHelper.equipBooster(booster)` | sendet `market_equip_booster` (siehe Sektion 3) mit Timeout-Sicherung |
+
+### 9.4 Weitere Bridge-Helper
+
+| Funktion | Datei | Zweck |
+|---|---|---|
+| `getLoadingAnimation()` | `Utils/Utils.ts:22` | `window.shared?.animations?.loadingAnimation` mit Fallback auf no-op-Stubs |
+| `onAjaxResponse(pattern, callback)` | `Utils/Utils.ts:25` | Globaler `ajaxComplete`-Hook (siehe Sektion 4) |
+| `getCurrentSorting()` | `Utils/Utils.ts:118` | liest `localStorage.sort_by` (vom Spiel selbst gesetzt; nicht HHAuto) |
+| `getStoredValue/getStoredJSON/setStoredValue/deleteStoredValue` | `Helper/StorageHelper.ts` | HHAuto-eigener Wrapper ueber HHStoredVars-Registry |
+| `getStorage()` | `Helper/StorageHelper.ts:39` | gibt `sessionStorage` wenn `SK.settPerTab=true`, sonst `localStorage` (fuer `Storage()`-Vars) |
+| `getStorageItem(type)` | `Helper/StorageHelper.ts:131` | resolved `'localStorage'` / `'sessionStorage'` / `'Storage()'`-Tag in echte Storage-API |
+| `addNutakuSession(togoto)` | `Service/PageNavigationService.ts:191` | haengt `?sess=...` an URL wenn `unsafeWindow.hh_nutaku` |
+| `queryStringGetParam(qs, name)` | `Helper/UrlHelper.ts:13` | URLSearchParams-Wrapper |
+| `getPage(checkUnknown, checkPop)` | `Helper/PageHelper.ts:14` | resolved canonical Page-ID aus `<body page>`+Tab+Pop-Detection (siehe Sektion 6.1) |
+| `ConfigHelper.getEnvironnement()` | `Helper/ConfigHelper.ts:12` | matched `window.location.hostname` gegen `HHKnownEnvironnements` |
+| `ConfigHelper.getHHScriptVars(id, logNotFound)` | `Helper/ConfigHelper.ts:30` | env-spezifischer Lookup mit `global` als Fallback (siehe Sektion 11) |
+| `ConfigHelper.isPshEnvironnement()` | `Helper/ConfigHelper.ts:25` | true fuer `PH_prod` und `NPH_prod` |
+
+## 10. Page-spezifische Datenverfuegbarkeit
+
+Fuer jede Page-ID (aus `ConfigHelper.getHHScriptVars("pagesIDXxx")`): welche `unsafeWindow`-Globals sind dort lesbar, welche DOM-Quellen relevant.
+
+| Page-ID-Konstante (Wert) | Verfuegbare unsafeWindow-Globals | Verfuegbare DOM-Quellen |
+|---|---|---|
+| `pagesIDHome` (`home`) | `shared.Hero`, `hh_prices` (?) | `#contains_all header .currency .daily-reward-notif`, `#blessings_popup .blessings_wrapper` (nach `get_girls_blessings`) |
+| `pagesIDActivities` (`activities`) | `shared.Hero`, `pop_list`, `pop_index` (wenn Pop-Tab) | `#activities-tabs > div[data-tab=...]`, `div.pop_list`, `.pop_thumb_selected[pop_id]` |
+| `pagesIDMissions` (`missions`) (Activities-Tab `missions`) | `shared.Hero` | Mission-DOM (`Module/Missions.ts`) |
+| `pagesIDContests` (`contests`) (Activities-Tab `contests`) | `contests_timer.{next_contest,duration,remaining_time}`, `has_contests_datas` | Contest-Claim-Buttons (`Contest.getClaimsButton()`) |
+| `pagesIDDailyGoals` (`daily_goals`) (Activities-Tab `daily_goals`) | `daily_goals_list` | Tier-DOM in DailyGoals |
+| `pagesIDPowerplacemain` (`powerplacemain`) (Activities-Tab `pop`, Liste sichtbar) | `pop_list`, `pop_index` | `div.pop_list`, `.pop_thumb_selected[pop_id]` |
+| `pagesIDQuest` (`quest`) | `shared.Hero`, `Hero.infos.questing.{id_world,id_quest,current_url}` | Quest-DOM (`Module/Quest.ts`) |
+| `pagesIDHarem` (`harem`) | `shared.GirlSalaryManager.{girlsMap,girlsListSec}`, `availableGirls` / `girlsDataList` / `girls_data_list` (variantenabhaengig) | `#harem_right .opened` `.attr('girl')`, `.hhava`, `.select-group ... [data-index]` |
+| `pagesIDGirlPage` (`girl`) | `girl` (KKHaremGirl), `id_girl`, `player_gems_amount` | `.right-section .slot[data-d]`, `#girl-leveler-tabs .switch-tab[data-tab=...]` |
+| `pagesIDMap` (`map`) | `shared.Hero` | - |
+| `pagesIDPachinko` (`pachinko`) | `shared.Hero` | `#playzone-replace-info button[data-free="true"]`, `[girlsRewards].attr("data-rewards")` |
+| `pagesIDLeaderboard` (`leaderboard`) | `current_tier_number`, `opponents_list` (League) | `.league_content .data-list`, `.data-row.body-row`, `.data-column[column="..."]` |
+| `pagesIDShop` (`shop`) | `shared.animations.loadingAnimation`, `hh_prices` | `#shops div.{armor,booster,gift,potion}.merchant-inventory-item .slot[data-d]`, `#shops div.{gift,potion,booster}.player-inventory-content .slot[data-d]`, `#equiped .booster .slot`, `.shop div.shop_count span[rel="expires"]` |
+| `pagesIDClub` (`clubs`) | `Chat_vars.CLUB_INFO.id_club` | Club-Status-UI |
+| `pagesIDPantheon` (`pantheon`) | `Hero.energies.worship.*` | - |
+| `pagesIDPantheonPreBattle` (`pantheon-pre-battle`) | `Hero.energies.worship.*` | `#pre-battle .pantheon-single-battle-button[data-pantheon-id]` |
+| `pagesIDPantheonBattle` (`pantheon-battle`) | - | - |
+| `pagesIDLabyrinthEntrance` (`labyrinth-entrance`) | - | - |
+| `pagesIDLabyrinthPoolSelect` (`labyrinth-pool-select`) | - | - |
+| `pagesIDLabyrinth` (`labyrinth`) | `girl_squad` | `.team-hexagon .team-member-container[data-girl-id]` |
+| `pagesIDLabyrinthPreBattle` (`labyrinth-pre-battle`) | - | `.opponent-power .opponent-power-text[data-power]` |
+| `pagesIDLabyrinthBattle` (`labyrinth-battle`) | - | - |
+| `pagesIDChampionsPage` (`champions`) | `championData.{team,champion.id,champion.poses,freeDrafts,hero_damage,fight.{active,participants}}` | `.champions-over__champion-info ... .champion-pose` |
+| `pagesIDChampionsMap` (`champions_map`) | `championData.*` | - |
+| `pagesIDClubChampion` (`club_champion`) | `championData.fight.{active,participants}` | `div.club-champion-members-challenges .player-row .data-column:nth-of-type(3)` |
+| `pagesIDSeason` (`season`) | `season_sec_untill_event_end`, `Hero.energies.kiss.*` | - |
+| `pagesIDSeasonArena` (`season_arena`) | `season_sec_untill_event_end`, `hero_data`, `opponents` | `.season_arena_opponent_container[data-opponent=...]`, `.slot.girl_ico[data-rewards]` |
+| `pagesIDSeasonBattle` (`season-battle`) | `Hero.energies.kiss.*` | - |
+| `pagesIDLeaguePreBattle` (`leagues-pre-battle`) | `Hero.energies.challenge.*` | - |
+| `pagesIDLeagueBattle` (`league-battle`) | `Hero.energies.challenge.*` | - |
+| `pagesIDTrollPreBattle` (`troll-pre-battle`) | `Hero.energies.fight.*`, `Hero.infos.questing.*`, `Hero.infos.hc_confirm` | `#pre-battle .battle-buttons button.autofight[data-battles="10"]` / `[data-battles="50"]`, `.opponent_rewards .rewards_list .slot.girl_ico[data-rewards]` |
+| `pagesIDTrollBattle` (`troll-battle`) | `Hero.energies.fight.*` | - |
+| `pagesIDPentaDrill` (`penta_drill`) | `penta_drill_data.cycle_data.seconds_until_event_end`, `Hero.energies.drill.*` | - |
+| `pagesIDPentaDrillArena` (`penta_drill_arena`) | `opponents_list` (KKPentaDrillOpponents[]) | - |
+| `pagesIDEditPentaDrillTeam` (`edit-penta-drill-team`) | - | `.team-member-container[data-girl-id]` |
+| `pagesIDPentaDrillPreBattle` (`penta_drill_pre_battle`) | - | - |
+| `pagesIDPentaDrillBattle` (`penta-drill-battle`) | - | - |
+| `pagesIDEvent` (`event`) | `event_data` (mit `girls`), `current_event` (Fallback) | `[data-select-girl-id=...]` |
+| `pagesIDPoV` (`path-of-valor`) | - | `[data-time-stamp]`, Reward-Slots |
+| `pagesIDPoG` (`path-of-glory`) | - | `[data-time-stamp]`, Reward-Slots |
+| `pagesIDPoA` (`path_of_attraction`) | - | `[data-nc-reward-id]`, `#poa-content .buttons:has(button[data-href="/champions-map.html"])` |
+| `pagesIDSeasonalEvent` (`seasonal`) | `seasonal_event_active`, `seasonal_time_remaining`, `mega_event_active`, `mega_event_time_remaining`, `mega_event_data.cards` | - |
+| `pagesIDBossBang` (`boss-bang-battle`) | (?) | - |
+| `pagesIDSexGodPath` (`sex-god-path`) | (?) | - |
+| `pagesIDLoveRaid` (`love_raids`) | `love_raids` (KKLoveRaid[]) | - |
+| `pagesIDWaifu` (`waifu`) | (?) | - |
+| `pagesIDBattleTeams` (`teams`) | `teams_data[selectedTeam].{girls,girls_ids}` | `.team-slot-container.selected-team[data-team-index]`, `.team-member-container[data-team-member-position=N][data-girl-id]` |
+| `pagesIDEditTeam` (`edit-team`) | `teams_data[...]` | gleiche Selectoren wie BattleTeams + `#edit-team-page` |
+| `pagesIDEditLabyrinthTeam` (`edit-labyrinth-team`) | - | `.team-member-container.selectable[data-team-member-position=...][data-girl-id]` |
+| `pagesIDMemberProgression` (`member-progression`) | (?) | - |
+| `pagesIDHeroPage` (`hero_pages`) | `shared.Hero` | - |
+| `pagesIDGirlEquipmentUpgrade` (`girl-equipment-upgrade`) | (?) | `.right-section .slot[data-d]` |
+
+Hinweis: `(?)` steht fuer "im Source nicht eindeutig nachweisbar".
+
+## 11. Per-Game-Unterschiede
+
+Erkennung: `ConfigHelper.getEnvironnement()` matched `window.location.hostname` gegen `HHKnownEnvironnements`.
+Bekannte Hosts (aus den `getEnv()`-Methoden in `src/config/game/`):
+
+| Hostname | Env-Name | gameID (HTML `<body id>`) | baseImgPath (Default `https://hh2.hh-content.com`) |
+|---|---|---|---|
+| `www.hentaiheroes.com` | `HH_prod` | `hh_hentai` | (default) |
+| `test.hentaiheroes.com` | `HH_test` | `hh_hentai` | (default) |
+| `nutaku.haremheroes.com` | `NHH_prod` | `hh_hentai` | (default) |
+| `thrix.hentaiheroes.com` | `THH_prod` | `hh_hentai` | (default) |
+| `eroges.hentaiheroes.com` | `EHH_prod` | `hh_hentai` | (default) |
+| `esprit.hentaiheroes.com` | `OGHH_prod` | `hh_hentai` | (default) |
+| `www.comixharem.com` | `CH_prod` | `hh_comix` | `https://ch.hh-content.com` |
+| `nutaku.comixharem.com` | `NCH_prod` | `hh_comix` | (default) |
+| `www.gayharem.com` | `GH_prod` | `hh_gay` | (siehe `GayHaremVars.ts`) |
+| `www.gaypornstarharem.com` | `GPSH_prod` | `hh_gay` (?) | (siehe `GayPornstarHaremVars.ts`) |
+| `www.pornstarharem.com` | `PSH_prod` (?) | (siehe `PornstarHaremVars.ts`) | (siehe ebd.) |
+| `www.transpornstarharem.com` | `TPSH_prod` (?) | (siehe `TransPornstarHaremVars.ts`) | (siehe ebd.) |
+| `www.mangarpg.com` | `MR_prod` (?) | (siehe `MangaRpgVars.ts`) | (siehe ebd.) |
+| `www.amouragent.com` | `AA_prod` (?) | (siehe `AmourAgentVars.ts`) | (siehe ebd.) |
+| `www.hornyheroes.com` | `SH_prod` | `hh_sexy` | (default) |
+
+`(?)` = exakter Env-Name muss in der jeweiligen `getEnv()`-Methode des Game-Files nachgelesen werden.
+
+Folgende Felder werden in `HHEnvVariables.ts` per `for (var key in <Game>.getEnv())` ueberschrieben:
+
+| Feld | Quelle | Wirkung |
+|---|---|---|
+| `gameID` | `HHKnownEnvironnements[host].id` | Wert des `<body id="...">` (von `PageHelper.getPage()` gelesen) |
+| `HHGameName` | env-Name | als ID in HHEnvVariables-Map |
+| `baseImgPath` | `HHKnownEnvironnements[host].baseImgPath` oder Default `https://hh2.hh-content.com` | Praefix fuer Bild-URLs |
+| `spreadsheet` | `HentaiHeroes.spreadsheet` (HH-Family), leer fuer andere | Externer Link in Blessing-Popup |
+| `trollzList` | `<Game>.getTrolls(languageCode)` | Lokalisierte Troll-Namen |
+| `sideTrollzList` | nur HH: `HentaiHeroes.getSideTrolls(...)` | - |
+| `trollGirlsID` | `<Game>.getTrollGirlsId()` | Mapping Troll-Index -> Girl-IDs |
+| `sideTrollGirlsID` | nur HH | - |
+| `trollIdMapping` / `sideTrollIdMapping` | spielspezifisches Remapping (z.B. `{21:19}` in HH) | - |
+| `lastQuestId` | `<Game>.lastQuestId` | Letzte bekannte Quest-ID (Pause-Schwelle) |
+| `boosterId_MB1` | Default 632 (HH); 2619 fuer ComixHarem, PornstarHarem, TransPornstarHarem, GayPornstarHarem | Sandalwood-Item-ID |
+| `pagesIDXxx` / `pagesURLXxx` | meist global; einzelne werden per `<Game>.updateFeatures(env)` ueberschrieben (siehe `MangaRpgVars`, `AmourAgentVars`, `TransPornstarHaremVars`, `GayPornstarHaremVars`) | Page-IDs / Page-URLs |
+| `isEnabledXxx` | global; SH_prod hat z.B. viele Features deaktiviert (Champs, Pantheon, Labyrinth, PoV, PoG, MythicPachinko, EquipmentPachinko, Side-Quest, Power-Places) | Feature-Toggles |
+| `isPshEnvironnement()` | true fuer `PH_prod`, `NPH_prod` | Generelle PSH-Sonderfaelle (siehe Code) |
+
+Build-spezifische Sonderwerte (Auszug aus `HHEnvVariables.ts`):
+
+- `HH_test.isEnabledDailyRewards = false` (vor Test-Rollout)
+- `HH_test.isEnabledFreeBundles = false`
+- `SH_prod`: zahlreiche Features deaktiviert (siehe Liste oben)
+- `boosterId_MB1`: Comix/PSH/TPSH/GPSH = 2619; HH = 632 (`HHEnvVariables["global"].boosterId_MB1 = 632`)
+
+Datenzugriffs-Unterschiede:
+
+- **Girl-Daten-Quelle**: HH-Family liest meist `availableGirls` oder `girlsDataList`; PSH-Build liefert die Liste unter `girls_data_list` (Module/harem/Harem.ts faellt auf alle drei Pfade nach Reihenfolge zurueck).
+- **`shared.Hero` vs `Hero`**: Auf modernen Builds aller Variants ist `unsafeWindow.shared` definiert -> `getHHVars('Hero.x')` haengt automatisch `shared.` davor (siehe Sektion 9.1).
+- **Iframe**: Nutaku-Builds (`unsafeWindow.hh_nutaku === true`) leben in einem iframe; HHAuto sendet `postMessage({ImAlive:true},'*')` an `window.top` (StartService.ts:464-468) und haengt `?sess=...` an interne Navigationen an.
+- **Endpoint-Unterschiede**: AJAX-Endpoint ist immer derselbe Host wie das Spiel (relativ zur Hostname). Unterschiede ergeben sich indirekt durch `pagesURLXxx`-Konstanten, die bei Game-Builds via `updateFeatures(env)` umgesetzt werden.
+
+## 12. Cheat-Click-Hook (`shared.general.is_cheat_click`)
+
+Im Spiel-Code ist `shared.general.is_cheat_click` eine Funktion, die bei "verdaechtigen" Klick-Mustern (zu schnelle Klicks, kein Mausweg, etc.) `true` zurueckgibt und Aktionen blockiert. Sie wird vom Spiel selbst beim Schicken bestimmter Aktionen ausgewertet.
+
+In HHAuto:
+
+- `Utils/Utils.ts:108-115` enthaelt die Funktion `replaceCheatClick()`. Sie ist **leer** (Body komplett auskommentiert):
+
+  ```ts
+  export function replaceCheatClick()
+  {
+      // unsafeWindow.is_cheat_click=function(e) {
+      //     return false;
+      // };
+      // unsafeWindow.shared.general.is_cheat_click =function(e) {
+      //     return false;
+      // };
+  }
+  ```
+
+- `Service/StartService.ts:223` ruft `replaceCheatClick()` einmalig in `start()` auf - aktuell ein No-Op, weil der Body auskommentiert ist.
+
+Bedeutung: Die Override-Stelle ist im Code vorbereitet, wurde aber **deaktiviert**. Eine fruehere Version ueberschrieb beide Pfade (`unsafeWindow.is_cheat_click` und `unsafeWindow.shared.general.is_cheat_click`) mit einer immer-`false`-Stub. Aktuell verlaesst sich HHAuto darauf, dass durch `randomInterval(...)` und Timing-Pausen kein Cheat-Detection-Trigger ausgeloest wird.
+
+Wann wuerde ein echter Cheat-Click triggern (Spielseite)? Wenn der Spielcode bei einem Action-Submit `is_cheat_click(event)` aufruft und dieses `true` liefert -> Action wird verworfen. HHAuto mitigiert das, indem es `getHHAjax()(params, ...)` direkt aufruft (statt synthetischer Klicks) und Buttons nur dort triggert, wo sie tatsaechlich noetig sind. Trotzdem zeigt der bewusste Verzicht auf den Override, dass aktuell **kein** synthetischer Klick-Pfad mehr Cheat-Detection ausloesen sollte.
+
+Window-Interface (`src/index.ts:62`) enthaelt `is_cheat_click: any` als declared property - das ist das Type-Hint fuer alte direkte Reads/Writes, die heute nicht mehr aktiv sind.
+
+## 13. Race-Conditions / Timing
+
+### 13.1 Skript-Start
+
+`src/index.ts:88` ruft `hardened_start()` direkt nach Modul-Load. Tampermonkey injiziert den User-Script aber **vor** dem game-eigenen JS, daher sind globale Variablen wie `shared.Hero` zum Erst-Aufruf typisch noch nicht da.
+
+Schritte in `hardened_start()` (`Service/StartService.ts:175`):
+
+1. Registriert `GM_registerMenuCommand("Save Debug Log", saveHHDebugLog)`.
+2. Pruefung `unsafeWindow.jQuery == undefined` -> falls fehlt: ggf. "Forbidden"-Page erkennen (innerText der `body`); bei Forbidden: reload nach `randomInterval(60, 300)` Sekunden; sonst Abbruch (kein Crash).
+3. `started` Lock + `start()`-Aufruf.
+
+In `start()` (`Service/StartService.ts:197`):
+
+1. **Hero-Retry-Loop**: Wenn `unsafeWindow.shared?.Hero === undefined`:
+   - `heroRetryCount++`. Maximal `HERO_MAX_RETRIES = 15` Versuche, dann Abbruch ("Try reloading the page.").
+   - `setTimeout(hardened_start, 5000)` -> alle 5 Sekunden neu versuchen.
+   - `started = false` zurueckgesetzt, damit ein erneuter Aufruf zaehlt.
+   - Diese Loop entspraeche bis zu 75 Sekunden Wartezeit.
+2. Sobald Hero verfuegbar: Timer-Cleanup (`clearTimeout(heroRetryTimer); heroRetryCount = 0`).
+3. Login-Check: `$("a[rel='phoenix_member_login']").length > 0` -> nicht eingeloggt, abbrechen.
+4. `StartService.checkVersion()` migriert von `previousScriptVersion` (`TK.scriptversion`) auf `GM.info.script.version`.
+5. `migrateHHVars()` migriert ggf. alten `HHAuto_`-Praefix auf einen custom Praefix (heute meist No-Op).
+6. Liest `Hero.infos.questing.choices_adventure` und `Hero.infos.questing.id_world`, persistiert als `TK.MainAdventureWorldID` / `TK.SideAdventureWorldID`.
+7. `setDefaults()` schreibt fehlende oder ungueltige Settings auf Defaults.
+8. Menu, Timers, Listener, Ad-Move, `Booster.collectBoostersFromAjaxResponses()` registrieren.
+9. `setTimeout(autoLoop, 1000)` schliesst den Init ab.
+
+### 13.2 Module-spezifische Retries
+
+Mehrere Module haben einen Retry-Pattern fuer den Fall, dass ihre erforderliche Game-Variable noch nicht da ist:
+
+- `HeroHelper.getHero()` (`Helper/HeroHelper.ts:23`): Wenn `shared.Hero === undefined`, schedule `autoLoop` (mit `TK.autoLoopTimeMili` ms) und gib `undefined` zurueck.
+- `League.getLeagueCurrentLevel()` (`Module/League.ts:73-78`): Wenn `unsafeWindow.current_tier_number === undefined`, schedule `autoLoop` (gleiches Muster).
+- `getHHVars(...)` returns `null` bei jeder fehlenden Pfad-Komponente -> Caller muessen das pruefen. Die meisten Caller akzeptieren `null` und logen.
+
+### 13.3 AJAX-Race um Booster-Status
+
+`equipBooster()` (`Helper/HeroHelper.ts:108-176`) hat einen kombinierten Race-Schutz:
+
+- Vor dem Call: `setStoredValue(TK.autoLoop, "false")` -> Loop pausiert.
+- 15-Sekunden-Timeout via `setTimeout(...)` als Safeguard wenn weder `onSuccess` noch `onError` vom Spiel kommen.
+- `settled`-Flag verhindert doppelte Auflosung.
+- Bei Timeout: `deleteStoredValue(TK.boosterStatusLastUpdate)` invalidiert den 10-Min-TTL-Cache, sodass beim naechsten Auto-Equip-Cycle der Markt-Refresh gefordert wird.
+- Bei `data.success === false`: gleiches Invalidieren (Annahme: anderer Tab hat in der Zwischenzeit equipped).
+- Nach Settle: `autoLoop` mit `randomInterval(500, 800)` neu gestartet.
+
+`Booster.waitForBattleResponse()` / `Booster.notifyBattleResponseProcessed()` (`Module/Booster.ts:52-99`): Lock-Pattern mit Promise + 10s-Timeout fuer den Fall, dass die Battle-AJAX-Response zu spaet kommt - resolveiert dann anyway, um den Loop nicht zu blockieren.
+
+### 13.4 AutoLoop-Pause-Mechaniken
+
+- `TK.autoLoop = "false"` schaltet die Hauptschleife aus. Wird gesetzt von:
+  - 31 Modulen (siehe Sektion 7) waehrend Multi-Page-Flows (Stuff Team, Give XP, Equip Booster, Page-Navigation).
+  - `Service/StartService.ts:441-449`: `setStoredValue(TK.autoLoop, "true")` nur, wenn KEIN aktiver `TK.haremGirlMode` laeuft - sonst wird der Loop nach Reload bewusst pausiert gelassen.
+- `SK.master = "false"` -> Master-Switch off, Loop laeuft nicht (gepfueft in `Scheduler.ts`, `AutoLoop.ts`, `HHMenuHelper.ts`).
+- `SK.mousePause = "true"` + `SK.mousePauseTimeout` -> Loop pausiert bei Maus-Aktivitaet (Mechanik in `MouseService.ts`).
+
+### 13.5 Timer-System
+
+- `TK.Timers` haelt eine JSON-Map `name -> {endAt, startedAt}`. Geschrieben von `Helper/TimerHelper.ts`, gelesen von `StartService.ts:266` beim Start (`setTimers(...)`).
+- Beim Skript-Start wird `setTimers(getStoredJSON(TK.Timers, {}))` ausgefuehrt; persistierte Timer leben also ueber Reloads weg.
+- `getSecondsLeft(name)` / `setTimer(name, seconds)` / `clearTimer(name)` / `checkTimer(name)` sind die Wrapper.
+- Hint: `convertTimeToInt(text)` parsed das Game-DOM-Timer-Format (HH:MM:SS) z.B. fuer Shop-Refresh.
+
+### 13.6 Bekannte Edge-Cases
+
+- **Erstaufruf vor Game-Load**: 15x 5s-Retry-Loop (siehe oben).
+- **Forbidden-Page**: 1-5min Random-Reload (Anti-Bot-Backoff).
+- **Tab-Wechsel und SK.settPerTab=true**: Settings landen in `sessionStorage`, also pro Tab. Migration zwischen Tabs ist nicht implementiert - User muss bewusst exportieren.
+- **boosterStatusLastUpdate TTL**: 10 Minuten (`Booster.BOOSTER_STATUS_TTL_MS = 10 * 60 * 1000`). Nach Ablauf wird Markt erneut gescraped, bevor equipt wird.
+- **`unsafeWindow.shared.GirlSalaryManager.girlsMap`**: Fuer Salary aktiv - kann erst nach Salary-Manager-Init genutzt werden. Code prueft mit `getHHVars(..., false)` (silent).
+

--- a/docs-internal/runtime-architecture.md
+++ b/docs-internal/runtime-architecture.md
@@ -1,0 +1,250 @@
+---
+last-verified: 2026-05-05
+verified-against-version: 7.35.20
+status: new
+---
+
+# Runtime Architecture
+
+Wie HHAuto im Browser tatsächlich läuft. Diese Datei dokumentiert Stolperfallen die im Code stecken aber nirgends sonst aufgeschrieben sind.
+
+---
+
+## 1. Iframe-Architektur (WICHTIG)
+
+Das Spiel läuft NICHT direkt auf der Top-Domain. Der Browser lädt:
+
+```
+https://www.hentaiheroes.com/        <- Top-Window: Wrapper-HTML
+  +-- <iframe id="hh_hentai">        <- Game-Window: Hier lebt der Spielzustand
+        +-- window.shared.Hero       <- Daten
+        +-- window.availableGirls    <- Daten
+        +-- window.hh_ajax           <- API-Bridge
+```
+
+### Iframe-IDs pro Spiel
+
+Aus `src/config/game/*.ts`:
+
+| Spiel | Domain | Iframe-ID |
+|-------|--------|-----------|
+| HentaiHeroes | hentaiheroes.com / haremheroes.com | `hh_hentai` |
+| ComixHarem | comixharem.com | `hh_comix` |
+| PornstarHarem | pornstarharem.com | `hh_star` |
+| GayPornstarHarem | gaypornstarharem.com | `hh_stargay` |
+| TransPornstarHarem | transpornstarharem.com | `hh_startrans` |
+| GayHarem | gayharem.com | `hh_gay` |
+| AmourAgent | amouragent.com | `hh_amour` |
+| MangaRpg | mangarpg.com | `hh_mangarpg` |
+| HornyHeroes | hornyheroes.com | `hh_sexy` |
+
+Die Iframe-IDs werden in `HHEnvVariables.ts` als `gameID` registriert.
+
+### Konsequenzen für Skripte
+
+- `unsafeWindow.shared` ist **leer** auf der Top-Window-Ebene
+- Standalone-Userscripts brauchen entweder `@noframes` (laufen nur im Top-Window — sehen kein Spiel) oder die Iframe-Erkennung
+- `document.getElementById(gameID)` sucht im Top-Window-DOM nach dem Iframe-Element selbst, NICHT im Iframe-Inhalt
+- Der Body innerhalb des Iframes trägt `<body page=\"...\" id=\"hh_hentai\">` — das `page`-Attribut wird von `getPage()` ausgelesen
+
+### Wie HHAuto.user.js es macht
+
+Das Hauptskript läuft mit `@match` direkt auf `*.hentaiheroes.com/*` — Tampermonkey/Greasemonkey injiziert in **alle** matchenden Frames, inklusive Iframes. `unsafeWindow` zeigt dann automatisch auf das jeweilige Frame-Window.
+
+### Wie der Debug-Inspector es macht
+
+`HHAuto_debug_inspector.user.js` v3.1.0+ hat `@noframes` — läuft nur im Top-Window — und sucht aktiv nach dem Iframe via bekannte IDs oder per Scan auf `shared`/`Hero`/`availableGirls`. Schaltet dann auf `iframe.contentWindow` um.
+
+---
+
+## 2. unsafeWindow.shared — der eigentliche State
+
+Was die Doku oft als `unsafeWindow.Hero` oder `Hero.energies.x` zeigt, ist tatsächlich:
+
+```javascript
+unsafeWindow.shared.Hero.energies.x
+```
+
+`HHHelper.getHHVars()` macht das transparent:
+
+```typescript
+function prefixIfNeeded(infoSearched) {
+    if (!!unsafeWindow.shared && infoSearched.indexOf('Hero.') == 0) {
+        infoSearched = 'shared.' + infoSearched;
+    }
+    return infoSearched;
+}
+```
+
+Wer direkt auf `unsafeWindow.Hero` zugreift kriegt undefined. Immer `getHHVars()` benutzen.
+
+### Was direkt auf unsafeWindow liegt (nicht in shared)
+
+| Variable | Quelle |
+|----------|--------|
+| `availableGirls` | Edit-Team-Seite |
+| `teams_data` | Battle-Teams-Seite |
+| `girlsDataList`, `girls_data_list` | verschiedene Seiten |
+| `opponents_list` | League-Seite |
+| `daily_goals_list` | Daily-Goals-Seite |
+| `girl_squad` | Labyrinth-Seite |
+| `pop_list`, `pop_index` | Place-of-Power-Seite |
+| `current_tier_number`, `league_tag` | League-Seite |
+| `hh_prices` | Booster/Energy-Preise |
+| `hh_nutaku` | nur auf Nutaku-Mirrors |
+| `has_contests_datas` | Contest-Seite |
+
+### Was unter shared liegt
+
+| Pfad | Inhalt |
+|------|--------|
+| `shared.Hero` | Hauptobjekt mit allen Player-Stats, Energien, Currencies, Equipment |
+| `shared.general.hh_ajax` | Game-eigener AJAX-Wrapper |
+| `shared.general.is_cheat_click` | Anti-Cheat-Hook |
+| `shared.GirlSalaryManager.girlsMap` | Voll-Daten aller Girls (Map: id_girl -> girl-object) |
+
+---
+
+## 3. AJAX-Wrapper
+
+`getHHAjax()` aus `Utils.ts`:
+
+```typescript
+return unsafeWindow.shared?.general?.hh_ajax;
+```
+
+Nicht `unsafeWindow.hh_ajax` (existiert nicht). Direktes `fetch()`/`XMLHttpRequest` umgeht Anti-Cheat und Session-Handling und schlägt fehl.
+
+### Nutaku-Session-Injection
+
+Auf `nutaku.*`-Mirrors muss vor jedem AJAX-Call `addNutakuSession()` aufgerufen werden — sonst fehlt das Session-Token und der Server lehnt ab:
+
+```typescript
+if (unsafeWindow.hh_nutaku) {
+    const hhSession = queryStringGetParam(window.location.search, 'sess');
+    // hhSession an params hängen
+}
+```
+
+Erkennen ob Nutaku: `unsafeWindow.hh_nutaku` ist gesetzt.
+
+### Referer-Manipulation vor AJAX
+
+Vor manchen AJAX-Calls macht der Code:
+
+```typescript
+window.history.replaceState(null, '', addNutakuSession('/shop.html'));
+```
+
+Kein Bug, kein Workaround — der Server prüft den Referer-Header. Beim Equip-All-Aufruf muss der Referer auf `/girl/<id>?resource=equipment` zeigen, sonst lehnt der Server ab. Nach dem Call wird der Referer zurückgesetzt.
+
+---
+
+## 4. Page-Detection
+
+`getPage()` in `PageHelper.ts`:
+
+```typescript
+const ob = document.getElementById(ConfigHelper.getHHScriptVars(\"gameID\"));
+const page = ob.getAttribute('page');
+```
+
+`gameID` ist die Iframe-ID (z.B. `hh_hentai`). Im Iframe-Document ist das `<body id=\"hh_hentai\" page=\"home\">`. Die Funktion liest also das `page`-Attribut vom Body innerhalb des Iframes.
+
+### Activities-Page-Multiplexing
+
+Mehrere logische Seiten teilen sich URL und Body-Page-Attribut. Sub-Seiten werden via Tab-Parameter unterschieden:
+
+| URL/Tab | Logische Page |
+|---------|--------------|
+| `?tab=contests` | Contests |
+| `?tab=missions` | Missions |
+| `?tab=daily_goals` | Daily Goals |
+| `?tab=pop` | Place of Power |
+
+`getPage()` resolved das automatisch und liefert den kanonischen Page-Namen.
+
+### Unbekannte Pages
+
+`getPage(checkUnknown=true)` schreibt unbekannte Page-IDs nach `localStorage` unter dem `unkownPagesList`-Key. So werden Game-Updates erkannt die neue Pages einführen.
+
+---
+
+## 5. Race-Conditions beim Start
+
+`StartService.start()` prüft:
+
+```typescript
+if (unsafeWindow.shared?.Hero === undefined) {
+    heroRetryCount++;
+    setTimeout(autoLoop, ...);
+    return;
+}
+```
+
+Das Spiel lädt asynchron. Wenn das Userscript zu früh startet ist `shared.Hero` noch nicht da. Daher der Retry-Loop. Userscripts sollten `@run-at document-idle` setzen UND zusätzlich auf `shared.Hero` warten bevor sie auf Daten zugreifen.
+
+---
+
+## 6. Tampermonkey-Sandbox vs. unsafeWindow
+
+`@grant unsafeWindow` ist Pflicht. Ohne den Grant ist `unsafeWindow === window` (ein Sandbox-Proxy), und die Spielvariablen sind durch die Greasemonkey-Wrapper hindurch teilweise nicht oder nur partiell sichtbar.
+
+Symptome ohne `unsafeWindow`-Grant:
+- `unsafeWindow.shared` ist undefined obwohl Daten da sind
+- Funktionen wie `hh_ajax` können nicht aufgerufen werden
+- Setzen von Werten in Spielvariablen wird ignoriert
+
+---
+
+## 7. localStorage
+
+Liegt **auf der Iframe-Domain**, nicht auf der Top-Domain. Auf `www.hentaiheroes.com` und im `iframe#hh_hentai` (gleiche Origin) ist es derselbe Storage. Auf Nutaku-Mirrors mit Cross-Origin-Iframes könnten zwei separate Storages existieren — der Inspector dumpt darum sicherheitshalber beide.
+
+HHAuto-eigene Keys haben den Präfix `HHStoredVarPrefixKey` (definiert in `config/index.ts`).
+
+---
+
+## 8. Was wo extrahiert werden kann
+
+| Daten | Beste Seite | Variable |
+|-------|-------------|----------|
+| Voll-Girls (alle 62 Felder, alle besessen) | Edit-Team / Harem | `availableGirls` (Edit-Team) oder `shared.GirlSalaryManager.girlsMap` (überall) |
+| Hero-Stats | jede Seite | `shared.Hero` |
+| Aktive Blessings | Home (nach Cache-Refresh) oder Live via `hh_ajax({action:'get_girls_blessings'})` | n/a |
+| League-Gegner | League-Seite | `opponents_list` |
+| Season-Gegner | Season-Seite | `season_opponents` |
+| Penta-Drill-Gegner | Penta-Drill-Seite | `penta_opponents` |
+| Equipment-Inventar | Edit-Team-Seite (Girl ausgewählt) | DOM `.inventory-slot` Elements |
+| Booster-Inventar | Battle-Teams-Seite | im DOM, Top-Bar |
+| Markt-Items | Market-Seite | `shop` Variable + DOM |
+| Daily-Goals | Daily-Goals-Seite | `daily_goals_list` |
+| Tower-of-Fame-Daten | Tower-Seite | `tower_data` |
+| Champion-Daten | Champion-Seite | `championData` / `champion_data` |
+| Labyrinth-Squad | Labyrinth-Seite | `girl_squad` |
+| Place-of-Power | POP-Seite | `pop_list`, `pop_index` |
+
+---
+
+## 9. Cheat-Click-Detection
+
+`shared.general.is_cheat_click` ist ein Hook den das Spiel aufruft um zu prüfen ob ein Click \"echt\" ist (echtes MouseEvent vs. simulated). Das Userscript hat eine auskommentierte Replace-Funktion in `Utils.ts`:
+
+```typescript
+// unsafeWindow.is_cheat_click = function(e) { return false; };
+// unsafeWindow.shared.general.is_cheat_click = function(e) { return false; };
+```
+
+Aktuell deaktiviert. Wenn ein Click trotz korrekter DOM-Ansprache nicht greift, kann das hier liegen.
+
+---
+
+## 10. Checkliste für neue Skripte/Tools
+
+- [ ] `@grant unsafeWindow` setzen
+- [ ] Iframe-Awareness: ggf. `iframe.contentWindow` ansprechen oder `@match` so setzen dass das Skript IM Iframe läuft
+- [ ] Daten via `getHHVars()` lesen, nicht direkt `unsafeWindow.x.y.z`
+- [ ] AJAX via `getHHAjax()`, nicht via `fetch()`
+- [ ] Auf Nutaku: `addNutakuSession()` vor jedem AJAX
+- [ ] Vor Daten-Zugriff prüfen: `shared.Hero !== undefined`
+- [ ] Page-Wechsel via `gotoPage()`, nicht `window.location.href = ...` direkt

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -1,39 +1,61 @@
 ---
-last-verified: 2026-04-29
-verified-against-version: 7.35.14
-status: minor-drift-fixed
+last-verified: 2026-05-05
+verified-against-version: 7.35.21
+status: current
 ---
 
 # Team-Algorithmus Design
 
-Implementierung der verbesserten Team-Auswahl (Issue #1340).
-Erstellt: 2026-03-24 | Letzte Aktualisierung: 2026-04-29 | Algorithmus-Version: v7.34.14 (keine Änderungen bis v7.35.14)
+Implementierung der League-Team-Auswahl (Issues #1340, #1573).
+Letzte grosse Aenderung: 2026-05-05, v7.35.21 (v4-Algorithmus).
 
 ---
 
 ## Uebersicht
 
-Der Team-Algorithmus (v3) baut ein optimales 7-Girl-Team mit
-Tier-3-Trait-Gruppen-Optimierung, Element-Synergien und Leader-Skill-Bewertung.
+Der Team-Algorithmus baut ein optimales 7-Girl-Team. Quellen sind die
+Kinkoid-Performance-Handbooks (Forum-Topics 21217 und 24008), das
+HH-Wiki und das Tom-208-Userscript. Anforderungen sind in
+`INPUT/league-team-algorithmus-spec.md` konsolidiert.
 
 ```
-Legacy-Algorithmus (Fallback):      Aktueller Algorithmus (v3):
-  Tooltip-Daten (11 Felder)          availableGirls (62 Felder)
-  Score = Stat-Summe                  Score = Stats + Synergie + Trait-Matching
-  Top 16 nach Score                   Optimales 7er-Team
-  Kein Rarity-Filter                  Nur Mythic (6★) + Legendary (5★)
-  Leader = hoechster Score            Leader = bester Tier-5-Skill (Mythic only)
+v3 (bis 7.35.x):              v4 (ab 7.35.21):
+  Score = caracs_sum            Score = main_carac (HC=c1, Charm=c2, KH=c3)
+  Position-Penalty 0.80         entfaellt
+  5%-Synergie-Tiebreaker        entfaellt
+  Hex-Werte in UI               Klar-Namen via window.GT.design.colors
+  Hard-Filter nur Rarity        Hard-Filter Rarity + Klasse
+  Trait-Cluster vs Stats        main_sum * (1 + tier3Bonus)
 ```
 
 ### Dateien
 
 | Datei | Zweck |
 |-------|-------|
-| `src/Service/TeamScoringService.ts` | Scoring-Engine: Tier-3 Traits, Synergien, Tier-5, Stat-Formeln, Rarity-Filter |
-| `src/Service/TeamBuilderService.ts` | Team-Builder: Trait-Gruppen, Leader, Slot-Fill |
-| `src/Module/TeamModule.ts` | Integration: Dispatch v3/Legacy, Daten-Mapping, UI-Update |
-| `spec/Service/TeamScoringService.spec.ts` | 58 Tests |
-| `spec/Service/TeamBuilderService.spec.ts` | 22 Tests |
+| `src/Service/TeamScoringService.ts` | Scoring, Klassen-Filter, Tier-3-Bonus, Synergien, Tier-5, Leader-Ranking |
+| `src/Service/TeamBuilderService.ts` | Team-Builder: Cluster-Vergleich, Slot-Fill, Alternativen-Liste |
+| `src/Service/TraitMappings.ts` | Hex/Position/Zodiac -> Klar-Namen mit Runtime + Hardcoded Fallback |
+| `src/Module/TeamModule.ts` | Integration: Dispatch v4/Legacy, Daten-Mapping, UI-Box |
+| `spec/Service/TeamScoringService.spec.ts` | Unit-Tests Scoring |
+| `spec/Service/TeamBuilderService.spec.ts` | Unit-Tests Builder |
+
+---
+
+## Anforderungen (aus League-Spec)
+
+| Punkt | Regel |
+|-------|-------|
+| Pool-Filter | Mythic (6*) + Legendary 5* |
+| Klassen-Filter | Hart auf player.class (1=HC, 2=Charm, 3=KH); cross-class wird verworfen |
+| Score | main_carac der Spielerklasse, nicht caracs_sum |
+| Trait-Cluster | Bestes Element-Paar nach `main_sum * (1 + tier3Bonus)` |
+| Leader | Mythic, Tier-5 Shield > Stun > Execute > Reflect, Tiebreaker = Trait-Match |
+| Blessing-Heuristik | Aktiv-blessed Trait-Kategorie kriegt x1.5 fuer fruehere Auswahl |
+| Tier-3-Bonus | 1.0% Mythic / 0.8% Legendary pro Trait-Match-Teammate |
+| Mono-Element-Synergie | linear pro Girl im Team (informational, nicht im Score) |
+| Equipment | KEIN Unequip noetig: `availableGirls.caracs` ist equipment-frei |
+| UI-Hinweis | "Stats are equipment-free. Hit Stuff Team after applying." |
+| Klar-Namen | window.GT.design.colors mit Hardcoded EN-Fallback |
 
 ---
 
@@ -44,314 +66,303 @@ Legacy-Algorithmus (Fallback):      Aktueller Algorithmus (v3):
 ```
 setTopTeam(mode)
   |
-  +-- availableGirls vorhanden?
-  |     JA  --> setTopTeamV2(mode, girls)
-  |     NEIN -> setTopTeamLegacy(mode)  [alter Code als Fallback]
+  +- availableGirls vorhanden?
+  |    JA  -> setTopTeamV2(mode, girls)
+  |    NEIN -> setTopTeamLegacy(mode)  [DOM-basierter Fallback]
   |
-  +-- setTopTeamV2:
-        1. Map availableGirls -> GirlData[]
-           (zodiac: substring(3).trim(), hairColor: hair_color1,
-            eyeColor: eye_color1, position: position_img ohne .png)
-        2. TeamBuilderService.buildTeam(girls, mode, playerLevel)
-           a. Filter: Mythic (6★) + Legendary (nur 5★, nicht 3★)
-           b. Score alle Kandidaten (Mode 1 oder Mode 2)
-           c. Sortiere nach Score, nimm Top 50
-           d. Finde beste Trait-Gruppe (Element-Paar + gemeinsamer Trait-Wert)
-           e. Leader aus Pool (nur Mythic, Tier-5 Prioritaet)
-           f. Slots 2-7: unified Vergleich (Stats + Synergie + Tier-3-Delta)
-        3. updateTeamUI(deckID, teamResult)
+  +- setTopTeamV2:
+      1. HeroHelper.getClass() -> playerClass (1, 2 oder 3)
+      2. Map availableGirls -> GirlData[]
+         (zodiac roh halten, Position als Nummer, Hex-Werte 1:1)
+      3. TeamBuilderService.buildTeam(girls, mode, playerLevel, playerClass)
+         a. filterEligible: Mythic/Legendary 5* AND class === playerClass
+         b. Score alle Kandidaten ueber main_carac (Mode 1 oder 2)
+         c. Sortiere alle eligible Girls (kein Cap)
+         d. detectBlessedTraits ueber blessing_bonuses
+         e. findTraitGroups (mit Blessed-Boost x1.5)
+         f. Top 5 Gruppen + alle blessed Gruppen evaluieren
+         g. Pro Gruppe Team bauen, vergleiche `main_sum * (1 + tier3Bonus)`
+         h. Beste Gruppe gewinnt
+      4. updateTeamUI(deckID, teamResult): Klar-Namen, Klasse, Equipment-Hinweis
 ```
 
-### Phase 1: Rarity-Filter (beide Modi)
+### Phase 1: Filter
 
 ```
-Mythic (nb_grades = 6):    immer beruecksichtigt
-Legendary (nb_grades = 5): beruecksichtigt
-Legendary (nb_grades = 3): ausgeschlossen
-Alle anderen Raritaeten:   ausgeschlossen
+class === playerClass?         hart, sonst raus
+rarity === 'mythic'             ja
+rarity === 'legendary' 5*       ja
+sonst                            raus
 ```
 
 ### Phase 2: Scoring
 
-#### Modus 1 — "Current Best"
+#### Modus 1 -- "Current Best"
 
 ```
-Score:   caracs.carac1 + caracs.carac2 + caracs.carac3
-         (bereits gesegnete Werte)
+score = caracs.caracN     (N = playerClass)
+        // bereits gesegnet, equipment-frei
 ```
 
-#### Modus 2 — "Best Possible"
+#### Modus 2 -- "Best Possible"
 
 ```
-Score:   currentStats / level * playerLevel
-         / (1 + 0.3 * graded)
-         * (1 + 0.3 * nb_grades)
+projected = caracN / level * playerLevel
+            / (1 + 0.3 * graded)
+            * (1 + 0.3 * nb_grades)
+
+score = max(projected, current_caracN)
+        // Schutz gegen blessing-inflated current > projected
 ```
 
-Projiziert Stats auf Player-Level mit vollen Grades.
+### Phase 3: Trait-Gruppen
 
-### Phase 3: Trait-Gruppen-Optimierung (Tier 3)
+Aus dem Top-50-Pool werden Girls nach Element-Paar und gemeinsamem
+Trait-Wert gruppiert. Gruppen-Score:
 
-Aus dem Top-50-Pool werden Girls nach Element-Paaren und gemeinsamen
-Trait-Werten gruppiert. Die beste Gruppe (mindestens 3 Girls) wird
-bevorzugt ins Team aufgenommen.
+```
+score = anzahlGirls * avg(main_carac)
+score *= 1.5  wenn traitCategory in blessedCategories
+```
 
 #### Element-Paare und Trait-Kategorien
 
-| Element-Paar | Trait-Kategorie | Farbe |
-|-------------|----------------|-------|
-| Darkness + Fire | eyeColor | Schwarz + Rot |
-| Light + Nature | hairColor | Weiss + Gruen |
-| Stone + Psychic | zodiac | Orange + Lila |
-| Water + Sun | position | Blau + Gelb |
+| Element-Paar | Trait-Kategorie | Hex-Beispiele |
+|-------------|----------------|---------------|
+| Darkness + Fire | eyeColor | 00F, A55, F00 |
+| Light + Nature | hairColor | FFF, 0F0, B62 |
+| Stone + Psychic | zodiac | "Aries", "Cancer" |
+| Water + Sun | position | 1, 2, ... 12 |
 
-#### Trait-Gruppen-Score
+### Phase 4: Cluster-Vergleich
 
-```
-score = anzahlGirls * durchschnittStats
-```
-
-Position-Gruppen erhalten einen Penalty-Faktor von 0.80 (Position-Trait
-reduziert Angriffs-Stats durch Equipment).
-
-Fallback: Wenn keine Gruppe mit >= 3 Girls gefunden wird, wird
-die groesste eyeColor-Gruppe verwendet.
-
-### Phase 4: Tier-3-Bonus-Berechnung
-
-Jedes Girl im Team prueft, wie viele Teammates den gleichen Trait-Wert
-innerhalb des gleichen Element-Paars teilen:
+Fuer jede Top-Gruppe wird ein vollstaendiges Team gebaut und
+nach effektiver Power verglichen:
 
 ```
-Mythic:    1.0% Bonus pro Match
-Legendary: 0.8% Bonus pro Match
+effectivePower = round(main_sum * (1 + tier3Bonus))
+
+main_sum     = Summe der main_carac-Scores aller 7 Team-Mitglieder
+tier3Bonus   = Summe ueber alle Mitglieder von:
+                 matchCount(member) * (member.rarity === 'mythic' ? 0.01 : 0.008)
 ```
 
-Der Bonus wird pro Girl berechnet und fuer das Team summiert (bis zu ~7%).
+Die Gruppe mit hoechster `effectivePower` gewinnt. Alle evaluierten
+Alternativen landen in `result.alternatives` fuer die UI-Anzeige.
 
-### Phase 5: Leader-Auswahl
+### Phase 5: Slot-Fill (innerhalb einer Gruppe)
 
-Leader muss Mythic sein. Ausnahme: wenn keine Mythics vorhanden sind,
-werden alle Girls als Fallback betrachtet.
+Drei Pass-Strategie pro Cluster:
 
-Sortierung der Leader-Kandidaten:
+| Pass | Filter | Sortiert nach |
+|------|--------|---------------|
+| 1 | Element gehoert zum Cluster-Paar UND traitValue matcht | main_carac desc |
+| 2 | Element gehoert zum Cluster-Paar (beliebiger trait) | main_carac desc |
+| 3 | beliebiges Element | main_carac desc |
+
+Pass 1 maximiert Tier-3-Match. Pass 2 haelt das Mono-Element-Bonus.
+Pass 3 ist nur Reserve, falls die Gruppe weniger als 7 Girls hat.
+
+### Phase 6: Leader
+
+Leader muss Mythic sein und idealerweise zum Cluster-Element-Paar gehoeren.
 
 | Prioritaet | Kriterium |
 |-----------|----------|
-| 1 (primaer) | Tier-5-Skill-Prioritaet (siehe Tabelle) |
-| 2 (sekundaer) | Trait-Match (Leader teilt Team-Trait) |
-| 3 (tertiaer) | Stat-Score |
+| 1 (primaer) | Tier-5-Skill: Shield(4) > Stun(3) > Execute(2) > Reflect(1) |
+| 2 (sekundaer) | Trait-Match (Leader teilt Cluster-Trait-Wert) |
+| 3 (tertiaer) | main_carac-Score |
 
-| Element | Tier-5 Skill | Prioritaet | ID |
-|---------|-------------|------------|----|
-| Light / Stone | Shield | 4 (hoechste) | 12 |
-| Sun / Darkness | Stun | 3 | 11 |
-| Fire / Water | Execute | 2 | 14 |
-| Psychic / Nature | Reflect | 1 (niedrigste) | 13 |
+| Element | Tier-5 Skill | Prioritaet |
+|---------|-------------|------------|
+| Light, Stone | Shield | 4 |
+| Sun, Darkness | Stun | 3 |
+| Fire, Water | Execute | 2 |
+| Psychic, Nature | Reflect | 1 |
 
-**Konsequenz:** Der Leader kann weniger Stat-Punkte haben als andere
-Team-Mitglieder. Ein Shield-Leader mit 29.000 Punkten ist staerker
-als ein Reflect-Leader mit 31.000 Punkten.
+### Phase 7: UI
 
-### Phase 6: Unified Slot-Fill (Positionen 2-7)
+Info-Box (oben mittig, dunkel, halbtransparent):
 
-Fuer jeden Slot werden **alle** verbleibenden Kandidaten im Pool bewertet.
-Trait-Gruppen-Girls und Nicht-Gruppen-Girls konkurrieren direkt:
+- Klassen-Hinweis: "Class: <Hardcore/Charm/Know-how> -- only X girls considered"
+- Trait optimiert: "[emoji] eyeColor = 'Blue' (4/7 girls match)"
+- Tier-3-Bonus: "+X.X% total stat boost"
+- Leader: Name + Tier-5-Skill + Element-Klasse
+- Element-Verteilung: "Eccentric x3, Sensual x2, ..."
+- Effective Power
+- Active Blessings + Match-Indikator
+- Compared: Liste der evaluierten Cluster-Alternativen mit Power
+- Equipment-Hinweis: "Stats are equipment-free. Hit Stuff Team after applying."
+- Mode-Hinweis: aktueller Modus (Current Best vs. Best Possible)
 
-```
-combinedScore = synergyScore + tier3Delta
-
-synergyScore  = statScore + synergyWeight * synergyDelta
-tier3Delta    = marginalPct * teamStatTotal
-```
-
-#### Tier-3-Delta-Berechnung (estimateTier3Delta)
-
-Berechnet den Stat-aequivalenten Wert des marginalen Tier-3-Bonus:
-
-```
-existingTraitCount = Anzahl Team-Mitglieder die traitCategory + traitValue matchen
-K = existingTraitCount
-
-newGirlBonus  = K * bonusPerMatch(candidate.rarity)
-existingBoost = Summe(bonusPerMatch(teammate.rarity)) fuer jeden Trait-Teammate
-
-marginalPct   = newGirlBonus + existingBoost
-tier3Delta    = marginalPct * teamStatTotal
-```
-
-- Kandidaten die nicht zur Trait-Gruppe gehoeren: `tier3Delta = 0`
-- `teamStatTotal` wird pro Slot neu berechnet
-- Trait-Girls haben einen Vorteil der mit der Anzahl bestehender
-  Trait-Matches quadratisch waechst
-
-**Konsequenz:** Eine Girl mit +40% Blessing-Bonus (z.B. 14.000 Stats)
-schlaegt eine Trait-Girl mit 10.000 Stats, wenn der Tier-3-Bonus den
-Stat-Gap nicht kompensiert. Umgekehrt gewinnt die Trait-Girl bei
-ausreichend vielen Trait-Matches im Team.
-
-**Cold-Start:** Die erste Trait-Girl hat `tier3Delta = 0` (keine
-bestehenden Trait-Teammates). Sie muss rein auf Stats und Synergie
-konkurrieren. Ab der zweiten Trait-Girl waechst der Bonus.
-
-### Phase 7: UI-Anzeige
-
-- Girls 1-7 mit Element-Emoji und Position
-- Leader: `[emoji] ★ [Skill-Name]` (z.B. "✨ ★ Shield")
-- Synergie-Info-Panel mit:
-  - Trait-Kategorie und -Wert (z.B. "👁 Blue (4/7)")
-  - Tier-3-Bonus in Prozent
-  - Leader-Skill und Element
-  - Element-Verteilung
+Klar-Namen via `TraitMappings.resolve(category, value)`. Wenn der
+Runtime-Lookup fehlschlaegt (z.B. GT nicht geladen), erscheint ein
+Hinweis "Trait label uses fallback dictionary -- may be inaccurate
+for new color codes".
 
 ---
 
-## Element-Synergien
+## Klar-Namen-Mapping (TraitMappings)
 
-Bonus pro Girl des jeweiligen Elements im Team:
+Quelle: Tom-208-Userscript (`gist a5c7065866fe1de5032aabbbd1ed9eff`),
+identisch mit `window.GT.design.colors`.
 
-| Element | Anzeige-Name | Bonus pro Girl | Effekt |
+### Lookup-Reihenfolge
+
+1. `unsafeWindow.GT.design.colors[hex]` (live, immer aktuell)
+2. Hardcoded EN-Fallback in `TraitMappings.ts`
+3. `'#' + hex` als letzter Fallback (z.B. `#765` wenn neue Farbe)
+
+### Fallback-Tabelle (Eye + Hair Colors)
+
+```
+F99 -> Pink         B06 -> Dark Pink     F00 -> Red
+B62 -> Dark blond   FFF -> White         321 -> Dark
+00F -> Blue         FF0 -> Blond         0F0 -> Green
+A55 -> Brown        000 -> Black         CCC -> Silver
+F0F -> Purple       F90 -> Orange        EB8 -> Strawberry blonde
+888 -> Grey         FD0 -> Golden        D83 -> Bronze
+765 -> Ash brown    XXX -> Unknown
+```
+
+### Position
+
+```
+position_img = "1.png" .. "12.png"
+-> Runtime: window.GT.design.figures[1..12]  ("Doggy", "69", ...)
+-> Fallback: "Pose 1" .. "Pose 12"
+```
+
+### Zodiac
+
+`"♈︎ Aries"` -> strip leading non-letters -> `"Aries"`. Keine Hex-Werte,
+daher Fallback identisch zur Live-Variante.
+
+---
+
+## Element-Synergien (informational)
+
+Mono-Element-Bonus pro Girl im Team. Wird im Score nicht angewendet
+(der Klar-Filter auf main_carac und Tier-3-Bonus genuegen), aber im
+UI angezeigt:
+
+| Element | Klassen-Name | Bonus pro Girl | Effekt |
 |---------|-------------|----------------|--------|
-| Fire | Eccentric | **+10%** | Critical Hit Damage |
+| Fire | Eccentric | +10% | Crit Damage |
 | Water | Sensual | +3% | Heal on Hit |
 | Nature | Exhibitionist | +3% | Ego (HP) |
-| Stone | Physical | +2% | Critical Hit Chance |
-| Sun | Playful | +2% | Gegner-Defense senken |
+| Stone | Physical | +2% | Crit Chance |
+| Sun | Playful | +2% | Defense Reduction |
 | Darkness | Dominatrix | +2% | Damage |
 | Psychic | Submissive | +2% | Defense |
 | Light | Voyeur | +2% | Harmony |
 
-Fire hat den hoechsten Einzel-Impact (10% vs 2-3%), daher bevorzugt
-der Algorithmus Fire-Girls bei aehnlichen Stats.
-
-### Synergie-Value-Berechnung
-
-```typescript
-synergyValue = critDamage * 1.0   // Fire: 10% * 1.0
-             + critChance * 2.0   // Stone: 2% * 2.0
-             + defReduce  * 2.0   // Sun: 2% * 2.0
-             + healOnHit  * 1.5   // Water: 3% * 1.5
-             + damage     * 1.5   // Darkness: 2% * 1.5
-             + ego        * 1.0   // Nature: 3% * 1.0
-             + defense    * 1.0   // Psychic: 2% * 1.0
-             + harmony    * 1.0   // Light: 2% * 1.0
-```
-
-Nur der Team-variable Anteil wird betrachtet. Der Harem-weite Anteil
-(basierend auf Gesamtzahl besessener Girls pro Element) ist konstant
-und beeinflusst die Team-Optimierung nicht.
+Quelle: Performance Handbook, bestaetigt durch Tom-208 Battle-Sim
+(`hero_data.team_synergies` Live-Werte).
 
 ---
 
-## Datenquellen
+## Datenfelder
 
-### Primaer: `availableGirls` (Edit Team Page)
+### `availableGirls` Felder
 
-Zugriff via `getHHVars("availableGirls")`. 62 Felder pro Girl.
-Nur auf der Edit-Team-Seite verfuegbar.
+Verfuegbar nur auf der Edit-Team-Seite. Zugriff via `getHHVars("availableGirls")`.
 
-Relevante Felder fuer Team-Selection:
-
-| Feld | Typ | Verwendung |
-|------|-----|------------|
+| Feld | Typ | Verwendung in v4 |
+|------|-----|------------------|
 | `id_girl` | number | Identifikation |
-| `name` | string | Log-Ausgabe |
-| `carac1`, `carac2`, `carac3` | number | Stats (gesegnet) |
-| `caracs` | object | Alternative Stats-Quelle |
-| `element_data.type` | string | Element-Typ |
-| `element` | string | Element-Typ (Fallback) |
-| `rarity` | string | Rarity-Filter (mythic, legendary) |
-| `level` | number | Potential-Berechnung |
-| `graded` | number | Aktuelle Grades |
-| `nb_grades` | number | Maximale Grades (3, 5 oder 6) — Filterkriterium |
-| `zodiac` | string | Tier-3-Trait (Zodiac-Kategorie) |
-| `hair_color1` | string | Tier-3-Trait (Hair-Color-Kategorie) |
-| `eye_color1` | string | Tier-3-Trait (Eye-Color-Kategorie) |
-| `position_img` | string | Tier-3-Trait (Position-Kategorie) |
-| `skill_tiers_info` | object | Skill-Daten (aktuell nicht fuer Scoring genutzt) |
+| `name` | string | UI/Log |
+| `caracs.carac1/2/3` | number | Score (equipment-frei) |
+| `class` | number | Klassen-Filter (1, 2, 3) |
+| `element_data.type` | string | Element-Cluster |
+| `rarity` | string | Rarity-Filter |
+| `level`, `graded`, `nb_grades` | number | Best-Possible-Projektion |
+| `eye_color1` | string | eyeColor-Trait (3-char Hex) |
+| `hair_color1` | string | hairColor-Trait (3-char Hex) |
+| `zodiac` | string | zodiac-Trait (Glyph + Name) |
+| `position_img` | string | position-Trait ("N.png") |
+| `blessing_bonuses` | object | Blessed-Categories-Erkennung |
 
-### Fallback: Tooltip-Daten
+### Equipment-Status
 
-Bei fehlendem `availableGirls` greift der Legacy-Algorithmus auf
-`data-new-girl-tooltip` zurueck (11 Felder, DOM-Parsing).
-Der Legacy-Algorithmus hat keinen Rarity-Filter und kein Trait-Matching.
+Verifiziert per Dump-Vergleich (2026-05-05):
+
+```
+teamGirls.blessed_caracs == availableGirls.caracs
+```
+
+`caracs` ist gesegnet aber **ohne Equipment**. Daher ist KEIN Unequip
+vor der Berechnung noetig. Stuff-Team danach ist trotzdem sinnvoll
+(Equipment fuegt 20-40% obendrauf).
 
 ---
 
 ## Konfiguration
 
-| Parameter | Default | Beschreibung |
-|-----------|---------|-------------|
-| `synergyWeight` | 0.05 | Gewichtung Synergie vs Stats (0-1) |
-| `CANDIDATE_POOL_SIZE` | 50 | Anzahl Top-Kandidaten fuer Greedy |
-| `TEAM_SIZE` | 7 | Team-Groesse |
-| `POSITION_TRAIT_PENALTY` | 0.80 | Penalty fuer Position-Trait-Gruppen |
-| `TIER3_BONUS_MYTHIC` | 0.01 | 1.0% Tier-3-Bonus pro Match (Mythic) |
-| `TIER3_BONUS_LEGENDARY` | 0.008 | 0.8% Tier-3-Bonus pro Match (Legendary) |
-| `FALLBACK_TRAIT_CATEGORY` | eyeColor | Fallback wenn keine gute Trait-Gruppe gefunden |
-
-Aktuell sind diese Werte als Konstanten in `TeamScoringService.ts` und
-`TeamBuilderService.ts` definiert.
+| Parameter | Default | Datei | Beschreibung |
+|-----------|---------|-------|-------------|
+| (kein Pool-Cap) | -- | TeamBuilderService.ts | Alle eligible Girls werden bewertet; der Klassen+Rarity-Filter ist bereits scharf (max ~170 pro Klasse spielweit) |
+| `TEAM_SIZE` | 7 | TeamBuilderService.ts | Team-Groesse |
+| `TIER3_BONUS_MYTHIC` | 0.01 | TeamScoringService.ts | 1.0% Bonus pro Match |
+| `TIER3_BONUS_LEGENDARY` | 0.008 | TeamScoringService.ts | 0.8% Bonus pro Match |
+| `BLESSED_CATEGORY_BOOST` | 1.5 | TeamScoringService.ts | Heuristik-Multiplikator fuer blessed Cluster |
 
 ---
 
 ## Entscheidungen und Begruendungen
 
-### Warum Greedy statt vollstaendige Suche?
+### Warum hard class filter?
 
-Vollstaendige Kombinatorik: C(800, 7) = ~2.3 Billionen Kombinationen.
-Greedy ueber 50 Kandidaten: 50+49+48+47+46+45 = 285 Iterationen.
-Performance ist kein Problem.
+Wiki und Tom-208 sind eindeutig: niemals quer-bauen. Fuer einen
+KH-Spieler (class=3) ist nur carac3 relevant. KH-Mythics (z.B. Elphiba
+sum=22698, c3=12128) schlagen Cross-Class HC-Mythics (Cumkai sum=36644,
+c3=10985) bei der KH-relevanten Bewertung.
 
-### Warum 5% Synergie-Gewicht?
+Datenbasis: KH-only main_sum 82120 vs. cross-class 54351 (+57%).
 
-Bei 5% dominieren Stats noch klar (95%), aber bei aehnlichen Stats
-kann die Synergie den Unterschied machen. Bei hoeherem Gewicht wuerden
-schwache Girls nur wegen des Elements ins Team gewaehlt.
+### Warum main_carac statt caracs_sum?
 
-### Warum kein Domination-Bonus in der Bewertung?
+caracs_sum ueberbewertet Cross-Class-Stats. Ein KH-Spieler profitiert
+nicht von hohen carac1/c2-Werten -- die werden im Kampf gegen die
+gleiche Klasse vom Gegner ueberbietbar. Der spielrelevante Wert ist
+allein der Klassen-Hauptstat.
 
-Domination (Element-Dreieck gegen Gegner) erfordert Wissen ueber den
-Gegner, das erst auf der Kampf-Seite verfuegbar ist. Die Team-Auswahl
-erfolgt aber auf der Edit-Team-Seite, ohne Gegner-Kontext.
+### Warum kein Position-Penalty mehr?
 
-### Warum 3-Sterne-Legendaries ausschliessen?
+Der Penalty kompensierte falsche Cluster-Vergleiche im alten Algorithmus.
+v4 vergleicht Cluster direkt nach effektiver Power -- wenn Position
+schlechter ist, gewinnt sie nicht. Wenn sie besser ist (z.B. weil dort
+viele Mythics sind), darf sie gewinnen.
 
-Legendary Girls gibt es mit max 3 oder max 5 Sternen. 3-Sterne-Legendaries
-haben deutlich weniger Stat-Potential als 5-Sterne-Legendaries und Mythics.
-Sie wuerden nie realistisch in ein optimales Team kommen und vergroessern
-nur den Kandidaten-Pool unnoetig.
+### Warum kein 5% Synergie-Tiebreaker?
 
-### Warum Trait-Gruppen vor Stats priorisieren?
+Mono-Element-Synergie ist linear: jede Fire-Girl gibt +10% Crit-Damage.
+Diese Information ist im Cluster-Vergleich implizit enthalten (gleicher
+Element-Cluster = gleiche Synergie). Im Score brauchen wir das nicht.
 
-Der Tier-3-Bonus (bis zu ~7%) ist ein Team-weiter multiplikativer Bonus.
-Ein Team mit guter Trait-Uebereinstimmung kann trotz niedrigerer Einzel-Stats
-staerker sein als ein Team mit maximalen Einzel-Stats ohne Trait-Match.
+### Warum kein Unequip vor der Berechnung?
+
+`availableGirls.caracs` ist im Dump verifiziert equipment-frei. Ein
+Unequip wuerde nur Reload-Zeit kosten, ohne die Auswahl zu aendern.
+
+### Warum Klar-Namen aus window.GT statt Hardcode-Only?
+
+Patches koennten neue Farben (z.B. `765 = Ash brown`) einfuehren.
+Runtime-Lookup deckt das automatisch ab. Hardcode dient nur als
+Fallback fuer Spec-Tests und den Fall dass GT noch nicht geladen ist.
 
 ---
 
-## Nicht im Scope (bewusst ausgeschlossen)
+## Nicht im Scope
 
 | Ausgeschlossen | Grund |
 |----------------|-------|
-| Gegner-adaptive Team-Auswahl | Gegner nicht im Voraus bekannt |
-| BDSM-Simulation pro Kombination | Zu langsam |
-| Domination-Optimierung | Gegner-Info erst nach Seitenwechsel |
-| Blessing-Vorhersage | Daten verfuegbar, aber Nutzen unklar |
+| Gegner-adaptive Auswahl | Gegner erst auf Battle-Seite bekannt |
+| BDSM-Simulation pro Kombo | Zu langsam, Gegner-Info fehlt |
+| Domination-Optimierung | Gegner-Klasse erst nach Seitenwechsel |
 | Equipment-Optimierung | Separates Feature (StuffTeam) |
-| Battle-Teams (alle 3 Teams) | Erstmal nur aktives Team |
-
----
-
-## Offene Punkte / Moegliche Erweiterungen
-
-1. **Synergie-Gewicht konfigurierbar** — per User-Setting (0-20%)
-2. **Tier-5 Prioritaet konfigurierbar** — z.B. Stun > Shield je nach Liga
-3. **Skill-Points in Bewertung** — `skill_tiers_info[5].skill_points_used`
-   ist verfuegbar, wird aber noch nicht fuer die Tier-5-Effektstaerke genutzt
-4. **Kampfmodus-spezifische Gewichtung** — Liga vs. Season vs. Troll koennten
-   unterschiedliche Synergie-Gewichte haben
-5. **Mehrere Teams optimieren** — Battle Teams (alle 3) statt nur aktives Team
+| Battle-Teams (alle 3) | Nur aktives Team wird optimiert |
+| Booster-Auswahl | Separates Feature |
 
 ---
 
@@ -359,7 +370,9 @@ staerker sein als ein Team mit maximalen Einzel-Stats ohne Trait-Match.
 
 | Version | Aenderung |
 |---------|-----------|
-| v7.34.0 | v2: Synergie-optimierter Greedy-Algorithmus mit Leader Tier-5 (PR #1519) |
-| v7.34.7 | v3: Tier-3-Trait-Gruppen-Optimierung, Trait-Matching, Trait-Info-Panel |
-| v7.34.13 | Rarity-Filter: 3-Sterne-Legendaries ausgeschlossen, nur 5★ Legendary + 6★ Mythic |
-| v7.34.14 | Unified Slot-Fill: Trait-Girls vs Nicht-Gruppen-Girls per-Slot-Vergleich mit Tier-3-Delta |
+| 7.34.0 | v2: Synergie-Greedy + Leader Tier-5 (PR #1519) |
+| 7.34.7 | v3: Trait-Gruppen-Optimierung, Trait-Info-Panel |
+| 7.34.13 | Rarity-Filter: 3-Sterne-Legendaries ausgeschlossen |
+| 7.34.14 | Unified Slot-Fill mit Tier-3-Delta |
+| 7.35.x | Hex-Mapping-Bug, BlessingService-Cache |
+| 7.35.21 | v4: main_carac-Score, Klassen-Filter, Klar-Namen, Equipment-Hinweis (Issues #1340, #1573) |

--- a/docs-internal/technical-reference-team-selection.md
+++ b/docs-internal/technical-reference-team-selection.md
@@ -290,23 +290,38 @@ Labyrinth-only blessings can be identified by `"in Love Labyrinth"` in the descr
 
 ---
 
+## Equipment
+
+`availableGirls.caracs` is **equipment-free**. Verified by dump comparison (2026-05-05):
+
+```
+teamGirls.blessed_caracs == availableGirls.caracs
+```
+
+The team builder reads `caracs` directly. **No unequip is required** before scoring.
+A UI hint reminds the user that the displayed power excludes equipment and
+recommends running `Stuff Team` after applying the team.
+
+---
+
 ## 5. Relevant Source Files
 
-### Team Selection (v3 — current as of v7.35.10, no algorithm changes since v7.34.14)
+### Team Selection (v4 — current as of v7.35.21)
 
 | File | Key Function | Purpose |
 |------|-------------|---------|
-| `src/Service/TeamScoringService.ts` | `filterHighRarity()` | Rarity filter: Mythic (6★) + Legendary (5★ only) |
-| `src/Service/TeamScoringService.ts` | `scoreCurrentBest()`, `scoreBestPossible()` | Stat scoring for both modes |
+| `src/Service/TeamScoringService.ts` | `filterEligible(girls, playerClass)` | Hard filter: Mythic/Legendary 5★ AND class === playerClass |
+| `src/Service/TeamScoringService.ts` | `getMainCarac(girl, playerClass)` | Returns carac1/2/3 based on player class (1/2/3) |
+| `src/Service/TeamScoringService.ts` | `scoreCurrentBest()`, `scoreBestPossible()` | Stat scoring (main_carac) for both modes |
 | `src/Service/TeamScoringService.ts` | `calculateTier3TeamBonus()` | Tier 3 trait matching bonus |
-| `src/Service/TeamScoringService.ts` | `estimateTier3Delta()` | Marginal tier 3 bonus for per-slot comparison |
-| `src/Service/TeamScoringService.ts` | `findTraitGroups()` | Group girls by element pair + shared trait value |
-| `src/Service/TeamScoringService.ts` | `calculateSynergies()`, `calculateSynergyValue()` | Element synergy calculation |
+| `src/Service/TeamScoringService.ts` | `findTraitGroups(girls, class, blessed?)` | Group girls by element pair + shared trait value |
+| `src/Service/TeamScoringService.ts` | `calculateSynergies()`, `calculateSynergyValue()` | Element synergy calculation (informational only) |
 | `src/Service/TeamScoringService.ts` | `rankLeaderCandidates()` | Leader ranking: Mythic only, Tier-5 priority |
-| `src/Service/TeamBuilderService.ts` | `buildTeam()` | Main entry: filter, trait groups, leader, slot-fill |
+| `src/Service/TeamBuilderService.ts` | `buildTeam(girls, mode, level, playerClass)` | Main entry: filter, cluster compare, leader, slot-fill |
 | `src/Service/TeamBuilderService.ts` | `getElementDistribution()` | Element count summary for UI |
-| `src/Module/TeamModule.ts` | `setTopTeam()` | Dispatch: v3 if availableGirls present, else legacy |
-| `src/Module/TeamModule.ts` | `setTopTeamV2()` | Maps game data to GirlData[], calls TeamBuilderService |
+| `src/Service/TraitMappings.ts` | `resolve(category, value)` | Hex/position/zodiac to readable label, runtime + fallback |
+| `src/Module/TeamModule.ts` | `setTopTeam()` | Dispatch: v4 if availableGirls present, else legacy |
+| `src/Module/TeamModule.ts` | `setTopTeamV2()` | Resolves player class via HeroHelper.getClass(), maps data, calls TeamBuilderService |
 | `src/Module/TeamModule.ts` | `setTopTeamLegacy()` | Old tooltip-based algorithm (fallback) |
 | `src/Module/TeamModule.ts` | `updateTeamUI()` | Shared UI logic with synergy + trait info overlay |
 | `src/Module/TeamModule.ts` | `moduleChangeTeam()` | Button setup (Current Best, Possible Best, Unequip) |
@@ -317,8 +332,8 @@ Labyrinth-only blessings can be identified by `"in Love Labyrinth"` in the descr
 
 | File | Tests | Purpose |
 |------|-------|---------|
-| `spec/Service/TeamScoringService.spec.ts` | 58 | Synergies, Tier-5, scoring, filtering, Tier-3 traits |
-| `spec/Service/TeamBuilderService.spec.ts` | 22 | Team building, modes, leader selection |
+| `spec/Service/TeamScoringService.spec.ts` | 53 | Synergies, Tier-5, scoring, filtering (class+rarity), Tier-3 traits |
+| `spec/Service/TeamBuilderService.spec.ts` | 20 | Team building, class filter, modes, leader selection |
 
 ### Girl Data Loading
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.20",
+  "version": "7.35.21",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -1,5 +1,5 @@
 import { TeamBuilderService, TeamResult } from '../../src/Service/TeamBuilderService';
-import { GirlData, ElementType, RarityType } from '../../src/Service/TeamScoringService';
+import { GirlData, ElementType, RarityType, PlayerClass } from '../../src/Service/TeamScoringService';
 
 let nextId = 1;
 
@@ -8,10 +8,11 @@ function makeGirl(overrides: Partial<GirlData> = {}): GirlData {
     return {
         id_girl: id,
         name: `Girl_${id}`,
-        carac1: 3000 + Math.random() * 1000,
+        carac1: 1000 + Math.random() * 1000,
         carac2: 2000 + Math.random() * 1000,
-        carac3: 1000 + Math.random() * 1000,
+        carac3: 3000 + Math.random() * 1000,
         level: 100,
+        class: 3,
         element: 'fire' as ElementType,
         rarity: 'mythic' as RarityType,
         graded: 3,
@@ -25,12 +26,13 @@ function makeTraitPool(count: number, defaults: Partial<GirlData> = {}): GirlDat
     const elements: ElementType[] = ['fire', 'darkness'];
     return Array.from({ length: count }, (_, i) => makeGirl({
         id_girl: 1000 + i,
-        carac1: 5000 - i * 50,
-        carac2: 4000 - i * 40,
-        carac3: 3000 - i * 30,
+        carac1: 2000 - i * 20,
+        carac2: 3000 - i * 30,
+        carac3: 5000 - i * 50,
         element: elements[i % elements.length],
         eyeColor: 'blue',
         rarity: 'mythic',
+        class: 3,
         ...defaults,
     }));
 }
@@ -43,35 +45,34 @@ describe('TeamBuilderService', () => {
 
     describe('buildTeam', () => {
 
-        it('should return null when fewer than 7 M+L girls available', () => {
+        it('should return null when fewer than 7 M+L girls of player class', () => {
             const girls = [
                 ...makeTraitPool(5),
-                // Epic girls should not help reach the threshold
-                makeGirl({ id_girl: 900, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999 }),
-                makeGirl({ id_girl: 901, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999 }),
-                makeGirl({ id_girl: 902, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999 }),
+                makeGirl({ id_girl: 900, rarity: 'epic', carac3: 99999 }),
+                makeGirl({ id_girl: 901, rarity: 'epic', carac3: 99999 }),
+                makeGirl({ id_girl: 902, rarity: 'epic', carac3: 99999 }),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 1, 100);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3);
             expect(result).toBeNull();
         });
 
         it('should return a team of exactly 7 girls', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3);
             expect(result).not.toBeNull();
             expect(result!.girls).toHaveLength(7);
         });
 
         it('should not have duplicate girls in the team', () => {
             const girls = makeTraitPool(30);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             const ids = result.girls.map(g => g.id_girl);
             expect(new Set(ids).size).toBe(7);
         });
 
-        it('should place leader at index 0', () => {
+        it('should place leader at index 0 with a valid Tier 5 skill', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             const tier5 = result.leaderTier5;
             expect(tier5.id).toBeGreaterThan(0);
             expect(['Execute', 'Stun', 'Shield', 'Reflect']).toContain(tier5.name);
@@ -79,35 +80,49 @@ describe('TeamBuilderService', () => {
 
         it('should include elements array matching team composition', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             expect(result.elements).toHaveLength(7);
             expect(result.elements[0]).toBe(result.girls[0].element);
         });
 
         it('should include stat scores for each team member', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             expect(result.statScores).toHaveLength(7);
             result.statScores.forEach(score => {
                 expect(score).toBeGreaterThan(0);
             });
         });
 
-        it('should calculate a positive synergy value', () => {
+        it('should expose the player class on the result', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
-            expect(result.synergyValue).toBeGreaterThan(0);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+            expect(result.playerClass).toBe(3);
         });
     });
 
-    describe('Rarity filtering (both modes)', () => {
+    describe('Class filtering', () => {
+
+        it('should exclude girls of a different class', () => {
+            const girls = [
+                ...makeTraitPool(10),
+                // High-stat HC girl (class 1) -- must be filtered out for KH player (class 3)
+                makeGirl({ id_girl: 999, rarity: 'mythic', class: 1, carac1: 99999, carac2: 99999, carac3: 99999, eyeColor: 'blue' }),
+            ];
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+            const hasHC = result.girls.some(g => g.id_girl === 999);
+            expect(hasHC).toBe(false);
+        });
+    });
+
+    describe('Rarity filtering', () => {
 
         it('should filter out non-mythic/legendary girls in Mode 1', () => {
             const girls = [
                 ...makeTraitPool(10),
-                makeGirl({ id_girl: 999, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999, eyeColor: 'blue' }),
+                makeGirl({ id_girl: 999, rarity: 'epic', class: 3, carac3: 99999, eyeColor: 'blue' }),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             const hasEpic = result.girls.some(g => g.id_girl === 999);
             expect(hasEpic).toBe(false);
         });
@@ -115,9 +130,9 @@ describe('TeamBuilderService', () => {
         it('should filter out non-mythic/legendary girls in Mode 2', () => {
             const girls = [
                 ...makeTraitPool(10),
-                makeGirl({ id_girl: 999, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999, eyeColor: 'blue' }),
+                makeGirl({ id_girl: 999, rarity: 'epic', class: 3, carac3: 99999, eyeColor: 'blue' }),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 2, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 2, 100, 3)!;
             const hasEpic = result.girls.some(g => g.id_girl === 999);
             expect(hasEpic).toBe(false);
         });
@@ -126,76 +141,19 @@ describe('TeamBuilderService', () => {
             const girls = [
                 ...makeTraitPool(3),
                 ...Array.from({ length: 20 }, (_, i) => makeGirl({
-                    id_girl: 500 + i, rarity: 'epic',
+                    id_girl: 500 + i, rarity: 'epic', class: 3,
                 })),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 1, 100);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3);
             expect(result).toBeNull();
         });
     });
 
     describe('Trait-based team selection', () => {
 
-        it('should prefer girls from the best trait group when stats are similar', () => {
-            // 6 fire/darkness girls with blue eyes (strong trait group)
-            const traitGirls = makeTraitPool(6).map((g, i) => ({
-                ...g, id_girl: 100 + i, carac1: 4000, carac2: 3000, carac3: 2000,
-            }));
-
-            // 1 light mythic leader
-            const leader = makeGirl({
-                id_girl: 50, element: 'light', rarity: 'mythic',
-                carac1: 4500, carac2: 3500, carac3: 2500, hairColor: 'blonde',
-            });
-
-            // 1 stone girl with slightly higher stats but no trait match
-            const nonTraitGirl = makeGirl({
-                id_girl: 200, element: 'stone', rarity: 'mythic',
-                carac1: 4200, carac2: 3200, carac3: 2200, zodiac: 'Aries',
-            });
-
-            const result = TeamBuilderService.buildTeam(
-                [...traitGirls, leader, nonTraitGirl], 1, 100
-            )!;
-
-            // Most team members should be from the trait group
-            // (the one non-trait girl may take a slot due to cold-start, but trait dominates)
-            const traitMembers = result.girls.filter(g =>
-                (g.element === 'fire' || g.element === 'darkness') && g.eyeColor === 'blue'
-            );
-            expect(traitMembers.length).toBeGreaterThanOrEqual(5);
-        });
-
-        it('should prefer high-stat non-group girl over weak trait-group girl', () => {
-            // 6 fire/darkness girls with blue eyes but weak stats
-            const traitGirls = makeTraitPool(6).map((g, i) => ({
-                ...g, id_girl: 100 + i, carac1: 3000, carac2: 2000, carac3: 1000,
-            }));
-
-            // 1 light mythic leader
-            const leader = makeGirl({
-                id_girl: 50, element: 'light', rarity: 'mythic',
-                carac1: 4500, carac2: 3500, carac3: 2500, hairColor: 'blonde',
-            });
-
-            // 1 psychic girl with +40% blessed stats, no trait match
-            const blessedGirl = makeGirl({
-                id_girl: 300, element: 'psychic', rarity: 'mythic',
-                carac1: 5600, carac2: 4200, carac3: 4200, zodiac: 'Cancer',
-            });
-
-            const result = TeamBuilderService.buildTeam(
-                [...traitGirls, leader, blessedGirl], 1, 100
-            )!;
-
-            // The blessed girl should be in the team despite not matching the trait
-            const hasBlessedGirl = result.girls.some(g => g.id_girl === 300);
-            expect(hasBlessedGirl).toBe(true);
-        });
-
         it('should include trait info in TeamResult', () => {
             const girls = makeTraitPool(20);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
 
             expect(result.traitCategory).toBeDefined();
             expect(result.traitValue).toBeDefined();
@@ -204,102 +162,90 @@ describe('TeamBuilderService', () => {
         });
 
         it('should report correct traitMatchCount', () => {
-            const girls = makeTraitPool(10); // all fire/darkness with blue eyes
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+            const girls = makeTraitPool(10);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
 
-            // All fire/darkness girls in the team have blue eyes
             const fireOrDarknessInTeam = result.girls.filter(g =>
                 g.element === 'fire' || g.element === 'darkness'
             ).length;
             expect(result.traitMatchCount).toBe(fireOrDarknessInTeam);
         });
+
+        it('should expose effective power = main_sum * (1 + tier3Bonus)', () => {
+            const girls = makeTraitPool(10);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+            const sum = result.statScores.reduce((s, n) => s + n, 0);
+            expect(result.effectivePower).toBe(Math.round(sum * (1 + result.tier3Bonus)));
+        });
     });
 
     describe('Leader selection', () => {
 
-        it('should prefer Shield (light/stone) leader when available', () => {
-            const girls = [
-                makeGirl({ id_girl: 1, element: 'light', rarity: 'mythic', carac1: 4000, carac2: 3000, carac3: 2000, hairColor: 'blonde' }),
-                ...makeTraitPool(10).map((g, i) => ({ ...g, id_girl: 100 + i })),
-            ];
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
+        it('should prefer Shield (light/stone) leader when the chosen cluster matches', () => {
+            // 7 light/nature girls with same hair color (strong hairColor cluster),
+            // plus 3 fire/darkness fillers so the hair group dominates by main_sum.
+            const hairCluster = Array.from({ length: 7 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'light' : 'nature',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                hairColor: 'blonde',
+            }));
+            const eyeFillers = Array.from({ length: 3 }, (_, i) => makeGirl({
+                id_girl: 200 + i,
+                element: 'fire',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 4000,
+                eyeColor: 'blue',
+            }));
+            const result = TeamBuilderService.buildTeam([...hairCluster, ...eyeFillers], 1, 100, 3)!;
+            expect(result.traitCategory).toBe('hairColor');
+            // Leader from light (Shield priority 4) beats nature (Reflect priority 1)
             expect(result.girls[0].element).toBe('light');
             expect(result.leaderTier5.name).toBe('Shield');
         });
 
         it('should use Mythic girls as leader even if legendary has higher stats', () => {
             const girls = [
-                makeGirl({ id_girl: 1, element: 'light', rarity: 'legendary', carac1: 9000, carac2: 8000, carac3: 7000, hairColor: 'blonde' }),
-                makeGirl({ id_girl: 2, element: 'stone', rarity: 'mythic', carac1: 3000, carac2: 2000, carac3: 1000, zodiac: 'Aries' }),
+                makeGirl({ id_girl: 1, element: 'light', rarity: 'legendary', class: 3, carac3: 9000, hairColor: 'blonde' }),
+                makeGirl({ id_girl: 2, element: 'stone', rarity: 'mythic', class: 3, carac3: 1000, zodiac: 'Aries' }),
                 ...makeTraitPool(10).map((g, i) => ({ ...g, id_girl: 100 + i })),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
-            // Leader should be the mythic stone girl, not the legendary light
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             expect(result.girls[0].rarity).toBe('mythic');
         });
 
         it('should fall back when no light/stone mythic exists', () => {
-            // All girls are fire/darkness (Execute)
             const girls = makeTraitPool(10);
-            const result = TeamBuilderService.buildTeam(girls, 1, 100)!;
-            // Should still pick a leader (fire or darkness)
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             expect(result.girls[0]).toBeDefined();
             expect(['fire', 'darkness']).toContain(result.girls[0].element);
-        });
-    });
-
-    describe('Position trait deprioritization', () => {
-
-        it('should prefer non-position traits over position traits', () => {
-            // 5 water/sun girls with same position (position group)
-            const posGirls = Array.from({ length: 5 }, (_, i) => makeGirl({
-                id_girl: 100 + i,
-                element: i % 2 === 0 ? 'water' : 'sun',
-                position: '3',
-                carac1: 5000, carac2: 4000, carac3: 3000,
-                rarity: 'mythic',
-            }));
-
-            // 5 fire/darkness girls with same eyes (eye color group)
-            const eyeGirls = Array.from({ length: 5 }, (_, i) => makeGirl({
-                id_girl: 200 + i,
-                element: i % 2 === 0 ? 'fire' : 'darkness',
-                eyeColor: 'blue',
-                carac1: 5000, carac2: 4000, carac3: 3000,
-                rarity: 'mythic',
-            }));
-
-            const result = TeamBuilderService.buildTeam([...posGirls, ...eyeGirls], 1, 100)!;
-
-            // Eye color group should be preferred over position (same stats, position has penalty)
-            expect(result.traitCategory).toBe('eyeColor');
         });
     });
 
     describe('Mode 2: Best Possible', () => {
 
         it('should use projected stats for scoring', () => {
-            // Low-level mythic with high potential
             const lowLevel = makeGirl({
-                id_girl: 1, rarity: 'mythic', level: 10,
-                carac1: 500, carac2: 400, carac3: 300, nb_grades: 6, graded: 0,
+                id_girl: 1, rarity: 'mythic', class: 3, level: 10,
+                carac1: 200, carac2: 300, carac3: 500, nb_grades: 6, graded: 0,
                 element: 'fire', eyeColor: 'blue',
             });
-            // High-level mythic already near max
             const highLevel = makeGirl({
-                id_girl: 2, rarity: 'mythic', level: 100,
-                carac1: 3000, carac2: 2000, carac3: 1000, nb_grades: 5, graded: 5,
+                id_girl: 2, rarity: 'mythic', class: 3, level: 100,
+                carac1: 1000, carac2: 2000, carac3: 3000, nb_grades: 5, graded: 5,
                 element: 'fire', eyeColor: 'blue',
             });
             const fillers = makeTraitPool(10).map((g, i) => ({
-                ...g, id_girl: 100 + i, carac1: 2000, carac2: 1500, carac3: 1000,
+                ...g, id_girl: 100 + i, carac1: 1000, carac2: 1500, carac3: 2000,
             }));
 
             const result = TeamBuilderService.buildTeam(
-                [lowLevel, highLevel, ...fillers], 2, 100
+                [lowLevel, highLevel, ...fillers], 2, 100, 3
             )!;
 
-            // Low-level mythic should be in the team due to high projected stats
             const hasLowLevel = result.girls.some(g => g.id_girl === 1);
             expect(hasLowLevel).toBe(true);
         });
@@ -307,9 +253,9 @@ describe('TeamBuilderService', () => {
         it('should only include M+L girls (not all rarities)', () => {
             const girls = [
                 ...makeTraitPool(8),
-                makeGirl({ id_girl: 999, rarity: 'epic', carac1: 99999, carac2: 99999, carac3: 99999, eyeColor: 'blue' }),
+                makeGirl({ id_girl: 999, rarity: 'epic', class: 3, carac3: 99999, eyeColor: 'blue' }),
             ];
-            const result = TeamBuilderService.buildTeam(girls, 2, 100)!;
+            const result = TeamBuilderService.buildTeam(girls, 2, 100, 3)!;
             const hasEpic = result.girls.some(g => g.rarity === 'epic');
             expect(hasEpic).toBe(false);
         });
@@ -317,21 +263,27 @@ describe('TeamBuilderService', () => {
 
     describe('getElementDistribution', () => {
 
+        const baseResult: TeamResult = {
+            girls: [],
+            statScores: [],
+            synergyValue: 0,
+            leaderTier5: { id: 12, name: 'Shield', priority: 4 },
+            elements: [],
+            traitCategory: 'eyeColor',
+            traitValue: 'blue',
+            tier3Bonus: 0,
+            traitMatchCount: 0,
+            blessedCategories: [],
+            blessedGirlCount: 0,
+            effectivePower: 0,
+            alternatives: [],
+            playerClass: 3,
+        };
+
         it('should count elements correctly', () => {
             const team: TeamResult = {
-                girls: [],
-                statScores: [],
-                synergyValue: 0,
-                leaderTier5: { id: 12, name: 'Shield', priority: 4 },
+                ...baseResult,
                 elements: ['fire', 'fire', 'fire', 'darkness', 'darkness', 'light', 'stone'],
-                traitCategory: 'eyeColor',
-                traitValue: 'blue',
-                tier3Bonus: 0.04,
-                traitMatchCount: 5,
-                blessedCategories: [],
-                blessedGirlCount: 0,
-                effectivePower: 0,
-                alternatives: [],
             };
             const dist = TeamBuilderService.getElementDistribution(team);
             expect(dist[0]).toEqual({ element: 'fire', count: 3 });
@@ -342,19 +294,8 @@ describe('TeamBuilderService', () => {
 
         it('should sort by count descending', () => {
             const team: TeamResult = {
-                girls: [],
-                statScores: [],
-                synergyValue: 0,
-                leaderTier5: { id: 12, name: 'Shield', priority: 4 },
+                ...baseResult,
                 elements: ['fire', 'darkness', 'fire', 'darkness', 'fire', 'light', 'darkness'],
-                traitCategory: 'eyeColor',
-                traitValue: 'blue',
-                tier3Bonus: 0.05,
-                traitMatchCount: 6,
-                blessedCategories: [],
-                blessedGirlCount: 0,
-                effectivePower: 0,
-                alternatives: [],
             };
             const dist = TeamBuilderService.getElementDistribution(team);
             expect(dist[0].count).toBe(3);

--- a/spec/Service/TeamScoringService.spec.ts
+++ b/spec/Service/TeamScoringService.spec.ts
@@ -3,7 +3,7 @@ import {
     ElementType,
     GirlData,
     RarityType,
-    TraitCategory,
+    PlayerClass,
 } from '../../src/Service/TeamScoringService';
 
 function makeGirl(overrides: Partial<GirlData> = {}): GirlData {
@@ -14,6 +14,7 @@ function makeGirl(overrides: Partial<GirlData> = {}): GirlData {
         carac2: 2000,
         carac3: 3000,
         level: 100,
+        class: 1,
         element: 'fire',
         rarity: 'mythic',
         graded: 0,
@@ -24,10 +25,20 @@ function makeGirl(overrides: Partial<GirlData> = {}): GirlData {
 
 describe('TeamScoringService', () => {
 
-    describe('getStatSum', () => {
-        it('should sum carac1 + carac2 + carac3 from direct fields', () => {
+    describe('getMainCarac', () => {
+        it('should return carac1 for class 1 (Hardcore)', () => {
             const girl = makeGirl({ carac1: 100, carac2: 200, carac3: 300 });
-            expect(TeamScoringService.getStatSum(girl)).toBe(600);
+            expect(TeamScoringService.getMainCarac(girl, 1)).toBe(100);
+        });
+
+        it('should return carac2 for class 2 (Charm)', () => {
+            const girl = makeGirl({ carac1: 100, carac2: 200, carac3: 300 });
+            expect(TeamScoringService.getMainCarac(girl, 2)).toBe(200);
+        });
+
+        it('should return carac3 for class 3 (Know-how)', () => {
+            const girl = makeGirl({ carac1: 100, carac2: 200, carac3: 300 });
+            expect(TeamScoringService.getMainCarac(girl, 3)).toBe(300);
         });
 
         it('should prefer caracs sub-object when available', () => {
@@ -35,80 +46,120 @@ describe('TeamScoringService', () => {
                 carac1: 100, carac2: 200, carac3: 300,
                 caracs: { carac1: 500, carac2: 600, carac3: 700 },
             });
-            expect(TeamScoringService.getStatSum(girl)).toBe(1800);
+            expect(TeamScoringService.getMainCarac(girl, 1)).toBe(500);
+            expect(TeamScoringService.getMainCarac(girl, 2)).toBe(600);
+            expect(TeamScoringService.getMainCarac(girl, 3)).toBe(700);
         });
     });
 
     describe('scoreCurrentBest', () => {
-        it('should return the raw stat sum', () => {
-            const girl = makeGirl({ carac1: 5000, carac2: 3000, carac3: 2000 });
-            expect(TeamScoringService.scoreCurrentBest(girl)).toBe(10000);
+        it('should return the main-class carac for player class 3', () => {
+            const girl = makeGirl({ carac1: 5000, carac2: 3000, carac3: 7000 });
+            expect(TeamScoringService.scoreCurrentBest(girl, 3)).toBe(7000);
         });
     });
 
     describe('scoreBestPossible', () => {
-        it('should project stats for a fully graded girl at player level', () => {
+        it('should project main-carac for a fully graded girl at player level', () => {
+            // KH player (class 3), girl with carac3=3000 at level 50, 0/5 grades
+            // projected = 3000 / 50 * 100 / (1 + 0) * (1 + 1.5) = 3000 * 2 * 2.5 = 15000
             const girl = makeGirl({
                 carac1: 1000, carac2: 2000, carac3: 3000,
                 level: 50, graded: 0, nb_grades: 5,
             });
-            expect(TeamScoringService.scoreBestPossible(girl, 100)).toBe(30000);
+            expect(TeamScoringService.scoreBestPossible(girl, 3, 100)).toBe(15000);
         });
 
         it('should account for existing grades reducing projected growth', () => {
+            // class 3, girl carac3=3000, level 50, 3/5 grades, player level 100
+            // projected = 3000 * 2 / 1.9 * 2.5
             const girl = makeGirl({
                 carac1: 1000, carac2: 2000, carac3: 3000,
                 level: 50, graded: 3, nb_grades: 5,
             });
-            const expected = 6000 * 2 / 1.9 * 2.5;
-            expect(TeamScoringService.scoreBestPossible(girl, 100)).toBeCloseTo(expected, 2);
+            const expected = 3000 * 2 / 1.9 * 2.5;
+            expect(TeamScoringService.scoreBestPossible(girl, 3, 100)).toBeCloseTo(expected, 2);
+        });
+
+        it('should never return less than current main-carac (blessing safeguard)', () => {
+            // High blessing makes current > projected when player already at max
+            const girl = makeGirl({
+                carac1: 0, carac2: 0, carac3: 12397,
+                level: 200, graded: 5, nb_grades: 5,
+            });
+            const result = TeamScoringService.scoreBestPossible(girl, 3, 100);
+            expect(result).toBe(12397);
         });
 
         it('should handle level 1 girls without division by zero', () => {
             const girl = makeGirl({ level: 1, carac1: 10, carac2: 20, carac3: 30 });
-            const result = TeamScoringService.scoreBestPossible(girl, 100);
+            const result = TeamScoringService.scoreBestPossible(girl, 3, 100);
             expect(result).toBeGreaterThan(0);
             expect(isFinite(result)).toBe(true);
         });
 
         it('should handle level 0 gracefully', () => {
             const girl = makeGirl({ level: 0, carac1: 10, carac2: 20, carac3: 30 });
-            const result = TeamScoringService.scoreBestPossible(girl, 100);
+            const result = TeamScoringService.scoreBestPossible(girl, 3, 100);
             expect(isFinite(result)).toBe(true);
         });
     });
 
-    describe('filterHighRarity', () => {
-        it('should keep mythic and 5-star legendary girls', () => {
+    describe('filterEligible', () => {
+        it('should keep mythic and 5-star legendary girls of the player class', () => {
             const girls = [
-                makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6 }),
-                makeGirl({ id_girl: 2, rarity: 'legendary', nb_grades: 5 }),
-                makeGirl({ id_girl: 3, rarity: 'epic' }),
-                makeGirl({ id_girl: 4, rarity: 'rare' }),
-                makeGirl({ id_girl: 5, rarity: 'common' }),
+                makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6, class: 3 }),
+                makeGirl({ id_girl: 2, rarity: 'legendary', nb_grades: 5, class: 3 }),
+                makeGirl({ id_girl: 3, rarity: 'epic', class: 3 }),
+                makeGirl({ id_girl: 4, rarity: 'rare', class: 3 }),
+                makeGirl({ id_girl: 5, rarity: 'common', class: 3 }),
             ];
-            const filtered = TeamScoringService.filterHighRarity(girls);
+            const filtered = TeamScoringService.filterEligible(girls, 3);
             expect(filtered).toHaveLength(2);
             expect(filtered.map(g => g.id_girl)).toEqual([1, 2]);
         });
 
+        it('should filter out girls of a different class', () => {
+            const girls = [
+                makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6, class: 1 }),
+                makeGirl({ id_girl: 2, rarity: 'mythic', nb_grades: 6, class: 2 }),
+                makeGirl({ id_girl: 3, rarity: 'mythic', nb_grades: 6, class: 3 }),
+            ];
+            const filtered = TeamScoringService.filterEligible(girls, 3);
+            expect(filtered).toHaveLength(1);
+            expect(filtered[0].id_girl).toBe(3);
+        });
+
+        it('should keep girls with no class field (treat as eligible)', () => {
+            const girls = [
+                makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6, class: undefined }),
+                makeGirl({ id_girl: 2, rarity: 'mythic', nb_grades: 6, class: 3 }),
+            ];
+            const filtered = TeamScoringService.filterEligible(girls, 3);
+            expect(filtered).toHaveLength(2);
+        });
+
         it('should exclude 3-star legendary girls', () => {
             const girls = [
-                makeGirl({ id_girl: 1, rarity: 'legendary', nb_grades: 3 }),
-                makeGirl({ id_girl: 2, rarity: 'legendary', nb_grades: 5 }),
-                makeGirl({ id_girl: 3, rarity: 'mythic', nb_grades: 6 }),
+                makeGirl({ id_girl: 1, rarity: 'legendary', nb_grades: 3, class: 3 }),
+                makeGirl({ id_girl: 2, rarity: 'legendary', nb_grades: 5, class: 3 }),
+                makeGirl({ id_girl: 3, rarity: 'mythic', nb_grades: 6, class: 3 }),
             ];
-            const filtered = TeamScoringService.filterHighRarity(girls);
+            const filtered = TeamScoringService.filterEligible(girls, 3);
             expect(filtered).toHaveLength(2);
             expect(filtered.map(g => g.id_girl)).toEqual([2, 3]);
         });
+    });
 
-        it('should return empty array when no high-rarity girls exist', () => {
+    describe('filterHighRarity (legacy)', () => {
+        it('should still filter by rarity only (back-compat shim)', () => {
             const girls = [
-                makeGirl({ rarity: 'epic' }),
-                makeGirl({ rarity: 'rare' }),
+                makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6, class: 1 }),
+                makeGirl({ id_girl: 2, rarity: 'legendary', nb_grades: 5, class: 2 }),
+                makeGirl({ id_girl: 3, rarity: 'epic', class: 3 }),
             ];
-            expect(TeamScoringService.filterHighRarity(girls)).toHaveLength(0);
+            const filtered = TeamScoringService.filterHighRarity(girls);
+            expect(filtered).toHaveLength(2);
         });
     });
 
@@ -133,8 +184,6 @@ describe('TeamScoringService', () => {
             expect(TeamScoringService.getTier5Skill('nature')).toEqual({ id: 13, name: 'Reflect', priority: 1 });
         });
     });
-
-    // ─── Trait / Tier 3 Tests ────────────────────────────────────────
 
     describe('getTraitCategory', () => {
         it('should map fire and darkness to eyeColor', () => {
@@ -180,7 +229,7 @@ describe('TeamScoringService', () => {
         });
 
         it('should return undefined when trait data is missing', () => {
-            const girl = makeGirl({ element: 'fire' }); // no eyeColor set
+            const girl = makeGirl({ element: 'fire' });
             expect(TeamScoringService.getTraitValue(girl)).toBeUndefined();
         });
     });
@@ -200,8 +249,6 @@ describe('TeamScoringService', () => {
         });
 
         it('should calculate bonus for matching fire/darkness girls (eye color)', () => {
-            // 3 mythic fire girls with same eye color
-            // Each matches 2 others → 3 × 2 × 0.01 = 0.06
             const team = [
                 makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'mythic' }),
                 makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue', rarity: 'mythic' }),
@@ -211,8 +258,6 @@ describe('TeamScoringService', () => {
         });
 
         it('should use lower bonus for legendary girls', () => {
-            // 2 legendary fire girls with same eye color
-            // Each matches 1 other → 2 × 1 × 0.008 = 0.016
             const team = [
                 makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'legendary' }),
                 makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue', rarity: 'legendary' }),
@@ -221,8 +266,6 @@ describe('TeamScoringService', () => {
         });
 
         it('should handle mixed mythic and legendary bonuses', () => {
-            // 1 mythic + 1 legendary with same eye color
-            // Mythic matches 1 → 0.01, Legendary matches 1 → 0.008
             const team = [
                 makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'mythic' }),
                 makeGirl({ id_girl: 2, element: 'darkness', eyeColor: 'blue', rarity: 'legendary' }),
@@ -231,8 +274,6 @@ describe('TeamScoringService', () => {
         });
 
         it('should calculate max bonus for full team of 7 matching mythics', () => {
-            // 7 mythic girls, all fire/darkness, all same eye color
-            // Each matches 6 others → 7 × 6 × 0.01 = 0.42
             const team = Array.from({ length: 7 }, (_, i) =>
                 makeGirl({
                     id_girl: i + 1,
@@ -245,7 +286,6 @@ describe('TeamScoringService', () => {
         });
 
         it('should not count cross-category matches', () => {
-            // fire (eyeColor) and light (hairColor) — different categories, no match
             const team = [
                 makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue' }),
                 makeGirl({ id_girl: 2, element: 'light', hairColor: 'blue' }),
@@ -256,135 +296,66 @@ describe('TeamScoringService', () => {
 
     describe('findTraitGroups', () => {
         it('should return empty array for no girls', () => {
-            expect(TeamScoringService.findTraitGroups([])).toHaveLength(0);
+            expect(TeamScoringService.findTraitGroups([], 1)).toHaveLength(0);
         });
 
-        it('should group fire/darkness girls by eye color', () => {
+        it('should group fire/darkness girls by eye color (HC player)', () => {
             const girls = [
                 makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
                 makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue', carac1: 4000, carac2: 3000, carac3: 2000 }),
                 makeGirl({ id_girl: 3, element: 'darkness', eyeColor: 'blue', carac1: 4500, carac2: 3000, carac3: 2000 }),
                 makeGirl({ id_girl: 4, element: 'fire', eyeColor: 'green', carac1: 6000, carac2: 3000, carac3: 2000 }),
             ];
-            const groups = TeamScoringService.findTraitGroups(girls);
+            const groups = TeamScoringService.findTraitGroups(girls, 1);
             const blueGroup = groups.find(g => g.traitValue === 'blue');
             expect(blueGroup).toBeDefined();
             expect(blueGroup!.girls).toHaveLength(3);
             expect(blueGroup!.traitCategory).toBe('eyeColor');
         });
 
-        it('should sort groups by score descending', () => {
+        it('should sort groups by score descending using main-carac', () => {
+            // KH player (class 3), score = average carac3
             const girls = [
-                // 3 fire girls with blue eyes (strong group)
-                makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 3, element: 'darkness', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                // 2 light girls with blonde hair (weaker group)
+                // 3 fire girls with blue eyes, carac3=3000 each
+                makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 3000 }),
+                makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 3000 }),
+                makeGirl({ id_girl: 3, element: 'darkness', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 3000 }),
+                // 2 light girls, carac3=2000 each
                 makeGirl({ id_girl: 4, element: 'light', hairColor: 'blonde', carac1: 5000, carac2: 3000, carac3: 2000 }),
                 makeGirl({ id_girl: 5, element: 'nature', hairColor: 'blonde', carac1: 5000, carac2: 3000, carac3: 2000 }),
             ];
-            const groups = TeamScoringService.findTraitGroups(girls);
+            const groups = TeamScoringService.findTraitGroups(girls, 3);
             expect(groups[0].traitCategory).toBe('eyeColor');
             expect(groups[0].girls).toHaveLength(3);
         });
 
-        it('should apply position penalty', () => {
+        it('should boost blessed-category groups by the heuristic factor', () => {
             const girls = [
-                // 3 water girls with same position
-                makeGirl({ id_girl: 1, element: 'water', position: '3', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 2, element: 'water', position: '3', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 3, element: 'sun', position: '3', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                // 3 fire girls with same eyes (should win due to no penalty)
-                makeGirl({ id_girl: 4, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 5, element: 'fire', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
-                makeGirl({ id_girl: 6, element: 'darkness', eyeColor: 'blue', carac1: 5000, carac2: 3000, carac3: 2000 }),
+                makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', carac3: 1000 }),
+                makeGirl({ id_girl: 2, element: 'darkness', eyeColor: 'blue', carac3: 1000 }),
+                makeGirl({ id_girl: 3, element: 'light', hairColor: 'blonde', carac3: 2000 }),
+                makeGirl({ id_girl: 4, element: 'nature', hairColor: 'blonde', carac3: 2000 }),
             ];
-            const groups = TeamScoringService.findTraitGroups(girls);
-            // Eye color group should rank higher than position group (same stats, but position has penalty)
-            expect(groups[0].traitCategory).toBe('eyeColor');
+            // Without boost: hairColor wins (avg 2000 * 2 = 4000) over eyeColor (avg 1000 * 2 = 2000)
+            const noBoost = TeamScoringService.findTraitGroups(girls, 3);
+            expect(noBoost[0].traitCategory).toBe('hairColor');
+
+            // With eye blessed: eye gets x1.5 -> 3000, still less than hair 4000
+            const eyeBlessed = TeamScoringService.findTraitGroups(girls, 3, new Set(['eyeColor']));
+            expect(eyeBlessed[0].traitCategory).toBe('hairColor');
         });
 
         it('should skip girls without trait data', () => {
             const girls = [
-                makeGirl({ id_girl: 1, element: 'fire' }), // no eyeColor
+                makeGirl({ id_girl: 1, element: 'fire' }),
                 makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue' }),
             ];
-            const groups = TeamScoringService.findTraitGroups(girls);
+            const groups = TeamScoringService.findTraitGroups(girls, 1);
             const blueGroup = groups.find(g => g.traitValue === 'blue');
             expect(blueGroup).toBeDefined();
             expect(blueGroup!.girls).toHaveLength(1);
         });
     });
-
-    // ─── Tier 3 Delta Estimation Tests ─────────────────────────────
-
-    describe('estimateTier3Delta', () => {
-        it('should return 0 when candidate does not match trait category', () => {
-            const candidate = makeGirl({ element: 'light', hairColor: 'blonde' }); // hairColor category
-            const team = [makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue' })];
-            const delta = TeamScoringService.estimateTier3Delta(
-                candidate, team, 'eyeColor', 'blue', 10000
-            );
-            expect(delta).toBe(0);
-        });
-
-        it('should return 0 when candidate has wrong trait value', () => {
-            const candidate = makeGirl({ element: 'fire', eyeColor: 'green' });
-            const team = [makeGirl({ id_girl: 2, element: 'fire', eyeColor: 'blue' })];
-            const delta = TeamScoringService.estimateTier3Delta(
-                candidate, team, 'eyeColor', 'blue', 10000
-            );
-            expect(delta).toBe(0);
-        });
-
-        it('should return 0 when no existing trait teammates', () => {
-            const candidate = makeGirl({ element: 'fire', eyeColor: 'blue', rarity: 'mythic' });
-            const team = [makeGirl({ id_girl: 2, element: 'light', hairColor: 'blonde' })];
-            const delta = TeamScoringService.estimateTier3Delta(
-                candidate, team, 'eyeColor', 'blue', 10000
-            );
-            expect(delta).toBe(0);
-        });
-
-        it('should calculate correct delta with one existing mythic trait teammate', () => {
-            const candidate = makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'mythic' });
-            const team = [makeGirl({ id_girl: 2, element: 'darkness', eyeColor: 'blue', rarity: 'mythic' })];
-            // newGirlBonus = 1 * 0.01 = 0.01
-            // existingBoost = 0.01 (one mythic teammate)
-            // marginalPct = 0.02
-            // delta = 0.02 * 10000 = 200
-            const delta = TeamScoringService.estimateTier3Delta(
-                candidate, team, 'eyeColor', 'blue', 10000
-            );
-            expect(delta).toBeCloseTo(200, 2);
-        });
-
-        it('should handle mixed mythic/legendary existing teammates', () => {
-            const candidate = makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'mythic' });
-            const team = [
-                makeGirl({ id_girl: 2, element: 'darkness', eyeColor: 'blue', rarity: 'mythic' }),
-                makeGirl({ id_girl: 3, element: 'fire', eyeColor: 'blue', rarity: 'legendary' }),
-            ];
-            // newGirlBonus = 2 * 0.01 = 0.02
-            // existingBoost = 0.01 + 0.008 = 0.018
-            // marginalPct = 0.038
-            // delta = 0.038 * 60000 = 2280
-            const delta = TeamScoringService.estimateTier3Delta(
-                candidate, team, 'eyeColor', 'blue', 60000
-            );
-            expect(delta).toBeCloseTo(2280, 2);
-        });
-
-        it('should scale with teamStatTotal', () => {
-            const candidate = makeGirl({ id_girl: 1, element: 'fire', eyeColor: 'blue', rarity: 'mythic' });
-            const team = [makeGirl({ id_girl: 2, element: 'darkness', eyeColor: 'blue', rarity: 'mythic' })];
-            const delta1 = TeamScoringService.estimateTier3Delta(candidate, team, 'eyeColor', 'blue', 10000);
-            const delta2 = TeamScoringService.estimateTier3Delta(candidate, team, 'eyeColor', 'blue', 50000);
-            expect(delta2).toBe(delta1 * 5);
-        });
-    });
-
-    // ─── Synergy Tests ───────────────────────────────────────────────
 
     describe('calculateSynergies', () => {
         it('should return zero bonuses for empty team', () => {
@@ -402,16 +373,6 @@ describe('TeamScoringService', () => {
         it('should add 10% critDamage per fire girl', () => {
             const syn = TeamScoringService.calculateSynergies(['fire', 'fire', 'fire']);
             expect(syn.critDamage).toBeCloseTo(0.30, 5);
-        });
-
-        it('should add 3% healOnHit per water girl', () => {
-            const syn = TeamScoringService.calculateSynergies(['water', 'water']);
-            expect(syn.healOnHit).toBeCloseTo(0.06, 5);
-        });
-
-        it('should add 2% critChance per stone girl', () => {
-            const syn = TeamScoringService.calculateSynergies(['stone']);
-            expect(syn.critChance).toBeCloseTo(0.02, 5);
         });
 
         it('should accumulate bonuses from mixed elements', () => {
@@ -444,42 +405,13 @@ describe('TeamScoringService', () => {
         });
     });
 
-    describe('scoreWithSynergy', () => {
-        it('should add synergy bonus on top of raw stat score', () => {
-            const girl = makeGirl({ element: 'fire', carac1: 5000, carac2: 3000, carac3: 2000 });
-            const statScore = 10000;
-            const maxStat = 10000;
-
-            const withoutSynergy = statScore;
-            const withSynergy = TeamScoringService.scoreWithSynergy(girl, [], statScore, maxStat);
-            expect(withSynergy).toBeGreaterThan(withoutSynergy);
-        });
-
-        it('should return raw stat score when synergy weight is 0', () => {
-            const girl = makeGirl({ element: 'fire' });
-            const score = TeamScoringService.scoreWithSynergy(girl, [], 10000, 10000, 0);
-            expect(score).toBe(10000);
-        });
-
-        it('should give consistent returns for duplicate elements', () => {
-            const girl = makeGirl({ element: 'fire' });
-            const firstFire = TeamScoringService.scoreWithSynergy(girl, [], 10000, 10000);
-            const sixthFire = TeamScoringService.scoreWithSynergy(
-                girl, ['fire', 'fire', 'fire', 'fire', 'fire'], 10000, 10000
-            );
-            expect(firstFire).toBeCloseTo(sixthFire, 5);
-        });
-    });
-
-    // ─── Leader Selection Tests ──────────────────────────────────────
-
     describe('rankLeaderCandidates', () => {
         it('should rank Shield elements (light/stone) first', () => {
             const girls = [
-                makeGirl({ id_girl: 1, element: 'nature', rarity: 'mythic' }),   // Reflect (1)
-                makeGirl({ id_girl: 2, element: 'fire', rarity: 'mythic' }),     // Execute (2)
-                makeGirl({ id_girl: 3, element: 'sun', rarity: 'mythic' }),      // Stun (3)
-                makeGirl({ id_girl: 4, element: 'light', rarity: 'mythic' }),    // Shield (4)
+                makeGirl({ id_girl: 1, element: 'nature', rarity: 'mythic' }),
+                makeGirl({ id_girl: 2, element: 'fire', rarity: 'mythic' }),
+                makeGirl({ id_girl: 3, element: 'sun', rarity: 'mythic' }),
+                makeGirl({ id_girl: 4, element: 'light', rarity: 'mythic' }),
             ];
             const scores = new Map([[1, 1000], [2, 1000], [3, 1000], [4, 1000]]);
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores);
@@ -491,13 +423,12 @@ describe('TeamScoringService', () => {
 
         it('should prefer higher priority even with lower stats', () => {
             const girls = [
-                makeGirl({ id_girl: 1, element: 'fire', rarity: 'mythic' }),     // Execute (2)
-                makeGirl({ id_girl: 2, element: 'light', rarity: 'mythic' }),    // Shield (4)
+                makeGirl({ id_girl: 1, element: 'fire', rarity: 'mythic' }),
+                makeGirl({ id_girl: 2, element: 'light', rarity: 'mythic' }),
             ];
-            // Fire has much higher stats but Shield priority is higher
             const scores = new Map([[1, 50000], [2, 10000]]);
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores);
-            expect(ranked[0].id_girl).toBe(2);  // Light with Shield wins
+            expect(ranked[0].id_girl).toBe(2);
         });
 
         it('should prefer trait-matching leader as tiebreaker within same priority', () => {
@@ -506,9 +437,8 @@ describe('TeamScoringService', () => {
                 makeGirl({ id_girl: 2, element: 'stone', rarity: 'mythic', zodiac: 'Aries' }),
             ];
             const scores = new Map([[1, 10000], [2, 10000]]);
-            // Team trait is hairColor:blonde → light girl matches
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores, 'hairColor', 'blonde');
-            expect(ranked[0].id_girl).toBe(1);  // light girl matches team trait
+            expect(ranked[0].id_girl).toBe(1);
         });
 
         it('should only consider mythic girls for leader', () => {
@@ -518,7 +448,6 @@ describe('TeamScoringService', () => {
             ];
             const scores = new Map([[1, 50000], [2, 10000]]);
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores);
-            // Only mythic girl should be returned
             expect(ranked).toHaveLength(1);
             expect(ranked[0].id_girl).toBe(2);
         });
@@ -531,7 +460,7 @@ describe('TeamScoringService', () => {
             const scores = new Map([[1, 10000], [2, 10000]]);
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores);
             expect(ranked).toHaveLength(2);
-            expect(ranked[0].element).toBe('light'); // Shield priority
+            expect(ranked[0].element).toBe('light');
         });
 
         it('should break ties by stat score within same priority and trait match', () => {
@@ -541,7 +470,7 @@ describe('TeamScoringService', () => {
             ];
             const scores = new Map([[1, 5000], [2, 9000]]);
             const ranked = TeamScoringService.rankLeaderCandidates(girls, scores);
-            expect(ranked[0].id_girl).toBe(2);  // StrongStone first (higher stats, same priority)
+            expect(ranked[0].id_girl).toBe(2);
         });
     });
 });

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -23,7 +23,8 @@ import {
 import { addNutakuSession, gotoPage } from '../Service/PageNavigationService';
 import { TeamBuilderService, ScoringMode, TeamResult } from '../Service/TeamBuilderService';
 import { BlessingService } from '../Service/BlessingService';
-import { GirlData, ElementType } from '../Service/TeamScoringService';
+import { GirlData, ElementType, PlayerClass } from '../Service/TeamScoringService';
+import { TraitMappings } from '../Service/TraitMappings';
 import { fillHHPopUp, getHHAjax, logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, TK } from '../config/index';
 import { KKTeamGirl, TeamData } from '../model/index';
@@ -467,6 +468,8 @@ export class TeamModule {
 
     private static setTopTeamV2(mode: ScoringMode, availableGirls: any[]) {
         const playerLevel = Number(HeroHelper.getLevel());
+        const rawClass = Number(HeroHelper.getClass());
+        const playerClass: PlayerClass = (rawClass === 1 || rawClass === 2 || rawClass === 3) ? rawClass as PlayerClass : 1;
 
         // Map availableGirls to GirlData interface
         const girls: GirlData[] = availableGirls.map(g => ({
@@ -476,6 +479,7 @@ export class TeamModule {
             carac2: Number(g.carac2 || 0),
             carac3: Number(g.carac3 || 0),
             level: Number(g.level || 1),
+            class: typeof g.class === 'number' ? g.class : undefined,
             element: (g.element_data?.type || g.element || 'fire') as ElementType,
             rarity: (g.rarity || 'common') as any,
             graded: Number(g.graded || 0),
@@ -486,15 +490,15 @@ export class TeamModule {
                 carac3: Number(g.caracs.carac3 || 0),
             } : undefined,
             skill_tiers_info: g.skill_tiers_info,
-            zodiac: g.zodiac ? g.zodiac.substring(3).trim() : undefined,
+            // Keep raw zodiac glyph; TraitMappings.resolveZodiac strips it for display
+            zodiac: g.zodiac || undefined,
             hairColor: g.hair_color1 || undefined,
             eyeColor: g.eye_color1 || undefined,
             position: g.position_img ? String(g.position_img).replace('.png', '') : undefined,
             blessingBonuses: g.blessing_bonuses || undefined,
-            armor: g.armor || undefined,
         }));
 
-        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel);
+        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel, playerClass);
 
         if (!result) {
             logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
@@ -585,6 +589,12 @@ export class TeamModule {
         sun: 'Playful', darkness: 'Dominatrix', psychic: 'Submissive', light: 'Voyeur',
     };
 
+    private static readonly PLAYER_CLASS_NAME: Record<number, string> = {
+        1: 'Hardcore',
+        2: 'Charm',
+        3: 'Know-how',
+    };
+
     private static updateTeamUI(deckID: number[], teamResult?: TeamResult) {
         const arr = $('div[id_girl]');
         // Remove all existing topNumber elements to prevent stale entries
@@ -631,7 +641,7 @@ export class TeamModule {
             mainTeamPanel.append(arrSort[0]);
         }
 
-        // Show team synergy info panel
+        // Show team selection info panel
         $('.hhTeamSynergyInfo').remove();
         if (teamResult) {
             const dist = TeamBuilderService.getElementDistribution(teamResult);
@@ -642,29 +652,42 @@ export class TeamModule {
 
             const traitEmoji = TeamModule.TRAIT_EMOJI[teamResult.traitCategory] || '';
             const tier3Pct = (teamResult.tier3Bonus * 100).toFixed(1);
+            const playerClassName = TeamModule.PLAYER_CLASS_NAME[teamResult.playerClass] || ('class ' + teamResult.playerClass);
+
+            // Resolve trait value to a human label
+            const traitResolved = TraitMappings.resolve(teamResult.traitCategory, teamResult.traitValue);
+            const traitDisplay = traitResolved.label;
+            const traitFromRuntime = traitResolved.fromRuntime;
+
             // Use cached blessings from BlessingService (loaded on Home page)
             let cachedBlessings: any = null;
             try { cachedBlessings = BlessingService.getCached(); } catch { /* cache not ready */ }
             const blessedVals = cachedBlessings?.blessedValues || {};
             const blessedStr = cachedBlessings && cachedBlessings.blessedTraits.length > 0
-                ? cachedBlessings.blessedTraits.map(c => (TeamModule.TRAIT_EMOJI[c] || '') + ' ' + c + (blessedVals[c] ? '=' + blessedVals[c] : '')).join(', ')
+                ? cachedBlessings.blessedTraits.map((c: string) => (TeamModule.TRAIT_EMOJI[c] || '') + ' ' + c + (blessedVals[c] ? '=' + blessedVals[c] : '')).join(', ')
                     + (cachedBlessings.blessedElement ? ' + ' + (TeamModule.CLASS_NAME[cachedBlessings.blessedElement] || cachedBlessings.blessedElement) : '')
                 : (cachedBlessings ? 'none parsed (check logs)' : 'not loaded yet (visit Home)');
             const blessedIsActive = cachedBlessings && cachedBlessings.blessedTraits.includes(teamResult.traitCategory);
-            const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && (
-                teamResult.traitValue.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase() ||
-                teamResult.traitValue === (cachedBlessings?.blessedValues?.[teamResult.traitCategory] || '')
-            );
+            const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
 
+            const altsHtml = teamResult.alternatives && teamResult.alternatives.length > 1
+                ? '<b>Compared:</b> ' + teamResult.alternatives.map((a: { traitCategory: string; traitValue: string; effectivePower: number }) => {
+                        const r = TraitMappings.resolve(a.traitCategory as any, a.traitValue);
+                        return a.traitCategory + '=' + r.label + ' (' + a.effectivePower.toLocaleString() + ')';
+                    }).join(' | ')
+                : '';
+
+            const fallbackNote = traitFromRuntime ? '' : '<div style="color:#fc6; font-size:10px;">Trait label uses fallback dictionary (game runtime not yet loaded -- may be inaccurate for new color codes).</div>';
+
             const synergyInfo = $(`<div class="hhTeamSynergyInfo" style="
-                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 280px; z-index: 10;
+                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 300px; z-index: 10;
                 background: rgba(0,0,0,0.85); color: #fff; padding: 6px 10px;
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
-                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Why this team was chosen:</div>
-                <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${teamResult.traitValue}" (${teamResult.traitMatchCount}/7 girls match)</div>
+                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+                <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${traitDisplay}" (${teamResult.traitMatchCount}/7 girls match)</div>
                 <div style="color:#aaa; font-size:10px;">Tier 3 gives +stat% per teammate sharing this trait</div>
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Leader:</b> ${teamResult.girls[0].name} (${teamResult.leaderTier5.name} / ${TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element})</div>
@@ -673,9 +696,11 @@ export class TeamModule {
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>
                 <div style="color:#aaa; font-size:10px;">${cachedBlessings ? "Cache: " + new Date(cachedBlessings.timestamp).toLocaleString() : "No cache - go to Home page to load"}</div>
-                <div style="color:#aaa; font-size:10px; margin-top:2px;">${teamResult.alternatives && teamResult.alternatives.length > 1 ? '<b>Compared:</b> ' + teamResult.alternatives.map(a => a.traitCategory + '=' + a.traitValue + ' (' + a.effectivePower.toLocaleString() + ')').join(' | ') : ''}</div>
-                <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best): stats already include blessings</div>
-                <div style="color:#aaa; font-size:10px;">Mode 2 (Best Possible): projects to max level/grades</div>
+                ${altsHtml ? `<div style="color:#aaa; font-size:10px; margin-top:2px;">${altsHtml}</div>` : ''}
+                ${fallbackNote}
+                <hr style="border-color:#555; margin:4px 0"/>
+                <div style="color:#fc6; font-size:10px;"><b>Note:</b> Stats are equipment-free. Hit "Stuff Team" after applying.</div>
+                <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best) uses today's stats, Mode 2 (Best Possible) projects to max level / grades.</div>
             </div>`);
             $("#contains_all section").append(synergyInfo);
         }

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -46,12 +46,12 @@ const FEATURE_POPUP_CLOSE_LABEL: string = "OK";
  * Set to a specific version (e.g. "7.34.2") to activate the feature popup
  * for that version. Set to "0" to deactivate (default).
  */
-const FEATURE_POPUP_VERSION: string = "7.35.20";
+const FEATURE_POPUP_VERSION: string = "7.35.21";
 
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.20";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.21";
 
 /**
  * HTML content for the feature popup.
@@ -59,17 +59,16 @@ const FEATURE_POPUP_TITLE = "HHAuto v7.35.20";
  */
 const FEATURE_POPUP_CONTENT = `
   <div style="padding:10px; max-width:520px; color:#333;">
-    <p style="font-size:15px; font-weight:bold; margin-bottom:10px; color:#090;">Repository transfer complete</p>
-    <p style="margin-bottom:10px;">HHAuto now lives at <b style="color:#090;">github.com/OldRon1977/HHauto</b>.</p>
-    <p style="margin-bottom:10px;">The old Roukys/HHauto URL redirects automatically &mdash; no action needed on your side. Tampermonkey picks up updates from the new location. Your settings remain untouched.</p>
-    <p style="margin-bottom:6px;"><b>What's new in v7.35.20:</b></p>
+    <p style="font-size:15px; font-weight:bold; margin-bottom:10px; color:#090;">League team algorithm rebuilt</p>
+    <p style="margin-bottom:6px;"><b>What's new in v7.35.21:</b></p>
     <ul style="margin-bottom:10px; font-size:12px;">
-      <li>Team selection: blessing boost now works correctly (hex color codes no longer break matching)</li>
-      <li>Info box shows "#A55" instead of raw hex when no blessing name is available</li>
+      <li>Team selection now scores by your <b>main class stat</b> (HC=carac1, Charm=carac2, KH=carac3) instead of the raw stat sum</li>
+      <li>Hard class filter: only girls of your own class are considered &mdash; cross-class never wins</li>
+      <li>Trait clusters are compared by main_sum &times; (1 + tier3 bonus) &mdash; the actual game power, not heuristics</li>
+      <li>Position-trait penalty and synergy tiebreaker are gone &mdash; the new scoring captures it correctly</li>
+      <li>Info box shows readable trait names ("Blue", "Doggy") instead of hex codes ("00F", "2.png"), pulled live from the game UI</li>
+      <li>New note: stats are equipment-free &mdash; hit "Stuff Team" after applying</li>
     </ul>
-    <p style="margin-bottom:15px; font-size:13px;">
-      Thanks to <b>Roukys</b> for hosting HHAuto for so many years, and to <b>deuxge</b> for maintaining it!
-    </p>
     <p style="margin-bottom:0; font-size:11px; color:#888;">This popup will be deactivated in the next version.</p>
   </div>
 `;

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -1,25 +1,28 @@
-// TeamBuilderService.ts -- Builds optimal 7-girl teams.
+// TeamBuilderService.ts -- Builds optimal 7-girl teams using Tier 3
+// trait-group optimization (v4).
 //
-// Simple logic:
-//   1. Score all girls (base stats * blessing multiplier - equipment)
-//   2. Take top 7 by score
-//   3. Tiebreaker: prefer element clusters (Tier-3 bonus)
-//   4. Leader: highest-score Mythic girl
+// Algorithm:
+//   1. Hard-filter to Mythic + Legendary 5-star, player class only
+//   2. Score by player main-carac (current or projected)
+//   3. Find best trait group (element pair + shared trait value)
+//      compared by main_sum * (1 + tier3Bonus)
+//   4. Select Mythic leader (Shield/Stun priority)
+//   5. Fill slots 2-7 from trait group, then by main-carac
 
 import { BlessingService } from './BlessingService';
-import { logHHAuto } from '../Utils/index';
 import {
     TeamScoringService,
     GirlData,
     ElementType,
     TraitCategory,
     TraitGroupResult,
+    PlayerClass,
 } from './TeamScoringService';
 
 export interface TeamResult {
     girls: GirlData[];          // 7 girls, index 0 = leader
-    statScores: number[];       // individual stat scores
-    synergyValue: number;       // total team synergy value
+    statScores: number[];       // individual main-carac scores
+    synergyValue: number;       // total team synergy value (informational)
     leaderTier5: { id: number; name: string; priority: number };
     elements: ElementType[];    // team element composition
     traitCategory: TraitCategory;   // which trait was optimized
@@ -28,85 +31,127 @@ export interface TeamResult {
     traitMatchCount: number;        // how many girls match the trait
     blessedCategories: string[];   // currently blessed trait categories
     blessedGirlCount: number;      // how many girls have active blessings
-    effectivePower: number;        // team total power
+    effectivePower: number;        // main_sum * (1 + tier3Bonus)
     alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }>;
+    playerClass: PlayerClass;       // 1=HC, 2=Charm, 3=KH (for UI display)
 }
 
 export type ScoringMode = 1 | 2;  // 1 = Current Best, 2 = Best Possible
 
 const TEAM_SIZE = 7;
-const SAME_STAT_THRESHOLD = 100; // Girls within 100 points are considered equal
+// No pool cap: the Mythic + Legendary-5* filter is already strict
+// (max ~170 girls per class even if a player owned every released one).
+// Capping here would only risk excluding viable mythics on edge cases.
+// CANDIDATE_POOL_SIZE removed in v7.35.21.
+
+// Map trait category to its element pair for quick lookup
+const ELEMENT_PAIRS_MAP: Record<string, ElementType[]> = {
+    'eyeColor': ['darkness', 'fire'],
+    'hairColor': ['light', 'nature'],
+    'zodiac': ['stone', 'psychic'],
+    'position': ['water', 'sun'],
+};
 
 export class TeamBuilderService {
 
     /**
-     * Build the optimal team: simply the 7 strongest girls.
-     * At equal stats, prefer element clusters for Tier-3 bonus.
+     * Build the optimal team for the given mode.
+     *
+     * @param allGirls    - All available girls (from availableGirls)
+     * @param mode        - 1 = Current Best, 2 = Best Possible
+     * @param playerLevel - Player's current level (needed for mode 2)
+     * @param playerClass - Player's class (1=HC, 2=Charm, 3=KH)
+     * @returns TeamResult with the selected 7 girls, or null if not enough girls
      */
     static buildTeam(
         allGirls: GirlData[],
         mode: ScoringMode,
-        playerLevel: number
+        playerLevel: number,
+        playerClass: PlayerClass
     ): TeamResult | null {
-        // Phase 1: Filter to Mythic + Legendary only
-        const candidates = TeamScoringService.filterHighRarity(allGirls);
-        if (candidates.length < TEAM_SIZE) return null;
+        // Phase 1: Hard filter -- Mythic/Legendary AND own class
+        const candidates = TeamScoringService.filterEligible(allGirls, playerClass);
 
-        // Phase 2: Score all candidates (stats * blessing multiplier - equipment)
+        if (candidates.length < TEAM_SIZE) {
+            return null;
+        }
+
+        // Phase 2: Score all candidates by main-carac
         const scoreMap = new Map<number, number>();
         for (const girl of candidates) {
             const score = mode === 1
-                ? TeamScoringService.scoreCurrentBest(girl)
-                : TeamScoringService.scoreBestPossible(girl, playerLevel);
+                ? TeamScoringService.scoreCurrentBest(girl, playerClass)
+                : TeamScoringService.scoreBestPossible(girl, playerClass, playerLevel);
             scoreMap.set(girl.id_girl, score);
         }
 
-        // Sort by score descending
-        const sorted = [...candidates].sort(
+        // Pre-sort and pick a reasonable candidate pool
+        // Sort by score; no cap -- evaluate every eligible girl
+        const pool = [...candidates].sort(
             (a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0)
         );
 
-        // Log top girls
-        if (sorted.length >= 10) {
-            logHHAuto('TeamBuilder: top 10 by score: ' + sorted.slice(0, 10).map(g =>
-                g.name + '(' + Math.round(scoreMap.get(g.id_girl) || 0) + ',' + g.element + ',bls=' + TeamScoringService.getBlessingMultiplier(g).toFixed(2) + ')'
-            ).join(', '));
+        // Phase 2b: Detect active blessings (informational + heuristic)
+        const { blessedCategories, blessedGirlCount } = TeamScoringService.detectBlessedTraits(candidates);
+
+        // Phase 3: Build teams for multiple trait groups, pick highest effective power
+        const traitGroups = TeamScoringService.findTraitGroups(pool, playerClass, blessedCategories);
+
+        // Evaluate top groups + all blessed groups
+        const groupsToEvaluate: TraitGroupResult[] = [];
+        const seenKeys = new Set<string>();
+        for (const g of traitGroups.slice(0, 5)) {
+            const key = g.traitCategory + '=' + g.traitValue;
+            if (!seenKeys.has(key)) { groupsToEvaluate.push(g); seenKeys.add(key); }
+        }
+        for (const g of traitGroups) {
+            const key = g.traitCategory + '=' + g.traitValue;
+            if (seenKeys.has(key)) continue;
+            if (blessedCategories.has(g.traitCategory)) { groupsToEvaluate.push(g); seenKeys.add(key); }
+        }
+        if (groupsToEvaluate.length === 0 && traitGroups.length > 0) {
+            groupsToEvaluate.push(traitGroups[0]);
         }
 
-        // Phase 3: Select top 7 with element-cluster tiebreaker
-        const team = TeamBuilderService._selectWithCluster(sorted, scoreMap);
-        if (team.length < TEAM_SIZE) return null;
+        // Build a team for each group and compare effective power
+        let bestBuilt: { team: GirlData[], cat: TraitCategory, val: string, power: number } | null = null;
+        const alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }> = [];
 
-        // Phase 4: Choose leader (highest-score Mythic in team)
-        const leaderIdx = TeamBuilderService._pickLeader(team, scoreMap);
-        if (leaderIdx > 0) {
-            // Move leader to position 0
-            const leader = team.splice(leaderIdx, 1)[0];
-            team.unshift(leader);
+        for (const group of groupsToEvaluate) {
+            const builtTeam = TeamBuilderService._buildTeamForGroup(group.traitCategory, group.traitValue, pool, scoreMap);
+            if (!builtTeam || builtTeam.length < TEAM_SIZE) continue;
+            const statSum = builtTeam.reduce((s, g) => s + (scoreMap.get(g.id_girl) || 0), 0);
+            const t3 = TeamScoringService.calculateTier3TeamBonus(builtTeam);
+            const power = Math.round(statSum * (1 + t3));
+            alternatives.push({ traitCategory: group.traitCategory, traitValue: group.traitValue, effectivePower: power });
+            if (!bestBuilt || power > bestBuilt.power) {
+                bestBuilt = { team: builtTeam, cat: group.traitCategory, val: group.traitValue, power };
+            }
         }
 
-        // Phase 5: Build result
+        if (!bestBuilt) return null;
+
+        const team = bestBuilt.team;
         const teamElements: ElementType[] = team.map(g => g.element);
+        const leader = team[0];
+        const traitCategory = bestBuilt.cat;
+        const traitValue = bestBuilt.val;
+
         const statScores = team.map(g => scoreMap.get(g.id_girl) || 0);
-        const power = Math.round(statScores.reduce((s, v) => s + v, 0));
         const synergyValue = TeamScoringService.calculateSynergyValue(teamElements);
-        const leaderTier5 = TeamScoringService.getTier5Skill(team[0].element);
+        const leaderTier5 = TeamScoringService.getTier5Skill(leader.element);
         const tier3Bonus = TeamScoringService.calculateTier3TeamBonus(team);
 
-        // Detect blessed info for display
-        const cachedBlessing = BlessingService.getCached();
-        const blessedTraits = cachedBlessing?.blessedTraits || [];
-        const blessedGirlCount = candidates.filter(g =>
-            g.blessingBonuses?.pvp_v3?.carac1?.length > 0
-        ).length;
-
-        // Find dominant trait in team for display
-        const { traitCategory, traitValue, traitMatchCount } = TeamBuilderService._findDominantTrait(team);
-
-        logHHAuto('TeamBuilder: team power = ' + power + ', leader = ' + team[0].name +
-            ' (' + team[0].element + '), elements: ' + teamElements.join(',') +
-            ', tier3 = ' + (tier3Bonus * 100).toFixed(1) + '%');
-        logHHAuto('TeamBuilder: team: ' + team.map(g => g.name + '(' + Math.round(scoreMap.get(g.id_girl) || 0) + ',' + g.element + ')').join(', '));
+        let traitMatchCount = 0;
+        for (const girl of team) {
+            const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+            if (girlCategory === traitCategory) {
+                const girlValue = TeamScoringService.getTraitValue(girl);
+                if (girlValue === traitValue) {
+                    traitMatchCount++;
+                }
+            }
+        }
 
         return {
             girls: team,
@@ -118,148 +163,59 @@ export class TeamBuilderService {
             traitValue,
             tier3Bonus,
             traitMatchCount,
-            blessedCategories: blessedTraits,
+            blessedCategories: Array.from(blessedCategories),
             blessedGirlCount,
-            effectivePower: power,
-            alternatives: [],
+            effectivePower: bestBuilt.power,
+            alternatives,
+            playerClass,
         };
     }
 
     /**
-     * Select top 7 girls with element-cluster optimization at equal stats.
-     * Girls with clearly higher stats always win. Among equal-stat girls,
-     * prefer those that form the largest element cluster.
+     * Build a team for a specific trait group.
+     *
+     * Pass 1: same element pair + matching trait value (max Tier-3 bonus).
+     * Pass 2: same element pair, any trait value (still keeps cluster).
+     * Pass 3: any element by score (last-resort fillers).
      */
-    private static _selectWithCluster(sorted: GirlData[], scoreMap: Map<number, number>): GirlData[] {
-        if (sorted.length <= TEAM_SIZE) return sorted.slice(0, TEAM_SIZE);
+    private static _buildTeamForGroup(cat: TraitCategory, val: string, pool: GirlData[], scoreMap: Map<number, number>): GirlData[] | null {
+        const elems = ELEMENT_PAIRS_MAP[cat] || [];
+        const leaders = pool.filter(g => g.rarity === 'mythic' && elems.includes(g.element));
+        const ranked = TeamScoringService.rankLeaderCandidates(leaders.length > 0 ? leaders : pool, scoreMap, cat, val);
+        if (ranked.length === 0) return null;
 
-        const topScore = scoreMap.get(sorted[0].id_girl) || 0;
-        const team: GirlData[] = [];
+        const team: GirlData[] = [ranked[0]];
+        const used = new Set<number>([ranked[0].id_girl]);
 
-        // Separate into tiers: girls clearly above others go in first
-        let i = 0;
-        while (i < sorted.length && team.length < TEAM_SIZE) {
-            // Find the end of this stat tier (all girls within SAME_STAT_THRESHOLD)
-            const tierScore = scoreMap.get(sorted[i].id_girl) || 0;
-            let tierEnd = i;
-            while (tierEnd < sorted.length &&
-                   Math.abs((scoreMap.get(sorted[tierEnd].id_girl) || 0) - tierScore) < SAME_STAT_THRESHOLD) {
-                tierEnd++;
-            }
-
-            const tierGirls = sorted.slice(i, tierEnd);
-            const slotsLeft = TEAM_SIZE - team.length;
-
-            if (tierGirls.length <= slotsLeft) {
-                // All girls in this tier fit, take them all
-                team.push(...tierGirls);
-            } else {
-                // More girls than slots: pick by element cluster
-                const picked = TeamBuilderService._pickByCluster(tierGirls, slotsLeft, team);
-                team.push(...picked);
-            }
-            i = tierEnd;
+        // Pass 1: matching trait value AND correct element
+        const pass1 = pool
+            .filter(g => !used.has(g.id_girl) && elems.includes(g.element) && TeamScoringService.getTraitValue(g) === val)
+            .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+        for (const g of pass1) {
+            if (team.length >= TEAM_SIZE) break;
+            team.push(g); used.add(g.id_girl);
         }
-
-        return team;
-    }
-
-    /**
-     * From a group of equal-stat girls, pick the ones that maximize element clusters.
-     * Consider already-selected team members for cluster building.
-     */
-    private static _pickByCluster(candidates: GirlData[], slots: number, currentTeam: GirlData[]): GirlData[] {
-        // Count elements already in team
-        const elementCounts = new Map<ElementType, number>();
-        for (const g of currentTeam) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-
-        // Count elements available in candidates
-        const candidateElements = new Map<ElementType, GirlData[]>();
-        for (const g of candidates) {
-            if (!candidateElements.has(g.element)) candidateElements.set(g.element, []);
-            candidateElements.get(g.element)!.push(g);
-        }
-
-        // Score each candidate by how much they contribute to a cluster
-        const scored = candidates.map(g => {
-            const currentCount = elementCounts.get(g.element) || 0;
-            // Prefer elements that already have members (builds cluster)
-            // or elements with many candidates available (can build new cluster)
-            const availableCount = candidateElements.get(g.element)?.length || 0;
-            const clusterScore = currentCount * 10 + availableCount;
-            // Mythic tiebreaker
-            const rarityBonus = g.rarity === 'mythic' ? 1000 : 0;
-            return { girl: g, score: clusterScore + rarityBonus };
-        });
-
-        // Sort by cluster score descending, pick top N
-        scored.sort((a, b) => b.score - a.score);
-        return scored.slice(0, slots).map(s => s.girl);
-    }
-
-    /**
-     * Pick the leader: highest-score Mythic girl in the team.
-     * Among equal Mythics, prefer the one in the largest element cluster.
-     */
-    private static _pickLeader(team: GirlData[], scoreMap: Map<number, number>): number {
-        let bestIdx = 0;
-        let bestScore = -1;
-        const elementCounts = new Map<ElementType, number>();
-        for (const g of team) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-
-        for (let i = 0; i < team.length; i++) {
-            const g = team[i];
-            if (g.rarity !== 'mythic') continue;
-            const score = scoreMap.get(g.id_girl) || 0;
-            const clusterSize = elementCounts.get(g.element) || 0;
-            // Compare: higher stats win, then larger cluster
-            const composite = score * 1000 + clusterSize;
-            if (composite > bestScore) {
-                bestScore = composite;
-                bestIdx = i;
+        // Pass 2: correct element, any trait value
+        if (team.length < TEAM_SIZE) {
+            const pass2 = pool
+                .filter(g => !used.has(g.id_girl) && elems.includes(g.element))
+                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+            for (const g of pass2) {
+                if (team.length >= TEAM_SIZE) break;
+                team.push(g); used.add(g.id_girl);
             }
         }
-        return bestIdx;
-    }
-
-    /**
-     * Find the dominant trait in the team for display purposes.
-     */
-    private static _findDominantTrait(team: GirlData[]): { traitCategory: TraitCategory; traitValue: string; traitMatchCount: number } {
-        // Count element occurrences to find dominant element pair
-        const elementCounts = new Map<ElementType, number>();
-        for (const g of team) {
-            elementCounts.set(g.element, (elementCounts.get(g.element) || 0) + 1);
-        }
-
-        // Find most common element
-        let bestElement: ElementType = team[0].element;
-        let bestCount = 0;
-        for (const [el, count] of elementCounts) {
-            if (count > bestCount) { bestCount = count; bestElement = el; }
-        }
-
-        const traitCategory = TeamScoringService.getTraitCategory(bestElement);
-        // Find most common trait value among team members of that category
-        const traitValues = new Map<string, number>();
-        for (const g of team) {
-            if (TeamScoringService.getTraitCategory(g.element) === traitCategory) {
-                const val = TeamScoringService.getTraitValue(g);
-                if (val) traitValues.set(val, (traitValues.get(val) || 0) + 1);
+        // Pass 3: any element by score
+        if (team.length < TEAM_SIZE) {
+            const pass3 = pool
+                .filter(g => !used.has(g.id_girl))
+                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
+            for (const g of pass3) {
+                if (team.length >= TEAM_SIZE) break;
+                team.push(g); used.add(g.id_girl);
             }
         }
-
-        let traitValue = '';
-        let traitMatchCount = 0;
-        for (const [val, count] of traitValues) {
-            if (count > traitMatchCount) { traitMatchCount = count; traitValue = val; }
-        }
-
-        return { traitCategory, traitValue, traitMatchCount };
+        return team.length >= TEAM_SIZE ? team : null;
     }
 
     /**

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -1,15 +1,20 @@
-// TeamScoringService.ts -- Scoring engine for team selection v3.
+// TeamScoringService.ts -- Scoring engine for team selection v4.
 //
 // Provides Tier 3 trait matching, element synergy calculations,
 // and leader skill evaluation for team optimization.
 //
-// Two modes (both filter Mythic + Legendary only):
-//   - "Current Best": uses current stats (blessed)
-//   - "Best Possible": projects stats to max level + full grades
+// Two modes (both filter Mythic + Legendary only, hard-filter to player class):
+//   - "Current Best": uses current main-class stat (blessed, equipment-free)
+//   - "Best Possible": projects main-class stat to player level + max grades
+//
+// Player class is HC=1 (carac1), Charm=2 (carac2), KH=3 (carac3).
+// Only the matching carac counts for scoring -- the game's own class
+// system does the rest (Wiki: "never build cross-class").
 
 export type ElementType = 'fire' | 'water' | 'nature' | 'stone' | 'sun' | 'darkness' | 'psychic' | 'light';
 export type RarityType = 'starting' | 'common' | 'rare' | 'epic' | 'legendary' | 'mythic';
 export type TraitCategory = 'eyeColor' | 'hairColor' | 'zodiac' | 'position';
+export type PlayerClass = 1 | 2 | 3;
 
 export interface GirlData {
     id_girl: number;
@@ -18,6 +23,7 @@ export interface GirlData {
     carac2: number;
     carac3: number;
     level: number;
+    class?: number;       // 1=HC, 2=Charm, 3=KH
     element: ElementType;
     rarity: RarityType;
     graded: number;       // grades currently applied
@@ -35,8 +41,6 @@ export interface GirlData {
     position?: string;
     // Blessing data (from game API)
     blessingBonuses?: any;
-    // Equipment data
-    armor?: Array<{ caracs?: { carac1?: number; carac2?: number; carac3?: number } }>;
 }
 
 export interface SynergyBonuses {
@@ -60,7 +64,7 @@ export interface TraitGroupResult {
     traitCategory: TraitCategory;
     traitValue: string;
     girls: GirlData[];
-    score: number;        // count × avg_stats, with position penalty
+    score: number;        // count * avg_main_carac, blessed-category boost applied
 }
 
 // Synergy bonus multiplier per girl of each element in the team
@@ -109,9 +113,6 @@ const ELEMENT_PAIRS: Array<{ elements: [ElementType, ElementType]; trait: TraitC
     { elements: ['water', 'sun'],        trait: 'position' },
 ];
 
-// Position penalty factor (position trait reduces attack stats via equipment)
-const POSITION_TRAIT_PENALTY = 0.80;
-
 // Rarities allowed for team selection (both modes)
 const HIGH_RARITIES: Set<RarityType> = new Set(['mythic', 'legendary']);
 
@@ -119,73 +120,53 @@ const HIGH_RARITIES: Set<RarityType> = new Set(['mythic', 'legendary']);
 const TIER3_BONUS_MYTHIC = 0.01;
 const TIER3_BONUS_LEGENDARY = 0.008;
 
+// Blessed-category boost when scoring trait groups (heuristic only;
+// the actual stat impact already lives inside girl.caracs once the
+// game applies the weekly blessing).
+const BLESSED_CATEGORY_BOOST = 1.5;
+
 export class TeamScoringService {
 
     /**
-     * Get the raw stat sum for a girl (carac1 + carac2 + carac3).
-     * Uses caracs sub-object if available, falls back to direct fields.
+     * Get the girl's main-class stat (carac1/2/3 by player class).
+     * Uses caracs sub-object if available (already equipment-free),
+     * falls back to direct fields.
+     *
+     * Player class -> stat field:
+     *   1 (Hardcore) -> carac1
+     *   2 (Charm)    -> carac2
+     *   3 (Know-how) -> carac3
      */
-    /**
-     * Get the BASE stat sum for a girl, EXCLUDING equipment (armor) bonuses.
-     * The game API includes armor stats in carac1/2/3, which must be subtracted
-     * to get the true girl power for fair comparison across differently-equipped girls.
-     */
-    static getStatSum(girl: GirlData): number {
-        let total: number;
-        if (girl.caracs) {
-            total = girl.caracs.carac1 + girl.caracs.carac2 + girl.caracs.carac3;
-        } else {
-            total = girl.carac1 + girl.carac2 + girl.carac3;
+    static getMainCarac(girl: GirlData, playerClass: PlayerClass): number {
+        const src = girl.caracs || { carac1: girl.carac1, carac2: girl.carac2, carac3: girl.carac3 };
+        switch (playerClass) {
+            case 1: return Number(src.carac1) || 0;
+            case 2: return Number(src.carac2) || 0;
+            case 3: return Number(src.carac3) || 0;
         }
-
-        // Subtract armor/equipment bonuses if present
-        if (girl.armor && Array.isArray(girl.armor)) {
-            for (const piece of girl.armor) {
-                if (piece.caracs) {
-                    total -= (piece.caracs.carac1 || 0) + (piece.caracs.carac2 || 0) + (piece.caracs.carac3 || 0);
-                }
-            }
-        }
-
-        return total;
-    }
-
-    /**
-     * Get the blessing multiplier for a girl from her blessing_bonuses.
-     * The pvp_v3 field contains an array of bonus percentages (one per active blessing).
-     * E.g. pvp_v3: { carac1: [30, 40] } means +30% from one blessing and +40% from another.
-     * These are additive: total = 1 + (30 + 40) / 100 = 1.70
-     */
-    static getBlessingMultiplier(girl: GirlData): number {
-        if (!girl.blessingBonuses || typeof girl.blessingBonuses !== 'object') return 1;
-        if (Array.isArray(girl.blessingBonuses) && girl.blessingBonuses.length === 0) return 1;
-        const pvp3 = girl.blessingBonuses.pvp_v3;
-        if (!pvp3 || !pvp3.carac1 || !Array.isArray(pvp3.carac1)) return 1;
-        const totalPct = pvp3.carac1.reduce((sum: number, pct: number) => sum + pct, 0);
-        return 1 + totalPct / 100;
     }
 
     /**
      * Score a girl for "Current Best" mode.
-     * Base stats from the API do NOT include blessing bonuses.
-     * We must apply the blessing multiplier manually.
+     * Returns the current main-carac (already includes blessings).
      */
-    static scoreCurrentBest(girl: GirlData): number {
-        const baseStats = TeamScoringService.getStatSum(girl);
-        const blessingMultiplier = TeamScoringService.getBlessingMultiplier(girl);
-        return baseStats * blessingMultiplier;
+    static scoreCurrentBest(girl: GirlData, playerClass: PlayerClass): number {
+        return TeamScoringService.getMainCarac(girl, playerClass);
     }
 
     /**
      * Score a girl for "Best Possible" mode.
-     * Projects stats to max level and full grades, then applies blessing bonus.
+     * Projects main-carac to player level and full grades.
      *
      * Formula:
-     *   potential = baseStats / level x playerLevel / (1 + 0.3 x currentGrades) x (1 + 0.3 x maxGrades)
-     *   final = potential x blessingMultiplier
+     *   potential = currentMainCarac / level * playerLevel
+     *               / (1 + 0.3 * currentGrades) * (1 + 0.3 * maxGrades)
+     *
+     * Returns max(projected, current) so blessing-inflated current
+     * stats never get demoted by the projection.
      */
-    static scoreBestPossible(girl: GirlData, playerLevel: number): number {
-        const currentStats = TeamScoringService.getStatSum(girl);
+    static scoreBestPossible(girl: GirlData, playerClass: PlayerClass, playerLevel: number): number {
+        const currentMain = TeamScoringService.getMainCarac(girl, playerClass);
         const level = girl.level || 1;
         const currentGrades = girl.graded || 0;
         const maxGrades = girl.nb_grades || 0;
@@ -194,13 +175,29 @@ export class TeamScoringService {
         const gradeDeflator = 1 + 0.3 * currentGrades;
         const gradeInflator = 1 + 0.3 * maxGrades;
 
-        const projected = (currentStats * levelFactor / gradeDeflator) * gradeInflator;
-        const blessingMultiplier = TeamScoringService.getBlessingMultiplier(girl);
-        return Math.max(projected * blessingMultiplier, currentStats * blessingMultiplier);
+        const projected = (currentMain * levelFactor / gradeDeflator) * gradeInflator;
+        return Math.max(projected, currentMain);
     }
 
     /**
-     * Filter girls: only Mythic and Legendary (both modes).
+     * Filter girls: only Mythic and Legendary 5-star, plus hard class match.
+     * Cross-class girls always lose because their main-carac is the
+     * non-matching one; filtering them out up-front keeps the pool small.
+     */
+    static filterEligible(girls: GirlData[], playerClass: PlayerClass): GirlData[] {
+        return girls.filter(g => {
+            // Class filter (hard)
+            if (typeof g.class === 'number' && g.class !== playerClass) return false;
+            // Rarity filter
+            if (g.rarity === 'mythic') return true;
+            if (g.rarity === 'legendary') return g.nb_grades >= 5;
+            return false;
+        });
+    }
+
+    /**
+     * Backwards-compatible alias used by existing tests.
+     * @deprecated Use filterEligible(girls, playerClass) instead.
      */
     static filterHighRarity(girls: GirlData[]): GirlData[] {
         return girls.filter(g => {
@@ -217,7 +214,7 @@ export class TeamScoringService {
         return ELEMENT_TO_TIER5[element];
     }
 
-    // ─── Trait / Tier 3 Logic ─────────────────────────────────────────
+    // --- Trait / Tier 3 logic --------------------------------------
 
     /**
      * Get the trait category for a girl based on her element.
@@ -324,12 +321,18 @@ export class TeamScoringService {
      * Find all possible trait groups from a pool of girls.
      *
      * For each element pair, groups girls by their shared trait value
-     * and scores each group. Position groups receive a penalty.
-     * Groups matching a currently blessed trait receive a bonus.
+     * and scores each group by `count * avg_main_carac`.
+     * Groups matching a currently blessed trait receive a heuristic
+     * boost to surface them in early evaluation; the actual stat
+     * impact is already in the girl's caracs from the game API.
      *
      * Returns groups sorted by score descending.
      */
-    static findTraitGroups(girls: GirlData[], blessedCategories?: Set<TraitCategory>, blessedValues?: Record<string, string>): TraitGroupResult[] {
+    static findTraitGroups(
+        girls: GirlData[],
+        playerClass: PlayerClass,
+        blessedCategories?: Set<TraitCategory>
+    ): TraitGroupResult[] {
         const results: TraitGroupResult[] = [];
 
         for (const pair of ELEMENT_PAIRS) {
@@ -346,27 +349,12 @@ export class TeamScoringService {
             }
 
             for (const [traitValue, groupGirls] of groups) {
-                // Use blessed stats (includes blessing multiplier) for fair comparison
-                const avgStats = groupGirls.reduce((sum, g) => sum + TeamScoringService.scoreCurrentBest(g), 0) / groupGirls.length;
-                let score = groupGirls.length * avgStats;
+                const avgMain = groupGirls.reduce((sum, g) => sum + TeamScoringService.getMainCarac(g, playerClass), 0) / groupGirls.length;
+                let score = groupGirls.length * avgMain;
 
-                // Position trait penalty (reduces attack stats via equipment)
-                if (pair.trait === 'position') {
-                    score *= POSITION_TRAIT_PENALTY;
-                }
-
-                // Blessing boost: only boost the specific group that matches the blessed value.
-                // blessedValues maps category -> hex code (resolved at runtime from girl data).
+                // Heuristic boost for blessed trait categories
                 if (blessedCategories && blessedCategories.has(pair.trait)) {
-                    const blessedHex = blessedValues?.[pair.trait];
-                    if (blessedHex && traitValue === blessedHex) {
-                        // Exact match: this is THE blessed group
-                        score *= 2.0;
-                    } else if (!blessedHex) {
-                        // Fallback: could not resolve hex, boost entire category (old behavior)
-                        score *= 1.5;
-                    }
-                    // If blessedHex exists but doesn't match: no boost (intentional)
+                    score *= BLESSED_CATEGORY_BOOST;
                 }
 
                 results.push({
@@ -381,7 +369,7 @@ export class TeamScoringService {
         return results.sort((a, b) => b.score - a.score);
     }
 
-    // ─── Synergy Calculations (secondary factor) ─────────────────────
+    // --- Synergy calculations (informational) ---------------------
 
     /**
      * Calculate synergy bonuses for a set of elements (one per team member).
@@ -427,83 +415,11 @@ export class TeamScoringService {
         );
     }
 
-    /**
-     * Score a girl's contribution to a team, considering both stats and
-     * the synergy bonus she adds. Used as tiebreaker when filling remaining slots.
-     */
-    static scoreWithSynergy(
-        girl: GirlData,
-        teamElements: ElementType[],
-        statScore: number,
-        maxStatInPool: number,
-        synergyWeight: number = 0.05
-    ): number {
-        const currentSynergyValue = TeamScoringService.calculateSynergyValue(teamElements);
-        const newSynergyValue = TeamScoringService.calculateSynergyValue([...teamElements, girl.element]);
-        const synergyDelta = newSynergyValue - currentSynergyValue;
-
-        const normalizedSynergyBonus = maxStatInPool > 0
-            ? (synergyDelta / maxStatInPool) * maxStatInPool
-            : 0;
-
-        return statScore + synergyWeight * normalizedSynergyBonus;
-    }
-
-    // ─── Tier 3 Delta Estimation ────────────────────────────────────
-
-    /**
-     * Estimate the stat-equivalent value of adding a candidate to the team,
-     * considering the marginal Tier 3 bonus she would provide.
-     *
-     * Returns 0 if the candidate does not match the target trait.
-     * Otherwise returns marginalPct × teamStatTotal, where marginalPct
-     * accounts for both the new girl's bonus and the boost to existing
-     * trait teammates.
-     */
-    static estimateTier3Delta(
-        candidate: GirlData,
-        currentTeam: GirlData[],
-        traitCategory: TraitCategory,
-        traitValue: string,
-        teamStatTotal: number
-    ): number {
-        const candidateCategory = ELEMENT_TO_TRAIT_CATEGORY[candidate.element];
-        if (candidateCategory !== traitCategory) return 0;
-
-        const candidateValue = TeamScoringService.getTraitValue(candidate);
-        if (candidateValue !== traitValue) return 0;
-
-        // Count existing trait-matching teammates and sum their bonus rates
-        let existingTraitCount = 0;
-        let existingBoostSum = 0;
-        for (const member of currentTeam) {
-            const memberCategory = ELEMENT_TO_TRAIT_CATEGORY[member.element];
-            if (memberCategory !== traitCategory) continue;
-            const memberValue = TeamScoringService.getTraitValue(member);
-            if (memberValue !== traitValue) continue;
-            existingTraitCount++;
-            existingBoostSum += member.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
-        }
-
-        // New girl sees existingTraitCount matches
-        const candidateBonusRate = candidate.rarity === 'mythic' ? TIER3_BONUS_MYTHIC : TIER3_BONUS_LEGENDARY;
-        const newGirlBonus = existingTraitCount * candidateBonusRate;
-
-        // Each existing trait teammate gains +1 match from this girl
-        const existingBoost = existingBoostSum;
-
-        const marginalPct = newGirlBonus + existingBoost;
-        return marginalPct * teamStatTotal;
-    }
-
-    // ─── Leader Selection ────────────────────────────────────────────
+    // --- Leader selection ----------------------------------------
 
     /**
      * Rank leader candidates by element priority (Shield > Stun > Execute > Reflect).
      * Leader must be Mythic. Among same priority: prefer trait match, then highest stats.
-     *
-     * @param traitCategory - The team's chosen trait category
-     * @param traitValue    - The team's chosen trait value
      */
     static rankLeaderCandidates(
         girls: GirlData[],
@@ -511,10 +427,8 @@ export class TeamScoringService {
         traitCategory?: TraitCategory,
         traitValue?: string
     ): GirlData[] {
-        // Only Mythic girls can be leaders
         const mythicGirls = girls.filter(g => g.rarity === 'mythic');
         if (mythicGirls.length === 0) {
-            // Fallback: allow all girls if no mythics available
             return TeamScoringService._sortLeaderCandidates(girls, statScores, traitCategory, traitValue);
         }
         return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue);
@@ -527,7 +441,15 @@ export class TeamScoringService {
         traitValue?: string
     ): GirlData[] {
         return [...girls].sort((a, b) => {
-            // Primary: trait match (does the leader match the team's trait?)
+            const tier5A = ELEMENT_TO_TIER5[a.element];
+            const tier5B = ELEMENT_TO_TIER5[b.element];
+
+            // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect)
+            if (tier5A.priority !== tier5B.priority) {
+                return tier5B.priority - tier5A.priority;
+            }
+
+            // Secondary: trait match bonus
             if (traitCategory && traitValue) {
                 const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
                 const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
@@ -536,7 +458,7 @@ export class TeamScoringService {
                 }
             }
 
-            // Secondary: stat score (includes blessing multiplier)
+            // Tertiary: stat score
             const scoreA = statScores.get(a.id_girl) || 0;
             const scoreB = statScores.get(b.id_girl) || 0;
             return scoreB - scoreA;
@@ -545,8 +467,6 @@ export class TeamScoringService {
 
     /**
      * Check if a leader candidate matches the team's trait.
-     * The leader's own element determines her trait category —
-     * she only matches if her element uses the same trait category as the team.
      */
     private static _leaderMatchesTrait(
         girl: GirlData,

--- a/src/Service/TraitMappings.ts
+++ b/src/Service/TraitMappings.ts
@@ -1,0 +1,142 @@
+// TraitMappings.ts -- Maps internal hex / image / unicode codes to
+// human-readable trait names.
+//
+// The game stores girl traits as compact codes:
+//   - eye_color1 / hair_color1: 3-character hex like "00F", "888", "F90"
+//   - position_img: numbered image like "1.png" .. "12.png"
+//   - zodiac: unicode glyph + name like "GLYPH Aries"
+//
+// At runtime, the game UI translates these via window.GT.design.colors
+// and window.GT.design.figures. We try the runtime lookup first
+// (covers patches that add new colors) and fall back to hardcoded
+// English values from Tom-208's userscript reference.
+//
+// Used by: TeamModule UI box (cluster name, blessing match indicator)
+
+// Hardcoded English fallback. Mirrors the Tom-208 userscript (gist
+// a5c7065866fe1de5032aabbbd1ed9eff) which itself is reverse-engineered
+// from window.GT.design.colors.
+const COLOR_FALLBACK_EN: Record<string, string> = {
+    'F99': 'Pink',
+    'B06': 'Dark Pink',
+    'F00': 'Red',
+    'B62': 'Dark blond',
+    'FFF': 'White',
+    '321': 'Dark',
+    '00F': 'Blue',
+    'FF0': 'Blond',
+    '0F0': 'Green',
+    'XXX': 'Unknown',
+    'A55': 'Brown',
+    '000': 'Black',
+    'CCC': 'Silver',
+    'F0F': 'Purple',
+    'F90': 'Orange',
+    'EB8': 'Strawberry blonde',
+    '888': 'Grey',
+    'FD0': 'Golden',
+    'D83': 'Bronze',
+    '765': 'Ash brown',
+};
+
+// Position images don't have human-readable names server-side.
+// The game presents them via window.GT.design.figures[1..12], which
+// returns localized labels (e.g. "Doggy", "69", "Cowgirl"). When the
+// runtime lookup fails we keep the bare number which is always accurate.
+const POSITION_FALLBACK_PREFIX = 'Pose ';
+
+export interface TraitMappingResult {
+    /** The display name of the trait value. */
+    label: string;
+    /** True when label came from window.GT, false when fallback was used. */
+    fromRuntime: boolean;
+}
+
+export class TraitMappings {
+
+    /**
+     * Look up the runtime color map from window.GT.design.colors.
+     * Returns null if the structure is not available (e.g. spec tests).
+     */
+    private static getRuntimeColorMap(): Record<string, string> | null {
+        try {
+            const w: any = typeof unsafeWindow !== 'undefined' ? unsafeWindow : (typeof window !== 'undefined' ? window : null);
+            if (!w) return null;
+            const map = w.GT?.design?.colors;
+            return (map && typeof map === 'object') ? map : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Look up the runtime figure map from window.GT.design.figures.
+     */
+    private static getRuntimeFigureMap(): Record<string, string> | null {
+        try {
+            const w: any = typeof unsafeWindow !== 'undefined' ? unsafeWindow : (typeof window !== 'undefined' ? window : null);
+            if (!w) return null;
+            const map = w.GT?.design?.figures;
+            return (map && typeof map === 'object') ? map : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /**
+     * Resolve a hex color code (eye or hair) to its readable name.
+     * Tries window.GT.design.colors first, falls back to English.
+     */
+    static resolveColor(hex: string | undefined | null): TraitMappingResult {
+        if (!hex) return { label: '?', fromRuntime: false };
+        const upper = String(hex).toUpperCase();
+        const runtime = TraitMappings.getRuntimeColorMap();
+        if (runtime && typeof runtime[upper] === 'string') {
+            return { label: runtime[upper], fromRuntime: true };
+        }
+        if (COLOR_FALLBACK_EN[upper]) {
+            return { label: COLOR_FALLBACK_EN[upper], fromRuntime: false };
+        }
+        return { label: '#' + upper, fromRuntime: false };
+    }
+
+    /**
+     * Resolve a position image (e.g. "2.png" or "2") to a readable label.
+     * Falls back to "Pose N" when runtime map is unavailable.
+     */
+    static resolvePosition(value: string | undefined | null): TraitMappingResult {
+        if (!value) return { label: '?', fromRuntime: false };
+        const num = String(value).replace(/\.png$/i, '').trim();
+        const runtime = TraitMappings.getRuntimeFigureMap();
+        if (runtime && typeof runtime[num] === 'string') {
+            return { label: runtime[num], fromRuntime: true };
+        }
+        return { label: POSITION_FALLBACK_PREFIX + num, fromRuntime: false };
+    }
+
+    /**
+     * Resolve a zodiac string (e.g. unicode-glyph + " Aries") to a readable name.
+     * Strips the unicode glyph prefix and returns just the English name.
+     */
+    static resolveZodiac(value: string | undefined | null): TraitMappingResult {
+        if (!value) return { label: '?', fromRuntime: false };
+        // Strip leading non-letter characters (glyph + variation selector + space)
+        const cleaned = String(value).replace(/^[^A-Za-z]+/, '').trim();
+        return { label: cleaned || String(value), fromRuntime: false };
+    }
+
+    /**
+     * Generic resolver: dispatch by trait category.
+     */
+    static resolve(category: 'eyeColor' | 'hairColor' | 'zodiac' | 'position', value: string | undefined | null): TraitMappingResult {
+        switch (category) {
+            case 'eyeColor':
+            case 'hairColor':
+                return TraitMappings.resolveColor(value);
+            case 'zodiac':
+                return TraitMappings.resolveZodiac(value);
+            case 'position':
+                return TraitMappings.resolvePosition(value);
+        }
+    }
+}


### PR DESCRIPTION
## v7.35.21 - League team algorithm rebuild + inspector tooling

Flat-history PR (no merge commit) replacing #1601.

### Algorithm rebuild (Issue #1573, supersedes the v7.35.20 interim attempt)

- Score by player main class stat alone (HC=carac1, Charm=carac2, KH=carac3) instead of stat sum
- Hard class filter: only own-class girls eligible
- Compare trait clusters by `main_sum * (1 + tier3 bonus)`
- Leader picked by tier-5 priority (Shield > Stun > Execute > Reflect)
- New `TraitMappings` service: hex/position/zodiac to readable labels via `window.GT.design` with English fallback
- No pool cap, every eligible girl is evaluated
- UI: readable trait names, class hint, equipment-free note
- Bumped to v7.35.21

### Inspector tooling (Issue #1580)

- `HHAuto_debug_inspector.user.js` for ad-hoc game data extraction
- `runtime-architecture.md` and `data-sources-inventory.md` docs

### Validation

- 73 team-spec tests pass
- Full suite: 534 passed, 8 skipped
- Build: clean