### PR TITLE
fix: leader picked globally + mode-diff detection (#1573, #1603)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.22
+// @version      7.35.23
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17314,22 +17314,32 @@ class TeamScoringService {
      * Rank leader candidates by element priority (Shield > Stun > Execute > Reflect).
      * Leader must be Mythic. Among same priority: prefer trait match, then highest stats.
      */
-    static rankLeaderCandidates(girls, statScores, traitCategory, traitValue) {
+    static rankLeaderCandidates(girls, statScores, traitCategory, traitValue, clusterElements) {
         const mythicGirls = girls.filter(g => g.rarity === 'mythic');
         if (mythicGirls.length === 0) {
-            return TeamScoringService._sortLeaderCandidates(girls, statScores, traitCategory, traitValue);
+            // Beginner pool: no mythics. Tier-5 priority is pointless because
+            // legendary girls never have active tier-5 skills (skill_points_used
+            // is 0). Pick cluster membership first, then trait match, then stats.
+            return TeamScoringService._sortLeaderCandidatesNoMythic(girls, statScores, traitCategory, traitValue, clusterElements);
         }
-        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue);
+        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue, clusterElements);
     }
-    static _sortLeaderCandidates(girls, statScores, traitCategory, traitValue) {
+    /**
+     * Sort leader candidates when no mythics are available.
+     * Order: cluster membership > trait match > stats.
+     * (Tier-5 priority is omitted because legendaries never have active tier-5 skills.)
+     */
+    static _sortLeaderCandidatesNoMythic(girls, statScores, traitCategory, traitValue, clusterElements) {
         return [...girls].sort((a, b) => {
-            const tier5A = ELEMENT_TO_TIER5[a.element];
-            const tier5B = ELEMENT_TO_TIER5[b.element];
-            // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect)
-            if (tier5A.priority !== tier5B.priority) {
-                return tier5B.priority - tier5A.priority;
+            // Primary: cluster membership
+            if (clusterElements && clusterElements.length > 0) {
+                const aInCluster = clusterElements.includes(a.element);
+                const bInCluster = clusterElements.includes(b.element);
+                if (aInCluster !== bInCluster) {
+                    return aInCluster ? -1 : 1;
+                }
             }
-            // Secondary: trait match bonus
+            // Secondary: trait match
             if (traitCategory && traitValue) {
                 const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
                 const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
@@ -17338,6 +17348,40 @@ class TeamScoringService {
                 }
             }
             // Tertiary: stat score
+            const scoreA = statScores.get(a.id_girl) || 0;
+            const scoreB = statScores.get(b.id_girl) || 0;
+            return scoreB - scoreA;
+        });
+    }
+    static _sortLeaderCandidates(girls, statScores, traitCategory, traitValue, clusterElements) {
+        return [...girls].sort((a, b) => {
+            const tier5A = ELEMENT_TO_TIER5[a.element];
+            const tier5B = ELEMENT_TO_TIER5[b.element];
+            // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect)
+            // Applied GLOBALLY across all mythics, NOT gated by the chosen cluster.
+            // A Mythic with Shield wins over a Mythic with Execute even if the
+            // Shield mythic is from a different element pair than the cluster.
+            if (tier5A.priority !== tier5B.priority) {
+                return tier5B.priority - tier5A.priority;
+            }
+            // Secondary: cluster membership (prefer leaders from the chosen
+            // trait cluster's element pair when tier-5 priority is equal).
+            if (clusterElements && clusterElements.length > 0) {
+                const aInCluster = clusterElements.includes(a.element);
+                const bInCluster = clusterElements.includes(b.element);
+                if (aInCluster !== bInCluster) {
+                    return aInCluster ? -1 : 1;
+                }
+            }
+            // Tertiary: trait match bonus
+            if (traitCategory && traitValue) {
+                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
+                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
+                if (aMatches !== bMatches) {
+                    return aMatches ? -1 : 1;
+                }
+            }
+            // Quaternary: stat score
             const scoreA = statScores.get(a.id_girl) || 0;
             const scoreB = statScores.get(b.id_girl) || 0;
             return scoreB - scoreA;
@@ -17468,6 +17512,8 @@ class TeamBuilderService {
                 }
             }
         }
+        const clusterElements = ELEMENT_PAIRS_MAP[traitCategory] || [];
+        const leaderInCluster = clusterElements.includes(leader.element);
         return {
             girls: team,
             statScores,
@@ -17483,19 +17529,32 @@ class TeamBuilderService {
             effectivePower: bestBuilt.power,
             alternatives,
             playerClass,
+            leaderInCluster,
         };
     }
     /**
      * Build a team for a specific trait group.
      *
-     * Pass 1: same element pair + matching trait value (max Tier-3 bonus).
-     * Pass 2: same element pair, any trait value (still keeps cluster).
-     * Pass 3: any element by score (last-resort fillers).
+     * Leader (position 1): picked GLOBALLY from all mythics by tier-5
+     * priority (Shield > Stun > Execute > Reflect). Cluster membership is
+     * only a tiebreaker among same-priority candidates. The leader's job
+     * is the defensive skill, not the trait-3 stack.
+     *
+     * Slots 2-7: cluster-bound to maximize the tier-3 bonus.
+     *   Pass 1: same element pair + matching trait value (max Tier-3 bonus).
+     *   Pass 2: same element pair, any trait value (still keeps cluster).
+     *   Pass 3: any element by score (last-resort fillers).
      */
     static _buildTeamForGroup(cat, val, pool, scoreMap) {
         const elems = ELEMENT_PAIRS_MAP[cat] || [];
-        const leaders = pool.filter(g => g.rarity === 'mythic' && elems.includes(g.element));
-        const ranked = TeamScoringService.rankLeaderCandidates(leaders.length > 0 ? leaders : pool, scoreMap, cat, val);
+        // Leader pool: ALL mythics globally (not gated by cluster).
+        // Cluster membership is passed as tiebreaker via clusterElements.
+        // If no mythics exist (beginner accounts), fall back to legendary
+        // candidates and let cluster membership become the primary
+        // discriminator since legendary tier-5 skills are typically empty.
+        const mythicPool = pool.filter(g => g.rarity === 'mythic');
+        const leaderCandidates = mythicPool.length > 0 ? mythicPool : pool;
+        const ranked = TeamScoringService.rankLeaderCandidates(leaderCandidates, scoreMap, cat, val, elems);
         if (ranked.length === 0)
             return null;
         const team = [ranked[0]];
@@ -18368,17 +18427,37 @@ class TeamModule {
                 blessingBonuses: g.blessing_bonuses || undefined,
             });
         });
-        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel, playerClass);
+        // Build BOTH modes so we can detect when "Best Possible" produces
+        // the same team as "Current Best" — this happens when the top 7
+        // girls are already at full development potential (max level + max
+        // grades). We then surface that fact in the info box instead of
+        // letting the user think the buttons are broken (issue #1603).
+        const resultMode1 = TeamBuilderService.buildTeam(girls, 1, playerLevel, playerClass);
+        const resultMode2 = TeamBuilderService.buildTeam(girls, 2, playerLevel, playerClass);
+        const result = mode === 1 ? resultMode1 : resultMode2;
         if (!result) {
             LogUtils_logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
             TeamModule.setTopTeamLegacy(mode);
             return;
         }
+        // Mode-diff detection: identical top-7 (any order) means the pool
+        // is already maximised and Best Possible cannot improve on Current
+        // Best. We set this flag on BOTH results so the UI can show it
+        // regardless of which mode the user clicked.
+        let modesIdentical = false;
+        if (resultMode1 && resultMode2) {
+            const ids1 = new Set(resultMode1.girls.map(g => g.id_girl));
+            const ids2 = new Set(resultMode2.girls.map(g => g.id_girl));
+            modesIdentical = ids1.size === ids2.size && [...ids1].every(id => ids2.has(id));
+        }
+        result.modesIdentical = modesIdentical;
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
         const distStr = dist.map(d => `${d.count}x ${d.element}`).join(', ');
-        LogUtils_logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}`);
+        const inClusterStr = result.leaderInCluster ? 'in-cluster' : 'cross-cluster';
+        const identStr = modesIdentical ? ', modes identical' : '';
+        LogUtils_logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
         // UI update: same approach as legacy — hide non-selected, show + number selected
         TeamModule.updateTeamUI(deckID, result);
     }
@@ -18524,24 +18603,39 @@ class TeamModule {
                 }).join(' | ')
                 : '';
             const fallbackNote = traitFromRuntime ? '' : '<div style="color:#fc6; font-size:10px;">Trait label uses fallback dictionary (game runtime not yet loaded -- may be inaccurate for new color codes).</div>';
+            const leaderClassName = TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element;
+            const leaderClusterNote = teamResult.leaderInCluster
+                ? ''
+                : '<div style="color:#fc6; font-size:10px;">Leader is from a different element pair than positions 2-7. The cluster constraint applies to slots 2-7 only; the leader is picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>';
+            const modesIdenticalNote = teamResult.modesIdentical
+                ? '<div style="color:#fc6; font-size:10px;">Best Possible matches Current Best -- your top 7 girls are already at full development potential (max level + max grades).</div>'
+                : '';
             const synergyInfo = $(`<div class="hhTeamSynergyInfo" style="
-                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 300px; z-index: 10;
+                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 320px; z-index: 10;
                 background: rgba(0,0,0,0.85); color: #fff; padding: 6px 10px;
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
                 <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+
+                <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
+                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>
+                <div style="color:#aaa; font-size:10px;">Picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>
+                ${leaderClusterNote}
+
+                <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Cluster (Positions 2-7)</div>
                 <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${traitDisplay}" (${teamResult.traitMatchCount}/7 girls match)</div>
                 <div style="color:#aaa; font-size:10px;">Tier 3 gives +stat% per teammate sharing this trait</div>
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
-                <div><b>Leader:</b> ${teamResult.girls[0].name} (${teamResult.leaderTier5.name} / ${TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element})</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${((_a = teamResult.effectivePower) === null || _a === void 0 ? void 0 : _a.toLocaleString()) || 'N/A'}</div>
+
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>
                 <div style="color:#aaa; font-size:10px;">${cachedBlessings ? "Cache: " + new Date(cachedBlessings.timestamp).toLocaleString() : "No cache - go to Home page to load"}</div>
                 ${altsHtml ? `<div style="color:#aaa; font-size:10px; margin-top:2px;">${altsHtml}</div>` : ''}
                 ${fallbackNote}
+                ${modesIdenticalNote}
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div style="color:#fc6; font-size:10px;"><b>Note:</b> Stats are equipment-free. Hit "Stuff Team" after applying.</div>
                 <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best) uses today's stats, Mode 2 (Best Possible) projects to max level / grades.</div>
@@ -24790,7 +24884,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.22";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.23";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,23 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.23 - Team leader fix and Best Possible / Current Best clarity
+
+Two related fixes for the team selection.
+
+**Leader pick now respects the tier-5 priority across the whole roster.**
+The Shield > Stun > Execute > Reflect order now applies to all your Mythics, not only those whose element matches the chosen cluster. If you own a Shield Mythic and the best cluster is something else (e.g. eye color), the Shield Mythic still goes into slot 1. Slots 2-7 keep filling from the cluster so the Tier-3 trait bonus stays maximised.
+
+The total team power may end up slightly lower than it would be with a higher-stat leader from the cluster. That is intentional: a Shield leader anchors a defensive skill that scales over the entire fight, which is more valuable than the few extra stat points a non-Shield leader would add.
+
+**Info box restructured into two clear blocks.**
+"Leader (Position 1)" and "Cluster (Positions 2-7)" are now separate sections, with a note explaining why the leader may be from a different element pair than the rest of the team.
+
+**Best Possible vs Current Best now tells you when both produce the same team.**
+If your top 7 girls are already at your level cap with full grades, both buttons mathematically pick the same team. The info box now says so plainly instead of looking like a silent bug.
+
+---
+
 ### v7.35.22 - Fix: "Forbidden" errors and event/league loop
 
 Two related fixes that address the wave of "Access forbidden" reports (issue #1598).

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -163,15 +163,29 @@ Drei Pass-Strategie pro Cluster:
 Pass 1 maximiert Tier-3-Match. Pass 2 haelt das Mono-Element-Bonus.
 Pass 3 ist nur Reserve, falls die Gruppe weniger als 7 Girls hat.
 
-### Phase 6: Leader
+### Phase 6: Leader (ab v7.35.23: global)
 
-Leader muss Mythic sein und idealerweise zum Cluster-Element-Paar gehoeren.
+Leader (Position 1) wird **global** gepickt, nicht Cluster-gebunden. Tier-5-Prio gilt fuer alle Mythics, unabhaengig von der Cluster-Wahl. Slots 2-7 bleiben weiterhin Cluster-gebunden (Phase 5).
 
 | Prioritaet | Kriterium |
 |-----------|----------|
-| 1 (primaer) | Tier-5-Skill: Shield(4) > Stun(3) > Execute(2) > Reflect(1) |
-| 2 (sekundaer) | Trait-Match (Leader teilt Cluster-Trait-Wert) |
-| 3 (tertiaer) | main_carac-Score |
+| 1 (primaer) | Mythic-Filter (mit Legendary-Fallback fuer Beginner-Pools) |
+| 2 (sekundaer) | Tier-5-Skill: Shield(4) > Stun(3) > Execute(2) > Reflect(1) - **GLOBAL** ueber alle Elemente |
+| 3 (tertiaer) | Cluster-Mitgliedschaft (Leader-Element gehoert zum Cluster-Paar) - Tiebreaker bei gleicher Tier-5-Prio |
+| 4 (quartaer) | Trait-Match (Leader teilt Cluster-Trait-Wert) |
+| 5 (final) | main_carac-Score |
+
+Beispiel: Cluster ist `eyeColor=Blue` (Element-Paar darkness+fire). Spieler hat eine Light-Mythic (Shield, Prio 4). Leader wird die Light-Mythic, obwohl sie nicht im Cluster ist - der Shield-Skill ist im Combat wichtiger als ein zusaetzlicher Trait-Match. Slots 2-7 bleiben darkness/fire-Girls aus dem Cluster.
+
+#### Sonderfall: Beginner-Pool ohne Mythics
+
+Wenn 0 Mythics existieren, faellt das Skript auf Legendary 5*-Girls zurueck. Da Legendaries praktisch nie aktive Tier-5-Skills haben (`skill_points_used == 0`), waere die Tier-5-Sortierung wirkungslos. Stattdessen gilt fuer Legendary-Leader:
+
+| Prioritaet | Kriterium |
+|-----------|----------|
+| 1 | Cluster-Mitgliedschaft |
+| 2 | Trait-Match |
+| 3 | main_carac-Score |
 
 | Element | Tier-5 Skill | Prioritaet |
 |---------|-------------|------------|
@@ -187,13 +201,15 @@ Info-Box (oben mittig, dunkel, halbtransparent):
 - Klassen-Hinweis: "Class: <Hardcore/Charm/Know-how> -- only X girls considered"
 - Trait optimiert: "[emoji] eyeColor = 'Blue' (4/7 girls match)"
 - Tier-3-Bonus: "+X.X% total stat boost"
-- Leader: Name + Tier-5-Skill + Element-Klasse
+- Leader-Block (Position 1): Name + Tier-5-Skill + Element-Klasse + Hinweis bei Cross-Cluster
+- Cluster-Block (Positions 2-7): Trait, Element-Paar, Tier-3-Bonus, Effective Power
 - Element-Verteilung: "Eccentric x3, Sensual x2, ..."
 - Effective Power
 - Active Blessings + Match-Indikator
 - Compared: Liste der evaluierten Cluster-Alternativen mit Power
 - Equipment-Hinweis: "Stats are equipment-free. Hit Stuff Team after applying."
 - Mode-Hinweis: aktueller Modus (Current Best vs. Best Possible)
+- Mode-Diff: Hinweis "Best Possible matches Current Best" wenn beide Modi dieselben Top-7-Girls liefern (Pool ist bereits voll entwickelt)
 
 Klar-Namen via `TraitMappings.resolve(category, value)`. Wenn der
 Runtime-Lookup fehlschlaegt (z.B. GT nicht geladen), erscheint ein

--- a/docs-internal/technical-reference-team-selection.md
+++ b/docs-internal/technical-reference-team-selection.md
@@ -1,5 +1,5 @@
 ---
-last-verified: 2026-05-05
+last-verified: 2026-05-06
 verified-against-version: 7.35.21
 status: current
 ---
@@ -7,7 +7,7 @@ status: current
 # Technical Reference: Team Selection Data & API
 
 Referenz-Doku zur Team-Auswahl. Adressiert Issues #1340 und #1573.
-Letzte vollstaendige Verifikation: 2026-05-05 gegen v7.35.21.
+Letzte vollstaendige Verifikation: 2026-05-06 gegen v7.35.23.
 
 ---
 
@@ -318,7 +318,7 @@ Der Team-Builder liest `caracs` direkt. **Kein Unequip noetig vor Score.** Ein U
 | `src/Service/TeamScoringService.ts` | `calculateTier3TeamBonus()` | Tier-3 Trait-Match-Bonus |
 | `src/Service/TeamScoringService.ts` | `findTraitGroups(girls, class, blessed?)` | gruppiere nach Element-Paar + gemeinsamem Trait-Wert |
 | `src/Service/TeamScoringService.ts` | `calculateSynergies()`, `calculateSynergyValue()` | Synergie-Berechnung (informational) |
-| `src/Service/TeamScoringService.ts` | `rankLeaderCandidates()` | Leader-Ranking: Mythic only, Tier-5-Prioritaet |
+| `src/Service/TeamScoringService.ts` | `rankLeaderCandidates()` | Leader-Ranking: Mythic only, Tier-5-Prioritaet GLOBAL, Cluster-Membership Tiebreaker (v7.35.23) |
 | `src/Service/TeamBuilderService.ts` | `buildTeam(girls, mode, level, playerClass)` | Haupt-Eintritt: Filter, Cluster-Vergleich, Leader, Slot-Fill |
 | `src/Service/TeamBuilderService.ts` | `getElementDistribution()` | Element-Counts fuer UI |
 | `src/Service/TraitMappings.ts` | `resolve(category, value)` | Hex/Position/Zodiac -> lesbares Label, Runtime + Fallback |
@@ -417,7 +417,8 @@ Process:
                                                   blessed Cluster bekommen x1.5 Score-Boost
   6. Top 5 Cluster + alle blessed Cluster evaluieren
   7. Pro Cluster: Team mit Leader + 6 Slot-Fills bauen
-     - Leader: Mythic, Tier-5 Shield(4) > Stun(3) > Execute(2) > Reflect(1)
+     - Leader: GLOBAL Mythic-Pool, Tier-5 Shield(4) > Stun(3) > Execute(2) > Reflect(1)
+                 + Cluster-Mitgliedschaft als Tiebreaker (ab v7.35.23)
      - Slot 2-7 in 3 Passes:
        Pass 1: Element-Paar + Trait-Match
        Pass 2: Element-Paar (irgendein Trait)
@@ -474,3 +475,4 @@ Die Cycles sind in `BDSMHelper.ELEMENTS` als `chance` (3 Elemente) und `egoDamag
 | v7.35.x | Hex-Mapping-Bug, BlessingService-Cache (`Temp_blessingsCache`), kleinere UI-Korrekturen. |
 | v7.35.20 | Interim-Versuch: simpler "Top 7 by stats with element-cluster tiebreaker". Wurde durch v7.35.21 ersetzt. |
 | v7.35.21 | v4-Algorithmus: main_carac-Score, Klassen-Filter, Klar-Namen via TraitMappings, Cluster-Vergleich nach effective Power, kein Pool-Cap, Equipment-Hinweis (Issues #1340, #1573). |
+| v7.35.23 | Leader global gepickt (Tier-5-Prio ueber alle Mythics, nicht Cluster-gefiltert); Slots 2-7 bleiben Cluster-bound. Mode-Diff-Detection: Hinweis wenn beide Modi gleiches Top-7 liefern. Info-Box in 2 Bloecke (Leader / Cluster). Beginner-Pool ohne Mythics: Legendary-Leader nach Cluster + Trait + Stat (Tier-5 deaktiviert da Legendaries keine aktiven Tier-5-Skills haben). Issues #1573, #1603. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.22",
+  "version": "7.35.23",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -223,6 +223,117 @@ describe('TeamBuilderService', () => {
             expect(result.girls[0]).toBeDefined();
             expect(['fire', 'darkness']).toContain(result.girls[0].element);
         });
+
+        it('should pick a Shield mythic globally even if cluster is eyeColor (cross-cluster leader)', () => {
+            // Cluster will be eyeColor=blue (lots of dark/fire girls).
+            // A single light mythic (Shield) exists. The new logic must
+            // pick it as leader despite being outside the cluster pair.
+            const eyeCluster = Array.from({ length: 8 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                eyeColor: 'blue',
+            }));
+            const lightShieldMythic = makeGirl({
+                id_girl: 999,
+                element: 'light',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 1000,        // lower stats, must still win
+                hairColor: 'blonde',
+            });
+            const result = TeamBuilderService.buildTeam([...eyeCluster, lightShieldMythic], 1, 100, 3)!;
+            expect(result.traitCategory).toBe('eyeColor');
+            expect(result.girls[0].id_girl).toBe(999);
+            expect(result.leaderTier5.name).toBe('Shield');
+            expect(result.leaderInCluster).toBe(false);
+        });
+
+        it('should fill positions 2-7 from the cluster even when leader is cross-cluster', () => {
+            const eyeCluster = Array.from({ length: 8 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                eyeColor: 'blue',
+            }));
+            const lightShieldMythic = makeGirl({
+                id_girl: 999,
+                element: 'light',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 1000,
+                hairColor: 'blonde',
+            });
+            const result = TeamBuilderService.buildTeam([...eyeCluster, lightShieldMythic], 1, 100, 3)!;
+            // Slots 2-7 must all be from the eyeColor cluster (fire or darkness)
+            for (let i = 1; i < 7; i++) {
+                expect(['fire', 'darkness']).toContain(result.girls[i].element);
+            }
+        });
+
+        it('should mark leaderInCluster=true when leader is from the chosen cluster pair', () => {
+            const hairCluster = Array.from({ length: 8 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'light' : 'nature',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                hairColor: 'blonde',
+            }));
+            const result = TeamBuilderService.buildTeam(hairCluster, 1, 100, 3)!;
+            expect(result.traitCategory).toBe('hairColor');
+            expect(result.leaderInCluster).toBe(true);
+        });
+
+        it('should fall back to legendaries for leader when no mythics exist (beginner pool)', () => {
+            // 8 legendary 5* girls, no mythics. Leader must come from this pool.
+            const legendaries = Array.from({ length: 8 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'legendary',
+                class: 3,
+                nb_grades: 5,
+                graded: 5,
+                carac3: 4000,
+                eyeColor: 'blue',
+            }));
+            const result = TeamBuilderService.buildTeam(legendaries, 1, 100, 3);
+            expect(result).not.toBeNull();
+            expect(result!.girls[0].rarity).toBe('legendary');
+        });
+
+        it('should prefer cluster legendary as leader when no mythics exist', () => {
+            // Cluster will be eyeColor=blue. Two legendary candidates with
+            // identical (zero) tier-5 priority: one in cluster (fire), one
+            // out of cluster (light). The cluster member must win.
+            const eyeCluster = Array.from({ length: 7 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: 'fire',
+                rarity: 'legendary',
+                class: 3,
+                nb_grades: 5,
+                graded: 5,
+                carac3: 4000,
+                eyeColor: 'blue',
+            }));
+            const lightLegendary = makeGirl({
+                id_girl: 999,
+                element: 'light',
+                rarity: 'legendary',
+                class: 3,
+                nb_grades: 5,
+                graded: 5,
+                carac3: 4000,
+                hairColor: 'blonde',
+            });
+            const result = TeamBuilderService.buildTeam([...eyeCluster, lightLegendary], 1, 100, 3)!;
+            // No mythics, no tier-5 differentiation -> cluster tiebreaker decides
+            expect(result.girls[0].element).toBe('fire');
+        });
     });
 
     describe('Mode 2: Best Possible', () => {
@@ -278,6 +389,7 @@ describe('TeamBuilderService', () => {
             effectivePower: 0,
             alternatives: [],
             playerClass: 3,
+            leaderInCluster: true,
         };
 
         it('should count elements correctly', () => {

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -498,7 +498,14 @@ export class TeamModule {
             blessingBonuses: g.blessing_bonuses || undefined,
         }));
 
-        const result = TeamBuilderService.buildTeam(girls, mode, playerLevel, playerClass);
+        // Build BOTH modes so we can detect when "Best Possible" produces
+        // the same team as "Current Best" — this happens when the top 7
+        // girls are already at full development potential (max level + max
+        // grades). We then surface that fact in the info box instead of
+        // letting the user think the buttons are broken (issue #1603).
+        const resultMode1 = TeamBuilderService.buildTeam(girls, 1, playerLevel, playerClass);
+        const resultMode2 = TeamBuilderService.buildTeam(girls, 2, playerLevel, playerClass);
+        const result = mode === 1 ? resultMode1 : resultMode2;
 
         if (!result) {
             logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
@@ -506,11 +513,25 @@ export class TeamModule {
             return;
         }
 
+        // Mode-diff detection: identical top-7 (any order) means the pool
+        // is already maximised and Best Possible cannot improve on Current
+        // Best. We set this flag on BOTH results so the UI can show it
+        // regardless of which mode the user clicked.
+        let modesIdentical = false;
+        if (resultMode1 && resultMode2) {
+            const ids1 = new Set(resultMode1.girls.map(g => g.id_girl));
+            const ids2 = new Set(resultMode2.girls.map(g => g.id_girl));
+            modesIdentical = ids1.size === ids2.size && [...ids1].every(id => ids2.has(id));
+        }
+        (result as any).modesIdentical = modesIdentical;
+
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
         const distStr = dist.map(d => `${d.count}x ${d.element}`).join(', ');
-        logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}`);
+        const inClusterStr = result.leaderInCluster ? 'in-cluster' : 'cross-cluster';
+        const identStr = modesIdentical ? ', modes identical' : '';
+        logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
 
         // UI update: same approach as legacy — hide non-selected, show + number selected
         TeamModule.updateTeamUI(deckID, result);
@@ -680,24 +701,40 @@ export class TeamModule {
 
             const fallbackNote = traitFromRuntime ? '' : '<div style="color:#fc6; font-size:10px;">Trait label uses fallback dictionary (game runtime not yet loaded -- may be inaccurate for new color codes).</div>';
 
+            const leaderClassName = TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element;
+            const leaderClusterNote = teamResult.leaderInCluster
+                ? ''
+                : '<div style="color:#fc6; font-size:10px;">Leader is from a different element pair than positions 2-7. The cluster constraint applies to slots 2-7 only; the leader is picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>';
+            const modesIdenticalNote = (teamResult as any).modesIdentical
+                ? '<div style="color:#fc6; font-size:10px;">Best Possible matches Current Best -- your top 7 girls are already at full development potential (max level + max grades).</div>'
+                : '';
+
             const synergyInfo = $(`<div class="hhTeamSynergyInfo" style="
-                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 300px; z-index: 10;
+                position: absolute; top: 60px; left: 50%; transform: translateX(-50%); width: 320px; z-index: 10;
                 background: rgba(0,0,0,0.85); color: #fff; padding: 6px 10px;
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
                 <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+
+                <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
+                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>
+                <div style="color:#aaa; font-size:10px;">Picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>
+                ${leaderClusterNote}
+
+                <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Cluster (Positions 2-7)</div>
                 <div><b>Trait optimized:</b> ${traitEmoji} ${teamResult.traitCategory} = "${traitDisplay}" (${teamResult.traitMatchCount}/7 girls match)</div>
                 <div style="color:#aaa; font-size:10px;">Tier 3 gives +stat% per teammate sharing this trait</div>
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
-                <div><b>Leader:</b> ${teamResult.girls[0].name} (${teamResult.leaderTier5.name} / ${TeamModule.CLASS_NAME[teamResult.girls[0].element] || teamResult.girls[0].element})</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${teamResult.effectivePower?.toLocaleString() || 'N/A'}</div>
+
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>
                 <div style="color:#aaa; font-size:10px;">${cachedBlessings ? "Cache: " + new Date(cachedBlessings.timestamp).toLocaleString() : "No cache - go to Home page to load"}</div>
                 ${altsHtml ? `<div style="color:#aaa; font-size:10px; margin-top:2px;">${altsHtml}</div>` : ''}
                 ${fallbackNote}
+                ${modesIdenticalNote}
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div style="color:#fc6; font-size:10px;"><b>Note:</b> Stats are equipment-free. Hit "Stuff Team" after applying.</div>
                 <div style="color:#aaa; font-size:10px; margin-top:2px;">Mode 1 (Current Best) uses today's stats, Mode 2 (Best Possible) projects to max level / grades.</div>

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.22";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.23";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -34,6 +34,7 @@ export interface TeamResult {
     effectivePower: number;        // main_sum * (1 + tier3Bonus)
     alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }>;
     playerClass: PlayerClass;       // 1=HC, 2=Charm, 3=KH (for UI display)
+    leaderInCluster: boolean;       // true if leader element belongs to the cluster pair
 }
 
 export type ScoringMode = 1 | 2;  // 1 = Current Best, 2 = Best Possible
@@ -153,6 +154,9 @@ export class TeamBuilderService {
             }
         }
 
+        const clusterElements = ELEMENT_PAIRS_MAP[traitCategory] || [];
+        const leaderInCluster = clusterElements.includes(leader.element);
+
         return {
             girls: team,
             statScores,
@@ -168,20 +172,33 @@ export class TeamBuilderService {
             effectivePower: bestBuilt.power,
             alternatives,
             playerClass,
+            leaderInCluster,
         };
     }
 
     /**
      * Build a team for a specific trait group.
      *
-     * Pass 1: same element pair + matching trait value (max Tier-3 bonus).
-     * Pass 2: same element pair, any trait value (still keeps cluster).
-     * Pass 3: any element by score (last-resort fillers).
+     * Leader (position 1): picked GLOBALLY from all mythics by tier-5
+     * priority (Shield > Stun > Execute > Reflect). Cluster membership is
+     * only a tiebreaker among same-priority candidates. The leader's job
+     * is the defensive skill, not the trait-3 stack.
+     *
+     * Slots 2-7: cluster-bound to maximize the tier-3 bonus.
+     *   Pass 1: same element pair + matching trait value (max Tier-3 bonus).
+     *   Pass 2: same element pair, any trait value (still keeps cluster).
+     *   Pass 3: any element by score (last-resort fillers).
      */
     private static _buildTeamForGroup(cat: TraitCategory, val: string, pool: GirlData[], scoreMap: Map<number, number>): GirlData[] | null {
         const elems = ELEMENT_PAIRS_MAP[cat] || [];
-        const leaders = pool.filter(g => g.rarity === 'mythic' && elems.includes(g.element));
-        const ranked = TeamScoringService.rankLeaderCandidates(leaders.length > 0 ? leaders : pool, scoreMap, cat, val);
+        // Leader pool: ALL mythics globally (not gated by cluster).
+        // Cluster membership is passed as tiebreaker via clusterElements.
+        // If no mythics exist (beginner accounts), fall back to legendary
+        // candidates and let cluster membership become the primary
+        // discriminator since legendary tier-5 skills are typically empty.
+        const mythicPool = pool.filter(g => g.rarity === 'mythic');
+        const leaderCandidates = mythicPool.length > 0 ? mythicPool : pool;
+        const ranked = TeamScoringService.rankLeaderCandidates(leaderCandidates, scoreMap, cat, val, elems);
         if (ranked.length === 0) return null;
 
         const team: GirlData[] = [ranked[0]];

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -425,31 +425,85 @@ export class TeamScoringService {
         girls: GirlData[],
         statScores: Map<number, number>,
         traitCategory?: TraitCategory,
-        traitValue?: string
+        traitValue?: string,
+        clusterElements?: ElementType[]
     ): GirlData[] {
         const mythicGirls = girls.filter(g => g.rarity === 'mythic');
         if (mythicGirls.length === 0) {
-            return TeamScoringService._sortLeaderCandidates(girls, statScores, traitCategory, traitValue);
+            // Beginner pool: no mythics. Tier-5 priority is pointless because
+            // legendary girls never have active tier-5 skills (skill_points_used
+            // is 0). Pick cluster membership first, then trait match, then stats.
+            return TeamScoringService._sortLeaderCandidatesNoMythic(girls, statScores, traitCategory, traitValue, clusterElements);
         }
-        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue);
+        return TeamScoringService._sortLeaderCandidates(mythicGirls, statScores, traitCategory, traitValue, clusterElements);
+    }
+
+    /**
+     * Sort leader candidates when no mythics are available.
+     * Order: cluster membership > trait match > stats.
+     * (Tier-5 priority is omitted because legendaries never have active tier-5 skills.)
+     */
+    private static _sortLeaderCandidatesNoMythic(
+        girls: GirlData[],
+        statScores: Map<number, number>,
+        traitCategory?: TraitCategory,
+        traitValue?: string,
+        clusterElements?: ElementType[]
+    ): GirlData[] {
+        return [...girls].sort((a, b) => {
+            // Primary: cluster membership
+            if (clusterElements && clusterElements.length > 0) {
+                const aInCluster = clusterElements.includes(a.element);
+                const bInCluster = clusterElements.includes(b.element);
+                if (aInCluster !== bInCluster) {
+                    return aInCluster ? -1 : 1;
+                }
+            }
+            // Secondary: trait match
+            if (traitCategory && traitValue) {
+                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
+                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
+                if (aMatches !== bMatches) {
+                    return aMatches ? -1 : 1;
+                }
+            }
+            // Tertiary: stat score
+            const scoreA = statScores.get(a.id_girl) || 0;
+            const scoreB = statScores.get(b.id_girl) || 0;
+            return scoreB - scoreA;
+        });
     }
 
     private static _sortLeaderCandidates(
         girls: GirlData[],
         statScores: Map<number, number>,
         traitCategory?: TraitCategory,
-        traitValue?: string
+        traitValue?: string,
+        clusterElements?: ElementType[]
     ): GirlData[] {
         return [...girls].sort((a, b) => {
             const tier5A = ELEMENT_TO_TIER5[a.element];
             const tier5B = ELEMENT_TO_TIER5[b.element];
 
             // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect)
+            // Applied GLOBALLY across all mythics, NOT gated by the chosen cluster.
+            // A Mythic with Shield wins over a Mythic with Execute even if the
+            // Shield mythic is from a different element pair than the cluster.
             if (tier5A.priority !== tier5B.priority) {
                 return tier5B.priority - tier5A.priority;
             }
 
-            // Secondary: trait match bonus
+            // Secondary: cluster membership (prefer leaders from the chosen
+            // trait cluster's element pair when tier-5 priority is equal).
+            if (clusterElements && clusterElements.length > 0) {
+                const aInCluster = clusterElements.includes(a.element);
+                const bInCluster = clusterElements.includes(b.element);
+                if (aInCluster !== bInCluster) {
+                    return aInCluster ? -1 : 1;
+                }
+            }
+
+            // Tertiary: trait match bonus
             if (traitCategory && traitValue) {
                 const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
                 const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
@@ -458,7 +512,7 @@ export class TeamScoringService {
                 }
             }
 
-            // Tertiary: stat score
+            // Quaternary: stat score
             const scoreA = statScores.get(a.id_girl) || 0;
             const scoreB = statScores.get(b.id_girl) || 0;
             return scoreB - scoreA;


### PR DESCRIPTION
Fixes #1573 and #1603.

## #1573 -- Leader pick was gated by the cluster element pair

The previous code filtered leader candidates to mythics from the cluster's element pair before applying tier-5 priority. That meant Shield (light/stone) could never win on an eyeColor cluster (darkness+fire) or a position cluster (water+sun), even though tier-5 priority was the documented #1 criterion.

**Change:** Leader is now picked **globally** by tier-5 priority across all mythics. Cluster membership becomes a tiebreaker, not a filter. Slots 2-7 remain cluster-bound for the tier-3 bonus.

**Trade-off:** When the leader is cross-cluster, the trait match count drops by 1 (e.g. 6/7 -> 5/7) in exchange for a defensive skill that scales over the entire fight.

**Beginner-pool case:** No mythics -> legendary leader picked by cluster > trait > stat (tier-5 skipped because legendaries never have active tier-5 skills).

## #1603 -- Current Best and Best Possible producing the same team

The Best Possible projection cancels out when a girl is already at the player's level cap with all grades. End-game players have most of their top-7 in that state, so both modes pick the same team. That is mathematically correct, but silent -- the user thinks the buttons are broken.

**Change:** Both modes are now computed on every click and the top-7 girl IDs compared (order-insensitive). When identical, the info box shows `Best Possible matches Current Best -- your top 7 girls are already at full development potential`.

**Cost:** One extra build per click. Single-digit ms, acceptable.

## UI

- Info box restructured into two clearly separated blocks: **Leader (Position 1)** and **Cluster (Positions 2-7)**
- Cross-cluster leader gets an explanatory line about the cluster constraint applying only to slots 2-7
- Mode-diff note appears when both modes converge

## Tests

- 5 new tests in `TeamBuilderService.spec.ts`:
  - cross-cluster Shield pick when cluster is eyeColor
  - slots 2-7 still cluster-bound when leader is cross-cluster
  - `leaderInCluster` flag correctly set
  - beginner pool falls back to legendary leader
  - legendary cluster member wins over cross-cluster legendary at tier-5 tie
- 539/547 tests green (was 534 + 5 new)
- Existing 73 team-spec tests untouched and passing

## Docs

- `team-algorithm-design.md` Phase 6 rewritten to match actual behaviour (was misleading: said tier-5 was Prio 1 globally, code did cluster gating)
- Phase 7 documents the two-block info box and the mode-diff note

## Version

- `package.json`, `HHAuto.user.js` -> 7.35.23
- `FeaturePopupService.ts` title bumped (popup gate kept at `0`, no announcement needed)
