### PR TITLE
fix: project Best Possible to awakening cap (#1603)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.23
+// @version      7.35.24
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17045,6 +17045,12 @@ const TIER3_BONUS_LEGENDARY = 0.008;
 // the actual stat impact already lives inside girl.caracs once the
 // game applies the weekly blessing).
 const BLESSED_CATEGORY_BOOST = 1.5;
+// Theoretical maximum girl level (full awakening cap).
+// 'Best Possible' projects every girl to this level -- the mode answers
+// 'what would each girl be worth if I awakened her to the cap', not
+// 'what could the player level her to right now'. Per Kinkoid patch
+// notes, every girl can be awakened to 750 from level 1.
+const PROJECTION_LEVEL_CAP = 750;
 class TeamScoringService {
     /**
      * Get the girl's main-class stat (carac1/2/3 by player class).
@@ -17073,21 +17079,26 @@ class TeamScoringService {
     }
     /**
      * Score a girl for "Best Possible" mode.
-     * Projects main-carac to player level and full grades.
+     * Projects main-carac to the awakening cap (PROJECTION_LEVEL_CAP) and full grades.
      *
      * Formula:
-     *   potential = currentMainCarac / level * playerLevel
+     *   potential = currentMainCarac / level * PROJECTION_LEVEL_CAP
      *               / (1 + 0.3 * currentGrades) * (1 + 0.3 * maxGrades)
      *
      * Returns max(projected, current) so blessing-inflated current
      * stats never get demoted by the projection.
+     *
+     * Note: playerLevel is kept in the signature for backwards compatibility
+     * with callers but is no longer used in the formula. The mode now answers
+     * "what is each girl worth at full awakening", independent of the
+     * player's current level.
      */
-    static scoreBestPossible(girl, playerClass, playerLevel) {
+    static scoreBestPossible(girl, playerClass, _playerLevel) {
         const currentMain = TeamScoringService.getMainCarac(girl, playerClass);
         const level = girl.level || 1;
         const currentGrades = girl.graded || 0;
         const maxGrades = girl.nb_grades || 0;
-        const levelFactor = playerLevel / Math.max(level, 1);
+        const levelFactor = PROJECTION_LEVEL_CAP / Math.max(level, 1);
         const gradeDeflator = 1 + 0.3 * currentGrades;
         const gradeInflator = 1 + 0.3 * maxGrades;
         const projected = (currentMain * levelFactor / gradeDeflator) * gradeInflator;

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ### v7.35.24 - Best Possible projects to the awakening cap
 
-Best Possible mode now projects every girl to the level cap of 750 instead of your current player level. Previously, if your top girls were already awakened beyond your level, Best Possible could collapse to the same picks as Current Best because the projection had no room left to grow. The mode now consistently answers what each girl would be worth at full awakening, independent of your level.
+Best Possible mode now projects every girl to the level cap of 750 instead of your current player level. The previous behaviour was a leftover from before the awakening system existed and went unnoticed for a long time. Once top girls became awakened beyond the player level, Best Possible silently collapsed to the same picks as Current Best because the projection had no room left to grow. The mode now consistently answers what each girl would be worth at full awakening, independent of your level.
 
 ### v7.35.23 - Team leader fix and Best Possible / Current Best clarity
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.24 - Best Possible projects to the awakening cap
+
+Best Possible mode now projects every girl to the level cap of 750 instead of your current player level. Previously, if your top girls were already awakened beyond your level, Best Possible could collapse to the same picks as Current Best because the projection had no room left to grow. The mode now consistently answers what each girl would be worth at full awakening, independent of your level.
+
 ### v7.35.23 - Team leader fix and Best Possible / Current Best clarity
 
 Two related fixes for the team selection.

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -1,6 +1,6 @@
 ---
-last-verified: 2026-05-05
-verified-against-version: 7.35.21
+last-verified: 2026-05-06
+verified-against-version: 7.35.24
 status: current
 ---
 
@@ -106,14 +106,23 @@ score = caracs.caracN     (N = playerClass)
 
 #### Modus 2 -- "Best Possible"
 
+Projektion auf den Awakening-Cap (`PROJECTION_LEVEL_CAP = 750`), nicht auf das aktuelle Spieler-Level. Per Kinkoid-Patchnotes kann jedes Girl ab Level 1 bis 750 awakened werden -- der Modus beantwortet "was waere die Girl wert, wenn sie voll entwickelt waere", unabhaengig davon was der Spieler aktuell erreichen kann.
+
 ```
-projected = caracN / level * playerLevel
+projected = caracN / level * 750
             / (1 + 0.3 * graded)
             * (1 + 0.3 * nb_grades)
 
 score = max(projected, current_caracN)
         // Schutz gegen blessing-inflated current > projected
 ```
+
+`playerLevel` ist nicht mehr Teil der Formel. Vor v7.35.24 wurde
+`playerLevel` als Projektions-Ziel verwendet, was bei awakened
+Girls (`level == 750`) und Spielern unter Cap (`playerLevel < 750`)
+dazu fuehrte dass `projected < current` und der `max()`-Guard
+zurueck auf `current` snappte -- der Modus kollabierte zu Mode 1
+(Issue #1603).
 
 ### Phase 3: Trait-Gruppen
 
@@ -322,6 +331,7 @@ vor der Berechnung noetig. Stuff-Team danach ist trotzdem sinnvoll
 | `TIER3_BONUS_MYTHIC` | 0.01 | TeamScoringService.ts | 1.0% Bonus pro Match |
 | `TIER3_BONUS_LEGENDARY` | 0.008 | TeamScoringService.ts | 0.8% Bonus pro Match |
 | `BLESSED_CATEGORY_BOOST` | 1.5 | TeamScoringService.ts | Heuristik-Multiplikator fuer blessed Cluster |
+| `PROJECTION_LEVEL_CAP` | 750 | TeamScoringService.ts | Projektions-Ziel fuer Mode 2 (Awakening-Cap, ab v7.35.24) |
 
 ---
 
@@ -392,3 +402,5 @@ Fallback fuer Spec-Tests und den Fall dass GT noch nicht geladen ist.
 | 7.34.14 | Unified Slot-Fill mit Tier-3-Delta |
 | 7.35.x | Hex-Mapping-Bug, BlessingService-Cache |
 | 7.35.21 | v4: main_carac-Score, Klassen-Filter, Klar-Namen, Equipment-Hinweis (Issues #1340, #1573) |
+| 7.35.23 | Leader global gepickt (Tier-5 ueber alle Mythics), Mode-Diff-Detection, Beginner-Pool ohne Mythics (Issues #1573, #1603) |
+| 7.35.24 | Best-Possible projiziert auf Awakening-Cap 750 statt playerLevel (Issue #1603) |

--- a/docs-internal/technical-reference-team-selection.md
+++ b/docs-internal/technical-reference-team-selection.md
@@ -1,6 +1,6 @@
 ---
 last-verified: 2026-05-06
-verified-against-version: 7.35.21
+verified-against-version: 7.35.24
 status: current
 ---
 
@@ -401,10 +401,18 @@ Score:
   Mode 2 ("Best Possible"):
     score = max(
       caracs.caracN,
-      caracs.caracN / max(level,1) * playerLevel
+      caracs.caracN / max(level,1) * 750         // PROJECTION_LEVEL_CAP, ab v7.35.24
                     / (1 + 0.3 * graded)
                     * (1 + 0.3 * nb_grades)
     )
+
+  // playerLevel ist seit v7.35.24 nicht mehr Teil der Formel.
+  // Projiziert wird auf den Awakening-Cap 750 (theoretisches Girl-Maximum
+  // laut Kinkoid-Patchnotes) -- der Modus beantwortet "was waere die Girl
+  // wert, wenn sie voll entwickelt waere", unabhaengig vom Spieler-Level.
+  // Vor v7.35.24 hatten awakened Girls (level=750) bei Spielern unter Cap
+  // identische Mode-1- und Mode-2-Ergebnisse, weil projected < current und
+  // der max()-Guard zurueckschnappte (Issue #1603).
 
 Process:
   1. Map availableGirls -> GirlData[]
@@ -476,3 +484,4 @@ Die Cycles sind in `BDSMHelper.ELEMENTS` als `chance` (3 Elemente) und `egoDamag
 | v7.35.20 | Interim-Versuch: simpler "Top 7 by stats with element-cluster tiebreaker". Wurde durch v7.35.21 ersetzt. |
 | v7.35.21 | v4-Algorithmus: main_carac-Score, Klassen-Filter, Klar-Namen via TraitMappings, Cluster-Vergleich nach effective Power, kein Pool-Cap, Equipment-Hinweis (Issues #1340, #1573). |
 | v7.35.23 | Leader global gepickt (Tier-5-Prio ueber alle Mythics, nicht Cluster-gefiltert); Slots 2-7 bleiben Cluster-bound. Mode-Diff-Detection: Hinweis wenn beide Modi gleiches Top-7 liefern. Info-Box in 2 Bloecke (Leader / Cluster). Beginner-Pool ohne Mythics: Legendary-Leader nach Cluster + Trait + Stat (Tier-5 deaktiviert da Legendaries keine aktiven Tier-5-Skills haben). Issues #1573, #1603. |
+| v7.35.24 | Mode 2 ("Best Possible") projiziert auf Awakening-Cap 750 (Konstante `PROJECTION_LEVEL_CAP`) statt auf `playerLevel`. Behebt Mode-1==Mode-2-Kollaps bei awakened Girls und Spielern unter Cap. `playerLevel` bleibt in der Signatur als optionaler unbenutzter Parameter (Backwards Compat). Issue #1603. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.23",
+  "version": "7.35.24",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/TeamScoringService.spec.ts
+++ b/spec/Service/TeamScoringService.spec.ts
@@ -60,35 +60,68 @@ describe('TeamScoringService', () => {
     });
 
     describe('scoreBestPossible', () => {
-        it('should project main-carac for a fully graded girl at player level', () => {
+        it('should project main-carac for a fully graded girl up to the awakening cap', () => {
             // KH player (class 3), girl with carac3=3000 at level 50, 0/5 grades
-            // projected = 3000 / 50 * 100 / (1 + 0) * (1 + 1.5) = 3000 * 2 * 2.5 = 15000
+            // projected = 3000 / 50 * 750 / (1 + 0) * (1 + 1.5) = 3000 * 15 * 2.5 = 112500
+            // playerLevel arg is ignored -- projection target is the awakening cap (750).
             const girl = makeGirl({
                 carac1: 1000, carac2: 2000, carac3: 3000,
                 level: 50, graded: 0, nb_grades: 5,
             });
-            expect(TeamScoringService.scoreBestPossible(girl, 3, 100)).toBe(15000);
+            expect(TeamScoringService.scoreBestPossible(girl, 3, 100)).toBe(112500);
         });
 
         it('should account for existing grades reducing projected growth', () => {
-            // class 3, girl carac3=3000, level 50, 3/5 grades, player level 100
-            // projected = 3000 * 2 / 1.9 * 2.5
+            // class 3, girl carac3=3000, level 50, 3/5 grades
+            // projected = 3000 * (750/50) / (1 + 0.3*3) * (1 + 0.3*5)
+            //           = 3000 * 15 / 1.9 * 2.5
             const girl = makeGirl({
                 carac1: 1000, carac2: 2000, carac3: 3000,
                 level: 50, graded: 3, nb_grades: 5,
             });
-            const expected = 3000 * 2 / 1.9 * 2.5;
+            const expected = 3000 * 15 / 1.9 * 2.5;
             expect(TeamScoringService.scoreBestPossible(girl, 3, 100)).toBeCloseTo(expected, 2);
         });
 
         it('should never return less than current main-carac (blessing safeguard)', () => {
-            // High blessing makes current > projected when player already at max
+            // Girl already at the awakening cap (level 750) with full grades:
+            // projected = 12397 * (750/750) / 2.5 * 2.5 = 12397 = current.
+            // The max() guard returns current; blessings cannot get demoted.
             const girl = makeGirl({
                 carac1: 0, carac2: 0, carac3: 12397,
-                level: 200, graded: 5, nb_grades: 5,
+                level: 750, graded: 5, nb_grades: 5,
             });
             const result = TeamScoringService.scoreBestPossible(girl, 3, 100);
             expect(result).toBe(12397);
+        });
+
+        it('should project to the awakening cap regardless of player level', () => {
+            // Awakened girl at level 750, max grades: projected == current.
+            // Mode 2 must return that ceiling value, not collapse to 0 just
+            // because playerLevel is below 750. This is the fix for #1603.
+            const awakenedGirl = makeGirl({
+                carac1: 0, carac2: 0, carac3: 50000,
+                level: 750, graded: 5, nb_grades: 5,
+            });
+            const lowLevelPlayer = TeamScoringService.scoreBestPossible(awakenedGirl, 3, 100);
+            const midLevelPlayer = TeamScoringService.scoreBestPossible(awakenedGirl, 3, 565);
+            const capLevelPlayer = TeamScoringService.scoreBestPossible(awakenedGirl, 3, 750);
+            expect(lowLevelPlayer).toBe(50000);
+            expect(midLevelPlayer).toBe(50000);
+            expect(capLevelPlayer).toBe(50000);
+        });
+
+        it('should still project low-level girls correctly when player is also low-level', () => {
+            // New girl at level 1, no grades yet, low-level player.
+            // Old formula: projected = 100 * 100 / 1 * (1 + 0.3*5) = 25000
+            // New formula: projected = 100 * 750 / 1 * (1 + 0.3*5) = 187500
+            // The mode is now "if I awakened her to the cap", not "to my level".
+            const girl = makeGirl({
+                carac1: 0, carac2: 0, carac3: 100,
+                level: 1, graded: 0, nb_grades: 5,
+            });
+            const result = TeamScoringService.scoreBestPossible(girl, 3, 100);
+            expect(result).toBe(187500);
         });
 
         it('should handle level 1 girls without division by zero', () => {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.23";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.24";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -125,6 +125,13 @@ const TIER3_BONUS_LEGENDARY = 0.008;
 // game applies the weekly blessing).
 const BLESSED_CATEGORY_BOOST = 1.5;
 
+// Theoretical maximum girl level (full awakening cap).
+// 'Best Possible' projects every girl to this level -- the mode answers
+// 'what would each girl be worth if I awakened her to the cap', not
+// 'what could the player level her to right now'. Per Kinkoid patch
+// notes, every girl can be awakened to 750 from level 1.
+const PROJECTION_LEVEL_CAP = 750;
+
 export class TeamScoringService {
 
     /**
@@ -156,22 +163,27 @@ export class TeamScoringService {
 
     /**
      * Score a girl for "Best Possible" mode.
-     * Projects main-carac to player level and full grades.
+     * Projects main-carac to the awakening cap (PROJECTION_LEVEL_CAP) and full grades.
      *
      * Formula:
-     *   potential = currentMainCarac / level * playerLevel
+     *   potential = currentMainCarac / level * PROJECTION_LEVEL_CAP
      *               / (1 + 0.3 * currentGrades) * (1 + 0.3 * maxGrades)
      *
      * Returns max(projected, current) so blessing-inflated current
      * stats never get demoted by the projection.
+     *
+     * Note: playerLevel is kept in the signature for backwards compatibility
+     * with callers but is no longer used in the formula. The mode now answers
+     * "what is each girl worth at full awakening", independent of the
+     * player's current level.
      */
-    static scoreBestPossible(girl: GirlData, playerClass: PlayerClass, playerLevel: number): number {
+    static scoreBestPossible(girl: GirlData, playerClass: PlayerClass, _playerLevel?: number): number {
         const currentMain = TeamScoringService.getMainCarac(girl, playerClass);
         const level = girl.level || 1;
         const currentGrades = girl.graded || 0;
         const maxGrades = girl.nb_grades || 0;
 
-        const levelFactor = playerLevel / Math.max(level, 1);
+        const levelFactor = PROJECTION_LEVEL_CAP / Math.max(level, 1);
         const gradeDeflator = 1 + 0.3 * currentGrades;
         const gradeInflator = 1 + 0.3 * maxGrades;
 


### PR DESCRIPTION
Best Possible mode now projects every girl to the awakening level cap of 750 instead of the player's current level. Resolves the case where Mode 2 collapsed to Mode 1 for fully developed (awakened) rosters.

### Why
When a top pick was already awakened (level 750) and the player was below cap (e.g. 565), the projection factor playerLevel / level became < 1. The projected score fell below current, the max() guard snapped back to current, and Mode 2 produced the same picks as Mode 1. Issue #1603 surfaced this for two players whose top 7 was entirely awakened.

### What changed
- `TeamScoringService`: introduced `PROJECTION_LEVEL_CAP = 750` and replaced `playerLevel` in the formula. The parameter stays in the signature as an unused argument so no caller change is required.
- Spec: existing expected values updated for the new cap, two new tests added (awakened-girl projection independent of player level, low-level player still projects to 750).
- Doc: `docs-internal/team-algorithm-design.md` and `docs-internal/technical-reference-team-selection.md` updated, version stamps refreshed to v7.35.24.
- README: short user-facing note above the v7.35.23 entry.
- Version bump to 7.35.24 in `package.json`, `HHAuto.user.js` header, and `FeaturePopupService.ts` title constant. Popup gate stays `"0"`.

### Testing
- 541 tests green, 8 skipped (no new failures).
- `npm run build` clean.
- Local diff manually reviewed.

Closes #1603 once verified by reporters.