### PR TITLE
fix: mythic coverage, leader picked after slots 2-7, richer info box (#1573, #1603)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.24
+// @version      7.35.25
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17414,19 +17414,26 @@ class TeamScoringService {
 // TeamBuilderService.ts -- Builds optimal 7-girl teams using Tier 3
 // trait-group optimization (v4).
 //
-// Algorithm:
+// Algorithm (since v7.35.25):
 //   1. Hard-filter to Mythic + Legendary 5-star, player class only
 //   2. Score by player main-carac (current or projected)
 //   3. Find best trait group (element pair + shared trait value)
 //      compared by main_sum * (1 + tier3Bonus)
-//   4. Select Mythic leader (Shield/Stun priority)
-//   5. Fill slots 2-7 from trait group, then by main-carac
+//   4. Fill positions 2-7 first (6 slots), in this order:
+//        Pass 1  cluster element-pair + matching trait value
+//        Pass 2  cluster element-pair, any trait value
+//        Pass 2a all remaining MYTHICS outside the cluster
+//                (so strong mythics are never ignored, issue #1603)
+//        Pass 3  legendaries outside the cluster (last resort)
+//   5. Pick the leader from the remaining pool (issue #1573):
+//        Mythic preferred, tier-5 priority Shield > Stun > Execute > Reflect,
+//        cluster membership and trait match as tiebreakers, stats last.
+//   6. Audit every mythic in the player's class for the UI: position
+//      in the team, or the reason why it was excluded (other cluster,
+//      lower stats than top picks, ...).
 
 const TEAM_SIZE = 7;
-// No pool cap: the Mythic + Legendary-5* filter is already strict
-// (max ~170 girls per class even if a player owned every released one).
-// Capping here would only risk excluding viable mythics on edge cases.
-// CANDIDATE_POOL_SIZE removed in v7.35.21.
+const POS_2_TO_7 = 6; // slots filled before the leader
 // Map trait category to its element pair for quick lookup
 const ELEMENT_PAIRS_MAP = {
     'eyeColor': ['darkness', 'fire'],
@@ -17440,7 +17447,7 @@ class TeamBuilderService {
      *
      * @param allGirls    - All available girls (from availableGirls)
      * @param mode        - 1 = Current Best, 2 = Best Possible
-     * @param playerLevel - Player's current level (needed for mode 2)
+     * @param playerLevel - Player's current level (kept for legacy callers; not used in scoring)
      * @param playerClass - Player's class (1=HC, 2=Charm, 3=KH)
      * @returns TeamResult with the selected 7 girls, or null if not enough girls
      */
@@ -17458,14 +17465,12 @@ class TeamBuilderService {
                 : TeamScoringService.scoreBestPossible(girl, playerClass, playerLevel);
             scoreMap.set(girl.id_girl, score);
         }
-        // Pre-sort and pick a reasonable candidate pool
-        // Sort by score; no cap -- evaluate every eligible girl
+        // Sort by score; no cap -- evaluate every eligible girl.
         const pool = [...candidates].sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
         // Phase 2b: Detect active blessings (informational + heuristic)
         const { blessedCategories, blessedGirlCount } = TeamScoringService.detectBlessedTraits(candidates);
         // Phase 3: Build teams for multiple trait groups, pick highest effective power
         const traitGroups = TeamScoringService.findTraitGroups(pool, playerClass, blessedCategories);
-        // Evaluate top groups + all blessed groups
         const groupsToEvaluate = [];
         const seenKeys = new Set();
         for (const g of traitGroups.slice(0, 5)) {
@@ -17487,7 +17492,6 @@ class TeamBuilderService {
         if (groupsToEvaluate.length === 0 && traitGroups.length > 0) {
             groupsToEvaluate.push(traitGroups[0]);
         }
-        // Build a team for each group and compare effective power
         let bestBuilt = null;
         const alternatives = [];
         for (const group of groupsToEvaluate) {
@@ -17525,6 +17529,7 @@ class TeamBuilderService {
         }
         const clusterElements = ELEMENT_PAIRS_MAP[traitCategory] || [];
         const leaderInCluster = clusterElements.includes(leader.element);
+        const mythicAudit = TeamBuilderService._buildMythicAudit(allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass);
         return {
             girls: team,
             statScores,
@@ -17541,70 +17546,232 @@ class TeamBuilderService {
             alternatives,
             playerClass,
             leaderInCluster,
+            mythicAudit,
         };
     }
     /**
      * Build a team for a specific trait group.
      *
-     * Leader (position 1): picked GLOBALLY from all mythics by tier-5
-     * priority (Shield > Stun > Execute > Reflect). Cluster membership is
-     * only a tiebreaker among same-priority candidates. The leader's job
-     * is the defensive skill, not the trait-3 stack.
+     * Order changed in v7.35.25 (issue #1573, Frank's request):
+     *   1. Fill positions 2-7 first (6 slots) using the four-pass logic.
+     *   2. Pick the leader from the remaining pool.
      *
-     * Slots 2-7: cluster-bound to maximize the tier-3 bonus.
-     *   Pass 1: same element pair + matching trait value (max Tier-3 bonus).
-     *   Pass 2: same element pair, any trait value (still keeps cluster).
-     *   Pass 3: any element by score (last-resort fillers).
+     * Pass logic for positions 2-7:
+     *   Pass 1  cluster element-pair AND matching trait value (max tier-3)
+     *   Pass 2  cluster element-pair (any trait value, keeps mono-element)
+     *   Pass 2a all remaining MYTHICS outside the cluster (NEW, issue #1603)
+     *   Pass 3  any remaining girls by score (legendary fillers)
+     *
+     * Leader (position 1): mythic preferred, tier-5 priority
+     * (Shield > Stun > Execute > Reflect), cluster membership and trait
+     * match as tiebreakers.
      */
     static _buildTeamForGroup(cat, val, pool, scoreMap) {
         const elems = ELEMENT_PAIRS_MAP[cat] || [];
-        // Leader pool: ALL mythics globally (not gated by cluster).
-        // Cluster membership is passed as tiebreaker via clusterElements.
-        // If no mythics exist (beginner accounts), fall back to legendary
-        // candidates and let cluster membership become the primary
-        // discriminator since legendary tier-5 skills are typically empty.
-        const mythicPool = pool.filter(g => g.rarity === 'mythic');
-        const leaderCandidates = mythicPool.length > 0 ? mythicPool : pool;
+        // Build BOTH strategies, score them, pick the higher Effective Power.
+        // Avoids rainbow teams when cluster-only fill gives a better
+        // tier-3 chain than mythic-priority fill (and vice versa).
+        const variantA = TeamBuilderService._buildVariant(elems, cat, val, pool, scoreMap, 'cluster-first');
+        const variantB = TeamBuilderService._buildVariant(elems, cat, val, pool, scoreMap, 'mythic-first');
+        if (!variantA && !variantB)
+            return null;
+        if (!variantA)
+            return variantB;
+        if (!variantB)
+            return variantA;
+        const epA = TeamBuilderService._effectivePower(variantA, scoreMap);
+        const epB = TeamBuilderService._effectivePower(variantB, scoreMap);
+        return epA >= epB ? variantA : variantB;
+    }
+    /**
+     * Build one variant (slot-fill strategy + leader swap).
+     */
+    static _buildVariant(elems, cat, val, pool, scoreMap, strategy) {
+        const slots = TeamBuilderService._fillSlotsTwoToSeven(elems, val, pool, scoreMap, strategy);
+        if (slots.length < POS_2_TO_7)
+            return null;
+        const usedIds = new Set(slots.map(g => g.id_girl));
+        const remaining = pool.filter(g => !usedIds.has(g.id_girl));
+        if (remaining.length === 0)
+            return null;
+        // Leader swap: if no mythic is left in the pool but slots contain
+        // mythics AND legendaries are available, swap the weakest slot
+        // mythic out and use it as leader. Guarantees a mythic leader
+        // whenever any mythic exists (Frank's request).
+        const remainingMythic = remaining.find(g => g.rarity === 'mythic');
+        let leaderCandidates = remaining;
+        let workingSlots = slots;
+        if (!remainingMythic) {
+            const slotMythics = slots.filter(g => g.rarity === 'mythic');
+            const remainingLegendary = remaining.find(g => g.rarity === 'legendary');
+            if (slotMythics.length > 0 && remainingLegendary) {
+                const weakestSlotMythic = slotMythics
+                    .slice()
+                    .sort((a, b) => (scoreMap.get(a.id_girl) || 0) - (scoreMap.get(b.id_girl) || 0))[0];
+                const strongestRemainingLegendary = remaining
+                    .filter(g => g.rarity === 'legendary')
+                    .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0))[0];
+                workingSlots = slots.map(g => g.id_girl === weakestSlotMythic.id_girl ? strongestRemainingLegendary : g);
+                leaderCandidates = [weakestSlotMythic];
+            }
+            else {
+                leaderCandidates = remaining;
+            }
+        }
+        else {
+            leaderCandidates = remaining.filter(g => g.rarity === 'mythic');
+        }
         const ranked = TeamScoringService.rankLeaderCandidates(leaderCandidates, scoreMap, cat, val, elems);
         if (ranked.length === 0)
             return null;
-        const team = [ranked[0]];
-        const used = new Set([ranked[0].id_girl]);
-        // Pass 1: matching trait value AND correct element
-        const pass1 = pool
-            .filter(g => !used.has(g.id_girl) && elems.includes(g.element) && TeamScoringService.getTraitValue(g) === val)
-            .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-        for (const g of pass1) {
-            if (team.length >= TEAM_SIZE)
-                break;
-            team.push(g);
-            used.add(g.id_girl);
-        }
-        // Pass 2: correct element, any trait value
-        if (team.length < TEAM_SIZE) {
-            const pass2 = pool
-                .filter(g => !used.has(g.id_girl) && elems.includes(g.element))
-                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-            for (const g of pass2) {
-                if (team.length >= TEAM_SIZE)
+        return [ranked[0], ...workingSlots];
+    }
+    /**
+     * Compute Effective Power = main_sum * (1 + tier3Bonus) for a built team.
+     */
+    static _effectivePower(team, scoreMap) {
+        const sum = team.reduce((s, g) => s + (scoreMap.get(g.id_girl) || 0), 0);
+        const t3 = TeamScoringService.calculateTier3TeamBonus(team);
+        return sum * (1 + t3);
+    }
+    /**
+     * Fill positions 2-7 (6 slots) using a pass-based strategy.
+     *
+     * Two variants are produced and the caller compares Effective Power.
+     *
+     * mythic-first: cluster mythics, then cross-cluster mythics, then
+     *               cluster legendaries, then any. Prefers mythic
+     *               coverage even at the cost of Tier-3 bonus.
+     * cluster-first: cluster mythics, then cluster legendaries, then
+     *                cross-cluster mythics, then any. Prefers Tier-3
+     *                bonus even if some mythics are skipped.
+     *
+     * The caller (see _buildTeamForGroup) computes Effective Power
+     * (main_sum * (1 + tier3Bonus)) for both variants and keeps the
+     * better one. That way rainbow teams only happen when they
+     * actually beat the cluster team on raw effective power.
+     */
+    static _fillSlotsTwoToSeven(elems, val, pool, scoreMap, strategy = 'cluster-first') {
+        const team = [];
+        const used = new Set();
+        const byScoreDesc = (a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0);
+        const fillPass = (predicate) => {
+            const candidates = pool
+                .filter(g => !used.has(g.id_girl) && predicate(g))
+                .sort(byScoreDesc);
+            for (const g of candidates) {
+                if (team.length >= POS_2_TO_7)
                     break;
                 team.push(g);
                 used.add(g.id_girl);
             }
+        };
+        // Step 1 (both strategies): cluster mythics with trait match.
+        // These are the strongest contributors and never hurt either way.
+        fillPass(g => g.rarity === 'mythic'
+            && elems.includes(g.element)
+            && TeamScoringService.getTraitValue(g) === val);
+        // Step 2 (both): cluster mythics with any trait value.
+        if (team.length < POS_2_TO_7) {
+            fillPass(g => g.rarity === 'mythic' && elems.includes(g.element));
         }
-        // Pass 3: any element by score
-        if (team.length < TEAM_SIZE) {
-            const pass3 = pool
-                .filter(g => !used.has(g.id_girl))
-                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-            for (const g of pass3) {
-                if (team.length >= TEAM_SIZE)
-                    break;
-                team.push(g);
-                used.add(g.id_girl);
+        if (strategy === 'mythic-first') {
+            // Step 3a: cross-cluster mythics before any legendary.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => g.rarity === 'mythic');
+            }
+            // Step 4a: cluster legendaries with trait match.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element)
+                    && TeamScoringService.getTraitValue(g) === val);
+            }
+            // Step 5a: cluster legendaries any trait.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element));
             }
         }
-        return team.length >= TEAM_SIZE ? team : null;
+        else {
+            // Cluster-first: keep Tier-3 chain intact before mixing in
+            // cross-cluster mythics.
+            // Step 3b: cluster legendaries with trait match.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element)
+                    && TeamScoringService.getTraitValue(g) === val);
+            }
+            // Step 4b: cluster legendaries any trait.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element));
+            }
+            // Step 5b: cross-cluster mythics.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => g.rarity === 'mythic');
+            }
+        }
+        // Step 6 (both): any remaining girls by score.
+        if (team.length < POS_2_TO_7) {
+            fillPass(() => true);
+        }
+        return team;
+    }
+    /**
+     * Build the mythic audit list shown in the UI.
+     */
+    static _buildMythicAudit(allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass) {
+        const teamIds = new Map();
+        team.forEach((g, idx) => teamIds.set(g.id_girl, idx + 1));
+        const entries = [];
+        for (const girl of allGirls) {
+            if (girl.rarity !== 'mythic')
+                continue;
+            const mainCarac = TeamScoringService.getMainCarac(girl, playerClass);
+            const pos = teamIds.get(girl.id_girl);
+            if (pos === 1) {
+                entries.push({
+                    id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                    mainCarac, status: 'leader', position: 1,
+                });
+                continue;
+            }
+            if (pos !== undefined) {
+                entries.push({
+                    id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                    mainCarac, status: 'pos2to7', position: pos,
+                });
+                continue;
+            }
+            let reason;
+            if (typeof girl.class === 'number' && girl.class !== playerClass) {
+                reason = 'wrong class (filtered out)';
+            }
+            else {
+                const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+                const girlValue = TeamScoringService.getTraitValue(girl);
+                if (girlCategory === traitCategory && girlValue === traitValue) {
+                    reason = 'same trait, lower stats than top picks';
+                }
+                else if (clusterElements.includes(girl.element)) {
+                    reason = 'cluster element, different trait value: '
+                        + girlCategory + '=' + (girlValue || '?');
+                }
+                else {
+                    reason = 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
+                }
+            }
+            entries.push({
+                id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                mainCarac, status: 'excluded', reason,
+            });
+        }
+        entries.sort((a, b) => {
+            const aIn = a.status !== 'excluded';
+            const bIn = b.status !== 'excluded';
+            if (aIn !== bIn)
+                return aIn ? -1 : 1;
+            if (aIn && bIn)
+                return (a.position || 99) - (b.position || 99);
+            return b.mainCarac - a.mainCarac;
+        });
+        return entries;
     }
     /**
      * Get a summary of element distribution in the team.
@@ -18607,6 +18774,21 @@ class TeamModule {
             const blessedIsActive = cachedBlessings && cachedBlessings.blessedTraits.includes(teamResult.traitCategory);
             const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
+            // Mythic audit (issue #1573, #1603): show every mythic in the
+            // player's class with its team status. Excluded mythics get a
+            // reason so the user can confirm whether the algorithm or the
+            // data is at fault.
+            const auditEntries = teamResult.mythicAudit || [];
+            const auditInTeam = auditEntries.filter((e) => e.status !== 'excluded');
+            const auditExcluded = auditEntries.filter((e) => e.status === 'excluded');
+            const auditTotalLine = `${auditEntries.length} mythics in your harem (player class): ${auditInTeam.length} in team, ${auditExcluded.length} excluded`;
+            const auditExcludedHtml = auditExcluded.length > 0
+                ? '<div style="color:#aaa; font-size:10px; margin-top:2px; max-height:120px; overflow-y:auto; border:1px solid #444; padding:3px;">'
+                    + '<b>Excluded mythics:</b><br/>'
+                    + auditExcluded.slice(0, 20).map((e) => `&bull; ${e.name} (${e.element}, stat=${Math.round(e.mainCarac)}): ${e.reason || 'unknown'}`).join('<br/>')
+                    + (auditExcluded.length > 20 ? `<br/>... and ${auditExcluded.length - 20} more` : '')
+                    + '</div>'
+                : '';
             const altsHtml = teamResult.alternatives && teamResult.alternatives.length > 1
                 ? '<b>Compared:</b> ' + teamResult.alternatives.map((a) => {
                     const r = TraitMappings.resolve(a.traitCategory, a.traitValue);
@@ -18640,6 +18822,11 @@ class TeamModule {
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${((_a = teamResult.effectivePower) === null || _a === void 0 ? void 0 : _a.toLocaleString()) || 'N/A'}</div>
+
+                <hr style="border-color:#555; margin:4px 0"/>
+                <div style="color:#ffb827; font-weight:bold;">Mythic Audit</div>
+                <div style="color:#aaa; font-size:10px;">${auditTotalLine}</div>
+                ${auditExcludedHtml}
 
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>
@@ -24895,7 +25082,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.23";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.25";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -17530,6 +17530,13 @@ class TeamBuilderService {
         const clusterElements = ELEMENT_PAIRS_MAP[traitCategory] || [];
         const leaderInCluster = clusterElements.includes(leader.element);
         const mythicAudit = TeamBuilderService._buildMythicAudit(allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass);
+        // Sum of the player's main carac across the 7 team girls.
+        // This is the league-relevant headline number: in the BDSM stat
+        // formulas (Slynia Performance Handbook), TeamPower is summed
+        // across all caracs of all girls, but only the main class stat
+        // matters for the player's combat math. We log the main_sum so
+        // the user can verify the algorithm's optimization target.
+        const mainSum = team.reduce((acc, g) => acc + TeamScoringService.getMainCarac(g, playerClass), 0);
         return {
             girls: team,
             statScores,
@@ -17546,6 +17553,7 @@ class TeamBuilderService {
             alternatives,
             playerClass,
             leaderInCluster,
+            mainSum,
             mythicAudit,
         };
     }
@@ -18629,13 +18637,26 @@ class TeamModule {
             modesIdentical = ids1.size === ids2.size && [...ids1].every(id => ids2.has(id));
         }
         result.modesIdentical = modesIdentical;
+        // Remember main sum per mode so the info box can show a
+        // mode-vs-mode delta (Current Best vs Best Possible). The
+        // previous-call sum is persisted on the class until reload.
+        const previousMainSumOtherMode = TeamModule.lastMainSum[mode === 1 ? 2 : 1];
+        const previousMainSumSameMode = TeamModule.lastMainSum[mode];
+        TeamModule.lastMainSum[mode] = result.mainSum;
+        // Stash delta context on the result so updateTeamUI can render it.
+        result.previousMainSumSameMode = previousMainSumSameMode;
+        result.previousMainSumOtherMode = previousMainSumOtherMode;
+        result.currentModeName = mode === 1 ? 'Current Best' : 'Best Possible';
+        result.otherModeName = mode === 1 ? 'Best Possible' : 'Current Best';
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
         const distStr = dist.map(d => `${d.count}x ${d.element}`).join(', ');
         const inClusterStr = result.leaderInCluster ? 'in-cluster' : 'cross-cluster';
         const identStr = modesIdentical ? ', modes identical' : '';
-        LogUtils_logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
+        const playerClassNameLog = TeamModule.PLAYER_CLASS_NAME[result.playerClass] || ('class ' + result.playerClass);
+        const mainCaracLabel = result.playerClass === 1 ? 'carac1' : (result.playerClass === 2 ? 'carac2' : 'carac3');
+        LogUtils_logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), MainSum=${result.mainSum.toLocaleString()}, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
         // UI update: same approach as legacy — hide non-selected, show + number selected
         TeamModule.updateTeamUI(deckID, result);
     }
@@ -18699,7 +18720,7 @@ class TeamModule {
         TeamModule.updateTeamUI(deckID);
     }
     static updateTeamUI(deckID, teamResult) {
-        var _a;
+        var _a, _b;
         const arr = $('div[id_girl]');
         // Remove all existing topNumber elements to prevent stale entries
         // from a previous team calculation (e.g. Current Best) interfering
@@ -18765,7 +18786,7 @@ class TeamModule {
             try {
                 cachedBlessings = BlessingService.getCached();
             }
-            catch ( /* cache not ready */_b) { /* cache not ready */ }
+            catch ( /* cache not ready */_c) { /* cache not ready */ }
             const blessedVals = (cachedBlessings === null || cachedBlessings === void 0 ? void 0 : cachedBlessings.blessedValues) || {};
             const blessedStr = cachedBlessings && cachedBlessings.blessedTraits.length > 0
                 ? cachedBlessings.blessedTraits.map((c) => (TeamModule.TRAIT_EMOJI[c] || '') + ' ' + c + (blessedVals[c] ? '=' + blessedVals[c] : '')).join(', ')
@@ -18774,6 +18795,29 @@ class TeamModule {
             const blessedIsActive = cachedBlessings && cachedBlessings.blessedTraits.includes(teamResult.traitCategory);
             const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
+            const mainCaracLabel = teamResult.playerClass === 1 ? 'carac1' : (teamResult.playerClass === 2 ? 'carac2' : 'carac3');
+            // Read delta info that setTopTeamV2 attached to the result
+            // (previous mainSum for the same mode or the other mode, if any).
+            const fmtPct = (current, prev) => {
+                if (!prev || prev === current)
+                    return '';
+                const diff = current - prev;
+                const pct = (diff / prev) * 100;
+                const sign = diff >= 0 ? '+' : '';
+                const colour = diff >= 0 ? '#7f7' : '#f77';
+                return `<span style="color:${colour}; font-size:10px;"> (${sign}${diff.toLocaleString()}, ${sign}${pct.toFixed(1)}%)</span>`;
+            };
+            const prevSame = teamResult.previousMainSumSameMode;
+            const prevOther = teamResult.previousMainSumOtherMode;
+            const currentModeName = teamResult.currentModeName;
+            const otherModeName = teamResult.otherModeName;
+            let mainSumDeltaHtml = '';
+            if (prevSame && prevSame !== teamResult.mainSum && currentModeName) {
+                mainSumDeltaHtml += ' ' + fmtPct(teamResult.mainSum, prevSame) + ` vs previous ${currentModeName}`;
+            }
+            if (prevOther && otherModeName) {
+                mainSumDeltaHtml += ' ' + fmtPct(teamResult.mainSum, prevOther) + ` vs ${otherModeName}`;
+            }
             // Mythic audit (issue #1573, #1603): show every mythic in the
             // player's class with its team status. Excluded mythics get a
             // reason so the user can confirm whether the algorithm or the
@@ -18822,6 +18866,8 @@ class TeamModule {
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${((_a = teamResult.effectivePower) === null || _a === void 0 ? void 0 : _a.toLocaleString()) || 'N/A'}</div>
+                <div><b>Main Sum (${mainCaracLabel}):</b> ${((_b = teamResult.mainSum) === null || _b === void 0 ? void 0 : _b.toLocaleString()) || 'N/A'}${mainSumDeltaHtml}</div>
+                <div style="color:#aaa; font-size:10px;">Sum of your main class stat across the 7 picked girls. League-relevant headline number.</div>
 
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div style="color:#ffb827; font-weight:bold;">Mythic Audit</div>
@@ -18866,6 +18912,12 @@ TeamModule.PLAYER_CLASS_NAME = {
     2: 'Charm',
     3: 'Know-how',
 };
+/**
+ * Last MainSum per mode, kept in memory so the info box can show
+ * "+X% vs Current Best / Best Possible" when the user clicks the
+ * other mode button. Cleared on page reload.
+ */
+TeamModule.lastMainSum = {};
 
 ;// CONCATENATED MODULE: ./src/Module/index.ts
 // Module/index.ts -- Barrel file re-exporting all game automation modules.

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -18648,6 +18648,24 @@ class TeamModule {
         result.previousMainSumOtherMode = previousMainSumOtherMode;
         result.currentModeName = mode === 1 ? 'Current Best' : 'Best Possible';
         result.otherModeName = mode === 1 ? 'Best Possible' : 'Current Best';
+        // Pool stats for the info box: how big is the eligible pool of
+        // own-class girls vs the total Mythic+Legendary5* pool, including
+        // a per-class breakdown for cross-class transparency.
+        const isHighRarity = (g) => g.rarity === 'mythic' || (g.rarity === 'legendary' && Number(g.nb_grades) >= 5);
+        const ownClass = girls.filter(g => isHighRarity(g) && (typeof g.class !== 'number' || g.class === playerClass));
+        const otherClass = {};
+        for (const g of girls) {
+            if (!isHighRarity(g))
+                continue;
+            if (typeof g.class !== 'number' || g.class === playerClass)
+                continue;
+            otherClass[g.class] = (otherClass[g.class] || 0) + 1;
+        }
+        result.poolStats = {
+            ownClass: ownClass.length,
+            otherClass, // { 1: n_HC, 2: n_Charm, 3: n_KH }
+            ownClassMythics: ownClass.filter(g => g.rarity === 'mythic').length,
+        };
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
@@ -18796,6 +18814,31 @@ class TeamModule {
             const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
             const mainCaracLabel = teamResult.playerClass === 1 ? 'carac1' : (teamResult.playerClass === 2 ? 'carac2' : 'carac3');
+            // Class explainer: show why only own-class girls are used,
+            // including pool size and per-class breakdown of what gets
+            // filtered out. Cross-class girls are intentionally never
+            // considered because the league/season formulas reward only
+            // the player's main class carac, so the script optimizes for
+            // that single stat (Performance Handbook, Slynia 2021;
+            // Wiki: 'never build cross-class').
+            const poolStats = teamResult.poolStats;
+            let classExplainerHtml = '';
+            if (poolStats) {
+                const otherClassParts = [];
+                for (const c of [1, 2, 3]) {
+                    if (c === teamResult.playerClass)
+                        continue;
+                    const n = poolStats.otherClass[c];
+                    if (!n)
+                        continue;
+                    otherClassParts.push(`${n} ${TeamModule.PLAYER_CLASS_NAME[c] || ('class ' + c)}`);
+                }
+                const otherTotal = otherClassParts.length > 0 ? ' (skipped: ' + otherClassParts.join(', ') + ')' : '';
+                classExplainerHtml = `<br/><span style="color:#bbb; font-size:10px;">Eligible pool: <b>${poolStats.ownClass}</b> ${playerClassName} girls (Mythic + Legendary 5*), of which ${poolStats.ownClassMythics} mythic. Cross-class girls ignored${otherTotal} -- league math rewards only your main class stat (${mainCaracLabel}), so cross-class girls cannot win on the metric that counts.</span>`;
+                if (poolStats.ownClass < 7) {
+                    classExplainerHtml += `<br/><span style="color:#fc6; font-size:10px;"><b>WARNING:</b> Fewer than 7 own-class Mythic/Legendary-5* girls available. Script falls back to legacy team selection (no Tier-3 / cluster optimization). Build up your ${playerClassName} roster to enable the full algorithm.</span>`;
+                }
+            }
             // Read delta info that setTopTeamV2 attached to the result
             // (previous mainSum for the same mode or the other mode, if any).
             const fmtPct = (current, prev) => {
@@ -18853,7 +18896,7 @@ class TeamModule {
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
-                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> ${classExplainerHtml}</div>
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
                 <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>

--- a/README.md
+++ b/README.md
@@ -16,21 +16,23 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
-### v7.35.25 - Mythic coverage and leader picked after slots 2-7
+### v7.35.25 - Mythic coverage, slot order, and richer team info box
 
-Two changes to the team-selection algorithm based on feedback from issues #1573 (Frank) and #1603 (Dimka).
+Algorithm refinements driven by feedback in issues #1573 (Frank) and #1603 (Dimka).
 
-Positions 2-7 are now filled before the leader is picked. Strong cluster girls are no longer "stolen" by leader selection, and the leader is then chosen from whatever is left in the pool. The leader hierarchy stays the same: mythic preferred, tier-5 priority Shield > Stun > Execute > Reflect, cluster membership and trait match as tiebreakers.
+**Slot order:** Positions 2-7 are now filled before the leader. The leader is picked from whatever is left in the pool, so a strong cluster girl can no longer be consumed by leader selection. Leader hierarchy stays the same: mythic, tier-5 priority Shield > Stun > Execute > Reflect, cluster membership and trait match as tiebreakers.
 
-The slot-fill logic now considers cross-cluster mythics. The team builder evaluates two strategies (cluster-priority and mythic-priority) and keeps the variant with the higher Effective Power. This guarantees that strong mythics are no longer silently dropped just because they belong to a different element pair, while weak cross-cluster mythics still cannot break a healthy Tier-3 chain.
+**Mythic coverage:** The slot fill evaluates two strategies (cluster-priority and mythic-priority) and keeps the variant with the higher Effective Power. Strong cross-cluster mythics now enter the team when including them beats the cluster-only Tier-3 chain. Weak cross-cluster mythics still cannot break a healthy chain. A leader swap step guarantees a mythic leader whenever any mythic exists in the player's class.
 
-The team info box now shows a Mythic Audit: every mythic in your class is listed as either leader, in slots 2-7, or excluded with a reason (other cluster, lower stats, wrong class). This makes it possible to verify whether a missing mythic is the algorithm's choice or a data issue.
+**Info box additions:**
+- Mythic Audit lists every mythic in the player's class with status (leader, in slots 2-7, or excluded with reason).
+- Class line shows the eligible pool size (own-class Mythic + Legendary 5*), the mythic count, and how many cross-class girls were skipped per class. Explains that league math rewards only the main class carac, so cross-class girls cannot win on the metric that counts.
+- Main Sum (sum of the main class carac across the 7 picked girls) is shown next to Effective Power, with green/red deltas vs the previous click and vs the other mode.
+- Yellow warning when the own-class pool drops below 7 girls (script falls back to the legacy DOM-based team selection without Tier-3 optimization).
 
-The team v2 log line now includes the player class and which carac is used as the main stat (carac1 for Hardcore, carac2 for Charm, carac3 for Know-how), plus the Main Sum -- the sum of the main class carac across the 7 picked girls. Main Sum is also shown in the info box, with a delta vs the previous click and vs the other mode (Current Best / Best Possible). Effective Power stays as the tie-breaker, but Main Sum makes the optimization target visible.
+**Logging:** The Team v2 log line now starts with the player class, the carac used as main stat (carac1/2/3), and the Main Sum, so the optimization target is directly visible in debug logs.
 
-The class line in the info box now explains why only own-class girls are considered: it shows the pool size (Mythic + Legendary 5*) of the player class, the number of mythics in that pool, and how many cross-class girls were skipped per class. League and season formulas reward only the main class carac, so cross-class girls cannot win on the metric that counts. When the own-class pool drops below 7 girls, a warning marks the fall-back to legacy team selection (no Tier-3 / cluster optimization).
-
-Heads-up for issue reports comparing total team power: Total Power in the game UI includes equipment, the script's Effective Power does not. To compare the two on equal footing, unequip all girls first, then look at both numbers.
+**Heads-up:** the game UI's Total Power reacts to equipment, the script's Effective Power does not. To compare the two on equal footing, unequip all girls first, then look at both numbers.
 
 ### v7.35.24 - Best Possible projects to the awakening cap
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,18 @@ c) TamperMonkey should automatically prompt you to install/update the script. If
 
 ## Latest Updates
 
+### v7.35.25 - Mythic coverage and leader picked after slots 2-7
+
+Two changes to the team-selection algorithm based on feedback from issues #1573 (Frank) and #1603 (Dimka).
+
+Positions 2-7 are now filled before the leader is picked. Strong cluster girls are no longer "stolen" by leader selection, and the leader is then chosen from whatever is left in the pool. The leader hierarchy stays the same: mythic preferred, tier-5 priority Shield > Stun > Execute > Reflect, cluster membership and trait match as tiebreakers.
+
+The slot-fill logic now considers cross-cluster mythics. The team builder evaluates two strategies (cluster-priority and mythic-priority) and keeps the variant with the higher Effective Power. This guarantees that strong mythics are no longer silently dropped just because they belong to a different element pair, while weak cross-cluster mythics still cannot break a healthy Tier-3 chain.
+
+The team info box now shows a Mythic Audit: every mythic in your class is listed as either leader, in slots 2-7, or excluded with a reason (other cluster, lower stats, wrong class). This makes it possible to verify whether a missing mythic is the algorithm's choice or a data issue.
+
+Heads-up for issue reports comparing total team power: Total Power in the game UI includes equipment, the script's Effective Power does not. To compare the two on equal footing, unequip all girls first, then look at both numbers.
+
 ### v7.35.24 - Best Possible projects to the awakening cap
 
 Best Possible mode now projects every girl to the level cap of 750 instead of your current player level. The previous behaviour was a leftover from before the awakening system existed and went unnoticed for a long time. Once top girls became awakened beyond the player level, Best Possible silently collapsed to the same picks as Current Best because the projection had no room left to grow. The mode now consistently answers what each girl would be worth at full awakening, independent of your level.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The team info box now shows a Mythic Audit: every mythic in your class is listed
 
 The team v2 log line now includes the player class and which carac is used as the main stat (carac1 for Hardcore, carac2 for Charm, carac3 for Know-how), plus the Main Sum -- the sum of the main class carac across the 7 picked girls. Main Sum is also shown in the info box, with a delta vs the previous click and vs the other mode (Current Best / Best Possible). Effective Power stays as the tie-breaker, but Main Sum makes the optimization target visible.
 
+The class line in the info box now explains why only own-class girls are considered: it shows the pool size (Mythic + Legendary 5*) of the player class, the number of mythics in that pool, and how many cross-class girls were skipped per class. League and season formulas reward only the main class carac, so cross-class girls cannot win on the metric that counts. When the own-class pool drops below 7 girls, a warning marks the fall-back to legacy team selection (no Tier-3 / cluster optimization).
+
 Heads-up for issue reports comparing total team power: Total Power in the game UI includes equipment, the script's Effective Power does not. To compare the two on equal footing, unequip all girls first, then look at both numbers.
 
 ### v7.35.24 - Best Possible projects to the awakening cap

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The slot-fill logic now considers cross-cluster mythics. The team builder evalua
 
 The team info box now shows a Mythic Audit: every mythic in your class is listed as either leader, in slots 2-7, or excluded with a reason (other cluster, lower stats, wrong class). This makes it possible to verify whether a missing mythic is the algorithm's choice or a data issue.
 
+The team v2 log line now includes the player class and which carac is used as the main stat (carac1 for Hardcore, carac2 for Charm, carac3 for Know-how), plus the Main Sum -- the sum of the main class carac across the 7 picked girls. Main Sum is also shown in the info box, with a delta vs the previous click and vs the other mode (Current Best / Best Possible). Effective Power stays as the tie-breaker, but Main Sum makes the optimization target visible.
+
 Heads-up for issue reports comparing total team power: Total Power in the game UI includes equipment, the script's Effective Power does not. To compare the two on equal footing, unequip all girls first, then look at both numbers.
 
 ### v7.35.24 - Best Possible projects to the awakening cap

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -242,6 +242,7 @@ Wenn 0 Mythics existieren, faellt das Skript auf Legendary 5*-Girls zurueck. Da 
 Info-Box (oben mittig, dunkel, halbtransparent):
 
 - Mythic Audit (ab v7.35.25): listet alle Mythics der Spielerklasse auf. Status pro Mythic: 'leader' / 'pos2to7' (mit Position) / 'excluded' (mit Grund: andere Cluster, gleicher Trait aber niedrigere Stats, falsche Klasse). Hilft, Daten- vs. Algorithmus-Bugs zu unterscheiden, wenn Spieler eine Mythic vermissen.
+- Class Explainer (ab v7.35.25): direkt unter dem Klassen-Hinweis steht der Pool-Stand: Anzahl Eligible-Girls (Mythic + Legendary 5*) der eigenen Klasse, davon Mythics, plus eine Aufschluesselung der ignorierten Cross-Class-Girls je Klasse. Begruendung warum keine Cross-Class-Girls verwendet werden (league math rewards nur main class carac). Wenn der Pool unter 7 liegt, kommt eine WARNING dass das Skript auf Legacy-Auswahl zurueckfaellt.
 - Main Sum (ab v7.35.25): Summe der Hauptklassen-Carac (carac1/2/3 je nach Spieler-Klasse) ueber alle 7 Team-Girls. Headline-Zahl, die in der Optimierung im Vordergrund steht. Bei wiederholten Klicks auf Current Best / Best Possible wird ein Delta zur vorigen Auswahl angezeigt (gruen = besser, rot = schlechter), inkl. Vergleich zum jeweils anderen Modus. Ergaenzt Effective Power, das Tier-3-Bonus mit einrechnet.
 
 - Klassen-Hinweis: "Class: <Hardcore/Charm/Know-how> -- only X girls considered"

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -1,6 +1,6 @@
 ---
-last-verified: 2026-05-06
-verified-against-version: 7.35.24
+last-verified: 2026-05-07
+verified-against-version: 7.35.25
 status: current
 ---
 
@@ -159,22 +159,56 @@ tier3Bonus   = Summe ueber alle Mitglieder von:
 Die Gruppe mit hoechster `effectivePower` gewinnt. Alle evaluierten
 Alternativen landen in `result.alternatives` fuer die UI-Anzeige.
 
-### Phase 5: Slot-Fill (innerhalb einer Gruppe)
+### Phase 5: Slot-Fill (ab v7.35.25 zwei-Variant)
 
-Drei Pass-Strategie pro Cluster:
+Slots 2-7 werden VOR dem Leader gefuellt (Frank-Anforderung aus Issue #1573). Damit kann ein starker Cluster-Slot nicht durch die Leader-Auswahl belegt werden, der Leader wird aus dem Rest gepickt.
 
-| Pass | Filter | Sortiert nach |
-|------|--------|---------------|
-| 1 | Element gehoert zum Cluster-Paar UND traitValue matcht | main_carac desc |
-| 2 | Element gehoert zum Cluster-Paar (beliebiger trait) | main_carac desc |
-| 3 | beliebiges Element | main_carac desc |
+Pro Cluster werden zwei Slot-Varianten gebaut und nach `main_sum * (1 + tier3Bonus)` verglichen. Die hoehere Effective Power gewinnt. So gibt es Rainbow-Teams nur, wenn sie tatsaechlich besser sind.
 
-Pass 1 maximiert Tier-3-Match. Pass 2 haelt das Mono-Element-Bonus.
-Pass 3 ist nur Reserve, falls die Gruppe weniger als 7 Girls hat.
+**Variant A: cluster-first** (Tier-3-Chain bevorzugen)
 
-### Phase 6: Leader (ab v7.35.23: global)
+| Pass | Filter |
+|------|--------|
+| 1 | Cluster-Mythic + traitValue match |
+| 2 | Cluster-Mythic, beliebiger trait |
+| 3 | Cluster-Legendary + traitValue match |
+| 4 | Cluster-Legendary, beliebiger trait |
+| 5 | Cross-Cluster-Mythic |
+| 6 | Beliebige verbleibende Girl |
 
-Leader (Position 1) wird **global** gepickt, nicht Cluster-gebunden. Tier-5-Prio gilt fuer alle Mythics, unabhaengig von der Cluster-Wahl. Slots 2-7 bleiben weiterhin Cluster-gebunden (Phase 5).
+**Variant B: mythic-first** (Mythic-Coverage bevorzugen, Issue #1603)
+
+| Pass | Filter |
+|------|--------|
+| 1 | Cluster-Mythic + traitValue match |
+| 2 | Cluster-Mythic, beliebiger trait |
+| 3 | Cross-Cluster-Mythic |
+| 4 | Cluster-Legendary + traitValue match |
+| 5 | Cluster-Legendary, beliebiger trait |
+| 6 | Beliebige verbleibende Girl |
+
+Beide Varianten fuellen 6 Slots. Anschliessend wird Effective Power gerechnet, die hoehere wird verwendet.
+
+### Phase 6: Leader (ab v7.35.25: nach Slots 2-7)
+
+Leader (Position 1) wird NACH den Slots 2-7 aus dem verbleibenden Pool gepickt.
+
+| Prioritaet | Kriterium |
+|-----------|----------|
+| 1 | Mythic bevorzugt (Fallback siehe unten) |
+| 2 | Tier-5-Skill: Shield(4) > Stun(3) > Execute(2) > Reflect(1) - GLOBAL |
+| 3 | Cluster-Mitgliedschaft (Tiebreaker) |
+| 4 | Trait-Match (Tiebreaker) |
+| 5 | main_carac-Score |
+
+#### Leader-Swap
+
+Falls keine Mythic mehr im verbleibenden Pool ist (alle 5-6 Mythics in Slots 2-7 verbraucht), aber Slots Mythics enthalten und mindestens eine Legendary uebrig ist:
+
+1. Schwaechste Slot-Mythic wird Leader.
+2. Staerkste verbleibende Legendary nimmt deren Slot ein.
+
+Garantiert: solange mindestens 1 Mythic existiert, ist sie Leader. Alle Mythics bleiben sichtbar (keine wird stumm fallengelassen).
 
 | Prioritaet | Kriterium |
 |-----------|----------|
@@ -206,6 +240,8 @@ Wenn 0 Mythics existieren, faellt das Skript auf Legendary 5*-Girls zurueck. Da 
 ### Phase 7: UI
 
 Info-Box (oben mittig, dunkel, halbtransparent):
+
+- Mythic Audit (ab v7.35.25): listet alle Mythics der Spielerklasse auf. Status pro Mythic: 'leader' / 'pos2to7' (mit Position) / 'excluded' (mit Grund: andere Cluster, gleicher Trait aber niedrigere Stats, falsche Klasse). Hilft, Daten- vs. Algorithmus-Bugs zu unterscheiden, wenn Spieler eine Mythic vermissen.
 
 - Klassen-Hinweis: "Class: <Hardcore/Charm/Know-how> -- only X girls considered"
 - Trait optimiert: "[emoji] eyeColor = 'Blue' (4/7 girls match)"
@@ -404,3 +440,4 @@ Fallback fuer Spec-Tests und den Fall dass GT noch nicht geladen ist.
 | 7.35.21 | v4: main_carac-Score, Klassen-Filter, Klar-Namen, Equipment-Hinweis (Issues #1340, #1573) |
 | 7.35.23 | Leader global gepickt (Tier-5 ueber alle Mythics), Mode-Diff-Detection, Beginner-Pool ohne Mythics (Issues #1573, #1603) |
 | 7.35.24 | Best-Possible projiziert auf Awakening-Cap 750 statt playerLevel (Issue #1603) |
+| 7.35.25 | Slots 2-7 vor Leader gepickt, zwei Slot-Varianten (cluster-first vs mythic-first) per Effective Power, Mythic-Audit in UI, Leader-Swap fuer komplette Mythic-Coverage (Issues #1573, #1603) |

--- a/docs-internal/team-algorithm-design.md
+++ b/docs-internal/team-algorithm-design.md
@@ -242,6 +242,7 @@ Wenn 0 Mythics existieren, faellt das Skript auf Legendary 5*-Girls zurueck. Da 
 Info-Box (oben mittig, dunkel, halbtransparent):
 
 - Mythic Audit (ab v7.35.25): listet alle Mythics der Spielerklasse auf. Status pro Mythic: 'leader' / 'pos2to7' (mit Position) / 'excluded' (mit Grund: andere Cluster, gleicher Trait aber niedrigere Stats, falsche Klasse). Hilft, Daten- vs. Algorithmus-Bugs zu unterscheiden, wenn Spieler eine Mythic vermissen.
+- Main Sum (ab v7.35.25): Summe der Hauptklassen-Carac (carac1/2/3 je nach Spieler-Klasse) ueber alle 7 Team-Girls. Headline-Zahl, die in der Optimierung im Vordergrund steht. Bei wiederholten Klicks auf Current Best / Best Possible wird ein Delta zur vorigen Auswahl angezeigt (gruen = besser, rot = schlechter), inkl. Vergleich zum jeweils anderen Modus. Ergaenzt Effective Power, das Tier-3-Bonus mit einrechnet.
 
 - Klassen-Hinweis: "Class: <Hardcore/Charm/Know-how> -- only X girls considered"
 - Trait optimiert: "[emoji] eyeColor = 'Blue' (4/7 girls match)"
@@ -262,6 +263,24 @@ Hinweis "Trait label uses fallback dictionary -- may be inaccurate
 for new color codes".
 
 ---
+
+## Logging
+
+Pro Aufruf von ``setTopTeamV2`` wird eine Zeile geloggt::
+
+```
+Team v2 [Current Best]: Class=Know-how (carac3), MainSum=123,456, Leader=<Name> (Shield, in-cluster), Trait: eyeColor=Blue (5/7), Tier3: 27.0%, Elements: 5x darkness, 1x fire, 1x light
+```
+
+Felder:
+
+- ``Class`` -- Spieler-Klasse + verwendetes carac-Feld (carac1/2/3) zur direkten Pruefung.
+- ``MainSum`` -- Summe der Hauptklassen-Carac aller 7 Team-Girls.
+- ``Leader`` -- Pos-1-Girl mit Tier-5-Skill und ob im Cluster.
+- ``Trait`` -- gewaehlter Cluster-Wert und Match-Anzahl.
+- ``Tier3`` -- Team-weiter Tier-3-Bonus.
+- ``Elements`` -- Element-Verteilung im Team.
+- ``modes identical`` -- Suffix wenn Best Possible und Current Best dieselben 7 Girls liefern.
 
 ## Klar-Namen-Mapping (TraitMappings)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.24",
+  "version": "7.35.25",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -372,6 +372,236 @@ describe('TeamBuilderService', () => {
         });
     });
 
+
+    describe('Leader picked AFTER positions 2-7 (issue #1573)', () => {
+
+        it('should not consume a strong cluster girl as leader if a weaker mythic exists for the leader role', () => {
+            // 7 strong cluster mythics (eyeColor=blue, fire/darkness) plus
+            // one weak Light/Shield mythic (out of cluster). The Light
+            // mythic must lead, so the 7 cluster mythics should ALL appear
+            // in positions 2-7 (only 6 fit, but the strongest 6 must be
+            // there -- the weak one stays excluded).
+            const strongCluster = Array.from({ length: 7 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000 + i,
+                eyeColor: 'blue',
+            }));
+            const weakLightLeader = makeGirl({
+                id_girl: 999,
+                element: 'light',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 1000,
+                hairColor: 'blonde',
+            });
+            const result = TeamBuilderService.buildTeam([...strongCluster, weakLightLeader], 1, 100, 3)!;
+
+            // Leader must be the Light/Shield mythic (priority 4)
+            expect(result.girls[0].id_girl).toBe(999);
+            expect(result.leaderTier5.name).toBe('Shield');
+
+            // Positions 2-7 must contain the 6 highest-stat cluster mythics
+            const slotIds = result.girls.slice(1).map(g => g.id_girl).sort();
+            expect(slotIds).toEqual([101, 102, 103, 104, 105, 106]);
+        });
+    });
+
+    describe('Mythic pass for cross-cluster girls (issue #1603)', () => {
+
+        it('should include cross-cluster mythics in positions 2-7 before any cross-cluster legendary', () => {
+            // 4 cluster mythics (eyeColor=blue) -- not enough to fill 6 slots.
+            // 3 cross-cluster mythics (hairColor=blonde, light/nature).
+            // 5 cross-cluster legendaries (zodiac, stone/psychic).
+            // Slots 2-7 must contain 4 cluster mythics + 2 cross-cluster mythics.
+            // Legendaries must NOT enter the team unless mythics run out.
+            const clusterMythics = Array.from({ length: 4 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                eyeColor: 'blue',
+            }));
+            const crossClusterMythics = Array.from({ length: 3 }, (_, i) => makeGirl({
+                id_girl: 200 + i,
+                element: i % 2 === 0 ? 'light' : 'nature',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 4000 - i,
+                hairColor: 'blonde',
+            }));
+            const crossClusterLegendaries = Array.from({ length: 5 }, (_, i) => makeGirl({
+                id_girl: 300 + i,
+                element: 'stone',
+                rarity: 'legendary',
+                class: 3,
+                nb_grades: 5,
+                graded: 5,
+                carac3: 3000,           // weaker than the cluster mythics
+                zodiac: 'Aries',
+            }));
+
+            const result = TeamBuilderService.buildTeam(
+                [...clusterMythics, ...crossClusterMythics, ...crossClusterLegendaries],
+                1, 100, 3
+            )!;
+
+            // Every mythic of the player's class must be either leader or in slots 2-7
+            const teamIds = new Set(result.girls.map(g => g.id_girl));
+            const mythicIds = [...clusterMythics, ...crossClusterMythics].map(g => g.id_girl);
+            for (const id of mythicIds) {
+                expect(teamIds.has(id)).toBe(true);
+            }
+
+            // No legendary should be in the team (we have exactly 7 mythics)
+            const hasAnyLegendary = result.girls.some(g => g.rarity === 'legendary');
+            expect(hasAnyLegendary).toBe(false);
+        });
+
+        it('should fall back to legendaries only after all mythics are placed', () => {
+            // 3 cluster mythics + 2 cross-cluster mythics = 5 mythics total.
+            // Cross-cluster mythics are strong enough that the mythic-first
+            // variant beats cluster-first on Effective Power.
+            // Need 7 slots. The remaining 2 must come from legendaries.
+            const clusterMythics = Array.from({ length: 3 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: 'fire',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                eyeColor: 'blue',
+            }));
+            const crossClusterMythics = Array.from({ length: 2 }, (_, i) => makeGirl({
+                id_girl: 200 + i,
+                element: 'light',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 8000,           // strong enough to beat cluster-first
+                hairColor: 'blonde',
+            }));
+            const legendaries = Array.from({ length: 10 }, (_, i) => makeGirl({
+                id_girl: 300 + i,
+                element: 'fire',
+                rarity: 'legendary',
+                class: 3,
+                nb_grades: 5,
+                graded: 5,
+                carac3: 2000,           // weak legendaries
+                eyeColor: 'blue',
+            }));
+
+            const result = TeamBuilderService.buildTeam(
+                [...clusterMythics, ...crossClusterMythics, ...legendaries],
+                1, 100, 3
+            )!;
+
+            // All 5 mythics must appear in the team
+            const mythicIds = [...clusterMythics, ...crossClusterMythics].map(g => g.id_girl);
+            const teamIds = new Set(result.girls.map(g => g.id_girl));
+            for (const id of mythicIds) {
+                expect(teamIds.has(id)).toBe(true);
+            }
+
+            // Exactly 2 legendaries fill the remaining slots
+            const legendaryCount = result.girls.filter(g => g.rarity === 'legendary').length;
+            expect(legendaryCount).toBe(2);
+        });
+
+        it('should NOT add weak cross-cluster mythics when cluster-only beats them on Effective Power', () => {
+            // 7 strong cluster mythics + 1 weak cross-cluster mythic.
+            // The cluster team has full Tier-3 chain; including the weak
+            // cross-cluster mythic would dilute it. Must keep cluster-only.
+            const clusterMythics = Array.from({ length: 7 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: i % 2 === 0 ? 'fire' : 'darkness',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000,
+                eyeColor: 'blue',
+            }));
+            const weakCross = makeGirl({
+                id_girl: 999,
+                element: 'light',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 100,           // very weak
+                hairColor: 'blonde',
+            });
+            const result = TeamBuilderService.buildTeam([...clusterMythics, weakCross], 1, 100, 3)!;
+
+            // Team must NOT include the weak cross-cluster mythic in slots 2-7
+            const weakInTeam = result.girls.slice(1).some(g => g.id_girl === 999);
+            // Weak mythic might be leader (only Shield-priority mythic),
+            // which is the existing leader-priority behavior.
+            // The point of this test: it must NOT take a slot 2-7.
+            if (!weakInTeam && result.girls[0].id_girl === 999) {
+                // Acceptable: weak mythic became leader (Shield > others), 6 cluster mythics in slots
+                expect(result.girls.slice(1).every(g => g.element === 'fire' || g.element === 'darkness')).toBe(true);
+            } else if (!weakInTeam) {
+                // Acceptable: leader is a cluster mythic, weak excluded entirely
+                expect(weakInTeam).toBe(false);
+            } else {
+                // Not acceptable: weak mythic stole a cluster slot
+                throw new Error('Weak cross-cluster mythic stole a cluster slot');
+            }
+        });
+    });
+
+    describe('Mythic audit (issue #1573, #1603)', () => {
+
+        it('should report status for every player-class mythic', () => {
+            const girls = makeTraitPool(20);
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+
+            // makeTraitPool generates mythics. Audit must contain all of them.
+            const mythicCount = girls.filter(g => g.rarity === 'mythic').length;
+            expect(result.mythicAudit.length).toBe(mythicCount);
+
+            // The 7 girls in the team must be marked leader/pos2to7
+            const inTeamCount = result.mythicAudit.filter(e => e.status !== 'excluded').length;
+            expect(inTeamCount).toBe(7);
+
+            // The first audit entry must be the leader
+            expect(result.mythicAudit[0].status).toBe('leader');
+            expect(result.mythicAudit[0].position).toBe(1);
+        });
+
+        it('should give a reason for excluded mythics', () => {
+            // Mix of cluster + cross-cluster mythics. With 8 cluster mythics,
+            // one is excluded; the audit must explain why.
+            const clusterMythics = Array.from({ length: 8 }, (_, i) => makeGirl({
+                id_girl: 100 + i,
+                element: 'fire',
+                rarity: 'mythic',
+                class: 3,
+                carac3: 5000 - i,    // lower stats for higher i -> last is excluded
+                eyeColor: 'blue',
+            }));
+            const result = TeamBuilderService.buildTeam(clusterMythics, 1, 100, 3)!;
+            const excluded = result.mythicAudit.filter(e => e.status === 'excluded');
+            expect(excluded).toHaveLength(1);
+            expect(excluded[0].reason).toBeDefined();
+            expect(excluded[0].reason!.length).toBeGreaterThan(0);
+        });
+
+        it('should flag wrong-class mythics in the audit', () => {
+            // Player class 3 (KH). Add a class-1 mythic -- it must show up as
+            // excluded with the wrong-class reason.
+            const girls = [
+                ...makeTraitPool(20),
+                makeGirl({ id_girl: 999, rarity: 'mythic', class: 1, carac1: 99999, eyeColor: 'blue' }),
+            ];
+            const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+            const wrongClass = result.mythicAudit.find(e => e.id_girl === 999);
+            expect(wrongClass).toBeDefined();
+            expect(wrongClass!.status).toBe('excluded');
+            expect(wrongClass!.reason).toMatch(/wrong class/i);
+        });
+    });
+
     describe('getElementDistribution', () => {
 
         const baseResult: TeamResult = {
@@ -390,6 +620,7 @@ describe('TeamBuilderService', () => {
             alternatives: [],
             playerClass: 3,
             leaderInCluster: true,
+            mythicAudit: [],
         };
 
         it('should count elements correctly', () => {

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -620,6 +620,7 @@ describe('TeamBuilderService', () => {
             alternatives: [],
             playerClass: 3,
             leaderInCluster: true,
+            mainSum: 0,
             mythicAudit: [],
         };
 

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -692,6 +692,22 @@ export class TeamModule {
             const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
 
+            // Mythic audit (issue #1573, #1603): show every mythic in the
+            // player's class with its team status. Excluded mythics get a
+            // reason so the user can confirm whether the algorithm or the
+            // data is at fault.
+            const auditEntries = teamResult.mythicAudit || [];
+            const auditInTeam = auditEntries.filter((e: any) => e.status !== 'excluded');
+            const auditExcluded = auditEntries.filter((e: any) => e.status === 'excluded');
+            const auditTotalLine = `${auditEntries.length} mythics in your harem (player class): ${auditInTeam.length} in team, ${auditExcluded.length} excluded`;
+            const auditExcludedHtml = auditExcluded.length > 0
+                ? '<div style="color:#aaa; font-size:10px; margin-top:2px; max-height:120px; overflow-y:auto; border:1px solid #444; padding:3px;">'
+                    + '<b>Excluded mythics:</b><br/>'
+                    + auditExcluded.slice(0, 20).map((e: any) => `&bull; ${e.name} (${e.element}, stat=${Math.round(e.mainCarac)}): ${e.reason || 'unknown'}`).join('<br/>')
+                    + (auditExcluded.length > 20 ? `<br/>... and ${auditExcluded.length - 20} more` : '')
+                    + '</div>'
+                : '';
+
             const altsHtml = teamResult.alternatives && teamResult.alternatives.length > 1
                 ? '<b>Compared:</b> ' + teamResult.alternatives.map((a: { traitCategory: string; traitValue: string; effectivePower: number }) => {
                         const r = TraitMappings.resolve(a.traitCategory as any, a.traitValue);
@@ -728,6 +744,11 @@ export class TeamModule {
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${teamResult.effectivePower?.toLocaleString() || 'N/A'}</div>
+
+                <hr style="border-color:#555; margin:4px 0"/>
+                <div style="color:#ffb827; font-weight:bold;">Mythic Audit</div>
+                <div style="color:#aaa; font-size:10px;">${auditTotalLine}</div>
+                ${auditExcludedHtml}
 
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div><b>Active Blessings:</b> ${blessedStr}${blessedNote}</div>

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -537,6 +537,23 @@ export class TeamModule {
         (result as any).currentModeName = mode === 1 ? 'Current Best' : 'Best Possible';
         (result as any).otherModeName = mode === 1 ? 'Best Possible' : 'Current Best';
 
+        // Pool stats for the info box: how big is the eligible pool of
+        // own-class girls vs the total Mythic+Legendary5* pool, including
+        // a per-class breakdown for cross-class transparency.
+        const isHighRarity = (g: any): boolean => g.rarity === 'mythic' || (g.rarity === 'legendary' && Number(g.nb_grades) >= 5);
+        const ownClass = girls.filter(g => isHighRarity(g) && (typeof g.class !== 'number' || g.class === playerClass));
+        const otherClass: { [c: number]: number } = {};
+        for (const g of girls) {
+            if (!isHighRarity(g)) continue;
+            if (typeof g.class !== 'number' || g.class === playerClass) continue;
+            otherClass[g.class] = (otherClass[g.class] || 0) + 1;
+        }
+        (result as any).poolStats = {
+            ownClass: ownClass.length,
+            otherClass,                 // { 1: n_HC, 2: n_Charm, 3: n_KH }
+            ownClassMythics: ownClass.filter(g => g.rarity === 'mythic').length,
+        };
+
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
@@ -714,6 +731,31 @@ export class TeamModule {
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
 
             const mainCaracLabel = teamResult.playerClass === 1 ? 'carac1' : (teamResult.playerClass === 2 ? 'carac2' : 'carac3');
+
+            // Class explainer: show why only own-class girls are used,
+            // including pool size and per-class breakdown of what gets
+            // filtered out. Cross-class girls are intentionally never
+            // considered because the league/season formulas reward only
+            // the player's main class carac, so the script optimizes for
+            // that single stat (Performance Handbook, Slynia 2021;
+            // Wiki: 'never build cross-class').
+            const poolStats = (teamResult as any).poolStats as { ownClass: number; otherClass: { [c: number]: number }; ownClassMythics: number } | undefined;
+            let classExplainerHtml = '';
+            if (poolStats) {
+                const otherClassParts: string[] = [];
+                for (const c of [1, 2, 3]) {
+                    if (c === teamResult.playerClass) continue;
+                    const n = poolStats.otherClass[c];
+                    if (!n) continue;
+                    otherClassParts.push(`${n} ${TeamModule.PLAYER_CLASS_NAME[c] || ('class ' + c)}`);
+                }
+                const otherTotal = otherClassParts.length > 0 ? ' (skipped: ' + otherClassParts.join(', ') + ')' : '';
+                classExplainerHtml = `<br/><span style="color:#bbb; font-size:10px;">Eligible pool: <b>${poolStats.ownClass}</b> ${playerClassName} girls (Mythic + Legendary 5*), of which ${poolStats.ownClassMythics} mythic. Cross-class girls ignored${otherTotal} -- league math rewards only your main class stat (${mainCaracLabel}), so cross-class girls cannot win on the metric that counts.</span>`;
+                if (poolStats.ownClass < 7) {
+                    classExplainerHtml += `<br/><span style="color:#fc6; font-size:10px;"><b>WARNING:</b> Fewer than 7 own-class Mythic/Legendary-5* girls available. Script falls back to legacy team selection (no Tier-3 / cluster optimization). Build up your ${playerClassName} roster to enable the full algorithm.</span>`;
+                }
+            }
+
             // Read delta info that setTopTeamV2 attached to the result
             // (previous mainSum for the same mode or the other mode, if any).
             const fmtPct = (current: number, prev: number): string => {
@@ -775,7 +817,7 @@ export class TeamModule {
                 border-radius: 4px; font-size: 11px; line-height: 1.5;
             ">
                 <div style="font-weight:bold; margin-bottom: 3px; color: #ffb827;">Team Selection Info</div>
-                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> -- only ${playerClassName} girls considered</div>
+                <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> ${classExplainerHtml}</div>
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
                 <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -525,13 +525,27 @@ export class TeamModule {
         }
         (result as any).modesIdentical = modesIdentical;
 
+        // Remember main sum per mode so the info box can show a
+        // mode-vs-mode delta (Current Best vs Best Possible). The
+        // previous-call sum is persisted on the class until reload.
+        const previousMainSumOtherMode = TeamModule.lastMainSum[mode === 1 ? 2 : 1];
+        const previousMainSumSameMode = TeamModule.lastMainSum[mode];
+        TeamModule.lastMainSum[mode] = result.mainSum;
+        // Stash delta context on the result so updateTeamUI can render it.
+        (result as any).previousMainSumSameMode = previousMainSumSameMode;
+        (result as any).previousMainSumOtherMode = previousMainSumOtherMode;
+        (result as any).currentModeName = mode === 1 ? 'Current Best' : 'Best Possible';
+        (result as any).otherModeName = mode === 1 ? 'Best Possible' : 'Current Best';
+
         const deckID = result.girls.map(g => g.id_girl);
         const modeName = mode === 1 ? 'Current Best' : 'Best Possible';
         const dist = TeamBuilderService.getElementDistribution(result);
         const distStr = dist.map(d => `${d.count}x ${d.element}`).join(', ');
         const inClusterStr = result.leaderInCluster ? 'in-cluster' : 'cross-cluster';
         const identStr = modesIdentical ? ', modes identical' : '';
-        logHHAuto(`Team v2 [${modeName}]: Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
+        const playerClassNameLog = TeamModule.PLAYER_CLASS_NAME[result.playerClass] || ('class ' + result.playerClass);
+        const mainCaracLabel = result.playerClass === 1 ? 'carac1' : (result.playerClass === 2 ? 'carac2' : 'carac3');
+        logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), MainSum=${result.mainSum.toLocaleString()}, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Tier3: ${(result.tier3Bonus * 100).toFixed(1)}%, Elements: ${distStr}${identStr}`);
 
         // UI update: same approach as legacy — hide non-selected, show + number selected
         TeamModule.updateTeamUI(deckID, result);
@@ -616,6 +630,13 @@ export class TeamModule {
         3: 'Know-how',
     };
 
+    /**
+     * Last MainSum per mode, kept in memory so the info box can show
+     * "+X% vs Current Best / Best Possible" when the user clicks the
+     * other mode button. Cleared on page reload.
+     */
+    private static lastMainSum: { [mode: number]: number } = {};
+
     private static updateTeamUI(deckID: number[], teamResult?: TeamResult) {
         const arr = $('div[id_girl]');
         // Remove all existing topNumber elements to prevent stale entries
@@ -692,6 +713,29 @@ export class TeamModule {
             const blessedValueMatch = blessedIsActive && blessedVals[teamResult.traitCategory] && traitDisplay.toLowerCase() === blessedVals[teamResult.traitCategory].toLowerCase();
             const blessedNote = blessedValueMatch ? ' (PERFECT match!)' : (blessedIsActive ? ' (category match, value differs)' : (cachedBlessings ? ' (not matching)' : ''));
 
+            const mainCaracLabel = teamResult.playerClass === 1 ? 'carac1' : (teamResult.playerClass === 2 ? 'carac2' : 'carac3');
+            // Read delta info that setTopTeamV2 attached to the result
+            // (previous mainSum for the same mode or the other mode, if any).
+            const fmtPct = (current: number, prev: number): string => {
+                if (!prev || prev === current) return '';
+                const diff = current - prev;
+                const pct = (diff / prev) * 100;
+                const sign = diff >= 0 ? '+' : '';
+                const colour = diff >= 0 ? '#7f7' : '#f77';
+                return `<span style="color:${colour}; font-size:10px;"> (${sign}${diff.toLocaleString()}, ${sign}${pct.toFixed(1)}%)</span>`;
+            };
+            const prevSame = (teamResult as any).previousMainSumSameMode as number | undefined;
+            const prevOther = (teamResult as any).previousMainSumOtherMode as number | undefined;
+            const currentModeName = (teamResult as any).currentModeName as string | undefined;
+            const otherModeName = (teamResult as any).otherModeName as string | undefined;
+            let mainSumDeltaHtml = '';
+            if (prevSame && prevSame !== teamResult.mainSum && currentModeName) {
+                mainSumDeltaHtml += ' ' + fmtPct(teamResult.mainSum, prevSame) + ` vs previous ${currentModeName}`;
+            }
+            if (prevOther && otherModeName) {
+                mainSumDeltaHtml += ' ' + fmtPct(teamResult.mainSum, prevOther) + ` vs ${otherModeName}`;
+            }
+
             // Mythic audit (issue #1573, #1603): show every mythic in the
             // player's class with its team status. Excluded mythics get a
             // reason so the user can confirm whether the algorithm or the
@@ -744,6 +788,8 @@ export class TeamModule {
                 <div><b>Tier 3 bonus:</b> +${tier3Pct}% total stat boost</div>
                 <div><b>Elements:</b> ${distHtml}</div>
                 <div><b>Effective Power:</b> ${teamResult.effectivePower?.toLocaleString() || 'N/A'}</div>
+                <div><b>Main Sum (${mainCaracLabel}):</b> ${teamResult.mainSum?.toLocaleString() || 'N/A'}${mainSumDeltaHtml}</div>
+                <div style="color:#aaa; font-size:10px;">Sum of your main class stat across the 7 picked girls. League-relevant headline number.</div>
 
                 <hr style="border-color:#555; margin:4px 0"/>
                 <div style="color:#ffb827; font-weight:bold;">Mythic Audit</div>

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.24";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.25";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -60,6 +60,7 @@ export interface TeamResult {
     alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }>;
     playerClass: PlayerClass;       // 1=HC, 2=Charm, 3=KH (for UI display)
     leaderInCluster: boolean;       // true if leader element belongs to the cluster pair
+    mainSum: number;                // sum of main-class carac across the 7 team girls (HC=carac1, Charm=carac2, KH=carac3)
     mythicAudit: MythicAuditEntry[]; // every player-class mythic with status (issue #1573, #1603)
 }
 
@@ -181,6 +182,17 @@ export class TeamBuilderService {
             allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass
         );
 
+        // Sum of the player's main carac across the 7 team girls.
+        // This is the league-relevant headline number: in the BDSM stat
+        // formulas (Slynia Performance Handbook), TeamPower is summed
+        // across all caracs of all girls, but only the main class stat
+        // matters for the player's combat math. We log the main_sum so
+        // the user can verify the algorithm's optimization target.
+        const mainSum = team.reduce(
+            (acc, g) => acc + TeamScoringService.getMainCarac(g, playerClass),
+            0
+        );
+
         return {
             girls: team,
             statScores,
@@ -197,6 +209,7 @@ export class TeamBuilderService {
             alternatives,
             playerClass,
             leaderInCluster,
+            mainSum,
             mythicAudit,
         };
     }

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -1,13 +1,23 @@
 // TeamBuilderService.ts -- Builds optimal 7-girl teams using Tier 3
 // trait-group optimization (v4).
 //
-// Algorithm:
+// Algorithm (since v7.35.25):
 //   1. Hard-filter to Mythic + Legendary 5-star, player class only
 //   2. Score by player main-carac (current or projected)
 //   3. Find best trait group (element pair + shared trait value)
 //      compared by main_sum * (1 + tier3Bonus)
-//   4. Select Mythic leader (Shield/Stun priority)
-//   5. Fill slots 2-7 from trait group, then by main-carac
+//   4. Fill positions 2-7 first (6 slots), in this order:
+//        Pass 1  cluster element-pair + matching trait value
+//        Pass 2  cluster element-pair, any trait value
+//        Pass 2a all remaining MYTHICS outside the cluster
+//                (so strong mythics are never ignored, issue #1603)
+//        Pass 3  legendaries outside the cluster (last resort)
+//   5. Pick the leader from the remaining pool (issue #1573):
+//        Mythic preferred, tier-5 priority Shield > Stun > Execute > Reflect,
+//        cluster membership and trait match as tiebreakers, stats last.
+//   6. Audit every mythic in the player's class for the UI: position
+//      in the team, or the reason why it was excluded (other cluster,
+//      lower stats than top picks, ...).
 
 import { BlessingService } from './BlessingService';
 import {
@@ -18,6 +28,21 @@ import {
     TraitGroupResult,
     PlayerClass,
 } from './TeamScoringService';
+
+export type MythicAuditStatus =
+    | 'leader'      // picked as position 1
+    | 'pos2to7'     // picked into positions 2-7
+    | 'excluded';   // not in the team
+
+export interface MythicAuditEntry {
+    id_girl: number;
+    name: string;
+    element: ElementType;
+    mainCarac: number;
+    status: MythicAuditStatus;
+    position?: number;          // 1..7 if status != 'excluded'
+    reason?: string;            // human-readable reason if excluded
+}
 
 export interface TeamResult {
     girls: GirlData[];          // 7 girls, index 0 = leader
@@ -35,15 +60,13 @@ export interface TeamResult {
     alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }>;
     playerClass: PlayerClass;       // 1=HC, 2=Charm, 3=KH (for UI display)
     leaderInCluster: boolean;       // true if leader element belongs to the cluster pair
+    mythicAudit: MythicAuditEntry[]; // every player-class mythic with status (issue #1573, #1603)
 }
 
 export type ScoringMode = 1 | 2;  // 1 = Current Best, 2 = Best Possible
 
 const TEAM_SIZE = 7;
-// No pool cap: the Mythic + Legendary-5* filter is already strict
-// (max ~170 girls per class even if a player owned every released one).
-// Capping here would only risk excluding viable mythics on edge cases.
-// CANDIDATE_POOL_SIZE removed in v7.35.21.
+const POS_2_TO_7 = 6;   // slots filled before the leader
 
 // Map trait category to its element pair for quick lookup
 const ELEMENT_PAIRS_MAP: Record<string, ElementType[]> = {
@@ -60,7 +83,7 @@ export class TeamBuilderService {
      *
      * @param allGirls    - All available girls (from availableGirls)
      * @param mode        - 1 = Current Best, 2 = Best Possible
-     * @param playerLevel - Player's current level (needed for mode 2)
+     * @param playerLevel - Player's current level (kept for legacy callers; not used in scoring)
      * @param playerClass - Player's class (1=HC, 2=Charm, 3=KH)
      * @returns TeamResult with the selected 7 girls, or null if not enough girls
      */
@@ -86,8 +109,7 @@ export class TeamBuilderService {
             scoreMap.set(girl.id_girl, score);
         }
 
-        // Pre-sort and pick a reasonable candidate pool
-        // Sort by score; no cap -- evaluate every eligible girl
+        // Sort by score; no cap -- evaluate every eligible girl.
         const pool = [...candidates].sort(
             (a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0)
         );
@@ -98,7 +120,6 @@ export class TeamBuilderService {
         // Phase 3: Build teams for multiple trait groups, pick highest effective power
         const traitGroups = TeamScoringService.findTraitGroups(pool, playerClass, blessedCategories);
 
-        // Evaluate top groups + all blessed groups
         const groupsToEvaluate: TraitGroupResult[] = [];
         const seenKeys = new Set<string>();
         for (const g of traitGroups.slice(0, 5)) {
@@ -114,7 +135,6 @@ export class TeamBuilderService {
             groupsToEvaluate.push(traitGroups[0]);
         }
 
-        // Build a team for each group and compare effective power
         let bestBuilt: { team: GirlData[], cat: TraitCategory, val: string, power: number } | null = null;
         const alternatives: Array<{ traitCategory: string; traitValue: string; effectivePower: number }> = [];
 
@@ -157,6 +177,10 @@ export class TeamBuilderService {
         const clusterElements = ELEMENT_PAIRS_MAP[traitCategory] || [];
         const leaderInCluster = clusterElements.includes(leader.element);
 
+        const mythicAudit = TeamBuilderService._buildMythicAudit(
+            allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass
+        );
+
         return {
             girls: team,
             statScores,
@@ -173,66 +197,262 @@ export class TeamBuilderService {
             alternatives,
             playerClass,
             leaderInCluster,
+            mythicAudit,
         };
     }
 
     /**
      * Build a team for a specific trait group.
      *
-     * Leader (position 1): picked GLOBALLY from all mythics by tier-5
-     * priority (Shield > Stun > Execute > Reflect). Cluster membership is
-     * only a tiebreaker among same-priority candidates. The leader's job
-     * is the defensive skill, not the trait-3 stack.
+     * Order changed in v7.35.25 (issue #1573, Frank's request):
+     *   1. Fill positions 2-7 first (6 slots) using the four-pass logic.
+     *   2. Pick the leader from the remaining pool.
      *
-     * Slots 2-7: cluster-bound to maximize the tier-3 bonus.
-     *   Pass 1: same element pair + matching trait value (max Tier-3 bonus).
-     *   Pass 2: same element pair, any trait value (still keeps cluster).
-     *   Pass 3: any element by score (last-resort fillers).
+     * Pass logic for positions 2-7:
+     *   Pass 1  cluster element-pair AND matching trait value (max tier-3)
+     *   Pass 2  cluster element-pair (any trait value, keeps mono-element)
+     *   Pass 2a all remaining MYTHICS outside the cluster (NEW, issue #1603)
+     *   Pass 3  any remaining girls by score (legendary fillers)
+     *
+     * Leader (position 1): mythic preferred, tier-5 priority
+     * (Shield > Stun > Execute > Reflect), cluster membership and trait
+     * match as tiebreakers.
      */
     private static _buildTeamForGroup(cat: TraitCategory, val: string, pool: GirlData[], scoreMap: Map<number, number>): GirlData[] | null {
         const elems = ELEMENT_PAIRS_MAP[cat] || [];
-        // Leader pool: ALL mythics globally (not gated by cluster).
-        // Cluster membership is passed as tiebreaker via clusterElements.
-        // If no mythics exist (beginner accounts), fall back to legendary
-        // candidates and let cluster membership become the primary
-        // discriminator since legendary tier-5 skills are typically empty.
-        const mythicPool = pool.filter(g => g.rarity === 'mythic');
-        const leaderCandidates = mythicPool.length > 0 ? mythicPool : pool;
+
+        // Build BOTH strategies, score them, pick the higher Effective Power.
+        // Avoids rainbow teams when cluster-only fill gives a better
+        // tier-3 chain than mythic-priority fill (and vice versa).
+        const variantA = TeamBuilderService._buildVariant(elems, cat, val, pool, scoreMap, 'cluster-first');
+        const variantB = TeamBuilderService._buildVariant(elems, cat, val, pool, scoreMap, 'mythic-first');
+
+        if (!variantA && !variantB) return null;
+        if (!variantA) return variantB;
+        if (!variantB) return variantA;
+
+        const epA = TeamBuilderService._effectivePower(variantA, scoreMap);
+        const epB = TeamBuilderService._effectivePower(variantB, scoreMap);
+        return epA >= epB ? variantA : variantB;
+    }
+
+    /**
+     * Build one variant (slot-fill strategy + leader swap).
+     */
+    private static _buildVariant(
+        elems: ElementType[],
+        cat: TraitCategory,
+        val: string,
+        pool: GirlData[],
+        scoreMap: Map<number, number>,
+        strategy: 'mythic-first' | 'cluster-first'
+    ): GirlData[] | null {
+        const slots = TeamBuilderService._fillSlotsTwoToSeven(elems, val, pool, scoreMap, strategy);
+        if (slots.length < POS_2_TO_7) return null;
+
+        const usedIds = new Set(slots.map(g => g.id_girl));
+        const remaining = pool.filter(g => !usedIds.has(g.id_girl));
+        if (remaining.length === 0) return null;
+
+        // Leader swap: if no mythic is left in the pool but slots contain
+        // mythics AND legendaries are available, swap the weakest slot
+        // mythic out and use it as leader. Guarantees a mythic leader
+        // whenever any mythic exists (Frank's request).
+        const remainingMythic = remaining.find(g => g.rarity === 'mythic');
+        let leaderCandidates: GirlData[] = remaining;
+        let workingSlots = slots;
+        if (!remainingMythic) {
+            const slotMythics = slots.filter(g => g.rarity === 'mythic');
+            const remainingLegendary = remaining.find(g => g.rarity === 'legendary');
+            if (slotMythics.length > 0 && remainingLegendary) {
+                const weakestSlotMythic = slotMythics
+                    .slice()
+                    .sort((a, b) => (scoreMap.get(a.id_girl) || 0) - (scoreMap.get(b.id_girl) || 0))[0];
+                const strongestRemainingLegendary = remaining
+                    .filter(g => g.rarity === 'legendary')
+                    .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0))[0];
+                workingSlots = slots.map(g =>
+                    g.id_girl === weakestSlotMythic.id_girl ? strongestRemainingLegendary : g
+                );
+                leaderCandidates = [weakestSlotMythic];
+            } else {
+                leaderCandidates = remaining;
+            }
+        } else {
+            leaderCandidates = remaining.filter(g => g.rarity === 'mythic');
+        }
         const ranked = TeamScoringService.rankLeaderCandidates(leaderCandidates, scoreMap, cat, val, elems);
         if (ranked.length === 0) return null;
 
-        const team: GirlData[] = [ranked[0]];
-        const used = new Set<number>([ranked[0].id_girl]);
+        return [ranked[0], ...workingSlots];
+    }
 
-        // Pass 1: matching trait value AND correct element
-        const pass1 = pool
-            .filter(g => !used.has(g.id_girl) && elems.includes(g.element) && TeamScoringService.getTraitValue(g) === val)
-            .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-        for (const g of pass1) {
-            if (team.length >= TEAM_SIZE) break;
-            team.push(g); used.add(g.id_girl);
-        }
-        // Pass 2: correct element, any trait value
-        if (team.length < TEAM_SIZE) {
-            const pass2 = pool
-                .filter(g => !used.has(g.id_girl) && elems.includes(g.element))
-                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-            for (const g of pass2) {
-                if (team.length >= TEAM_SIZE) break;
+    /**
+     * Compute Effective Power = main_sum * (1 + tier3Bonus) for a built team.
+     */
+    private static _effectivePower(team: GirlData[], scoreMap: Map<number, number>): number {
+        const sum = team.reduce((s, g) => s + (scoreMap.get(g.id_girl) || 0), 0);
+        const t3 = TeamScoringService.calculateTier3TeamBonus(team);
+        return sum * (1 + t3);
+    }
+
+    /**
+     * Fill positions 2-7 (6 slots) using a pass-based strategy.
+     *
+     * Two variants are produced and the caller compares Effective Power.
+     *
+     * mythic-first: cluster mythics, then cross-cluster mythics, then
+     *               cluster legendaries, then any. Prefers mythic
+     *               coverage even at the cost of Tier-3 bonus.
+     * cluster-first: cluster mythics, then cluster legendaries, then
+     *                cross-cluster mythics, then any. Prefers Tier-3
+     *                bonus even if some mythics are skipped.
+     *
+     * The caller (see _buildTeamForGroup) computes Effective Power
+     * (main_sum * (1 + tier3Bonus)) for both variants and keeps the
+     * better one. That way rainbow teams only happen when they
+     * actually beat the cluster team on raw effective power.
+     */
+    private static _fillSlotsTwoToSeven(
+        elems: ElementType[],
+        val: string,
+        pool: GirlData[],
+        scoreMap: Map<number, number>,
+        strategy: 'mythic-first' | 'cluster-first' = 'cluster-first'
+    ): GirlData[] {
+        const team: GirlData[] = [];
+        const used = new Set<number>();
+        const byScoreDesc = (a: GirlData, b: GirlData): number =>
+            (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0);
+
+        const fillPass = (predicate: (g: GirlData) => boolean): void => {
+            const candidates = pool
+                .filter(g => !used.has(g.id_girl) && predicate(g))
+                .sort(byScoreDesc);
+            for (const g of candidates) {
+                if (team.length >= POS_2_TO_7) break;
                 team.push(g); used.add(g.id_girl);
             }
+        };
+
+        // Step 1 (both strategies): cluster mythics with trait match.
+        // These are the strongest contributors and never hurt either way.
+        fillPass(g => g.rarity === 'mythic'
+            && elems.includes(g.element)
+            && TeamScoringService.getTraitValue(g) === val);
+
+        // Step 2 (both): cluster mythics with any trait value.
+        if (team.length < POS_2_TO_7) {
+            fillPass(g => g.rarity === 'mythic' && elems.includes(g.element));
         }
-        // Pass 3: any element by score
-        if (team.length < TEAM_SIZE) {
-            const pass3 = pool
-                .filter(g => !used.has(g.id_girl))
-                .sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
-            for (const g of pass3) {
-                if (team.length >= TEAM_SIZE) break;
-                team.push(g); used.add(g.id_girl);
+
+        if (strategy === 'mythic-first') {
+            // Step 3a: cross-cluster mythics before any legendary.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => g.rarity === 'mythic');
+            }
+            // Step 4a: cluster legendaries with trait match.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element)
+                    && TeamScoringService.getTraitValue(g) === val);
+            }
+            // Step 5a: cluster legendaries any trait.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element));
+            }
+        } else {
+            // Cluster-first: keep Tier-3 chain intact before mixing in
+            // cross-cluster mythics.
+            // Step 3b: cluster legendaries with trait match.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element)
+                    && TeamScoringService.getTraitValue(g) === val);
+            }
+            // Step 4b: cluster legendaries any trait.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => elems.includes(g.element));
+            }
+            // Step 5b: cross-cluster mythics.
+            if (team.length < POS_2_TO_7) {
+                fillPass(g => g.rarity === 'mythic');
             }
         }
-        return team.length >= TEAM_SIZE ? team : null;
+
+        // Step 6 (both): any remaining girls by score.
+        if (team.length < POS_2_TO_7) {
+            fillPass(() => true);
+        }
+
+        return team;
+    }
+
+    /**
+     * Build the mythic audit list shown in the UI.
+     */
+    private static _buildMythicAudit(
+        allGirls: GirlData[],
+        team: GirlData[],
+        scoreMap: Map<number, number>,
+        traitCategory: TraitCategory,
+        traitValue: string,
+        clusterElements: ElementType[],
+        playerClass: PlayerClass
+    ): MythicAuditEntry[] {
+        const teamIds = new Map<number, number>();
+        team.forEach((g, idx) => teamIds.set(g.id_girl, idx + 1));
+
+        const entries: MythicAuditEntry[] = [];
+        for (const girl of allGirls) {
+            if (girl.rarity !== 'mythic') continue;
+
+            const mainCarac = TeamScoringService.getMainCarac(girl, playerClass);
+            const pos = teamIds.get(girl.id_girl);
+
+            if (pos === 1) {
+                entries.push({
+                    id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                    mainCarac, status: 'leader', position: 1,
+                });
+                continue;
+            }
+            if (pos !== undefined) {
+                entries.push({
+                    id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                    mainCarac, status: 'pos2to7', position: pos,
+                });
+                continue;
+            }
+
+            let reason: string;
+            if (typeof girl.class === 'number' && girl.class !== playerClass) {
+                reason = 'wrong class (filtered out)';
+            } else {
+                const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+                const girlValue = TeamScoringService.getTraitValue(girl);
+                if (girlCategory === traitCategory && girlValue === traitValue) {
+                    reason = 'same trait, lower stats than top picks';
+                } else if (clusterElements.includes(girl.element)) {
+                    reason = 'cluster element, different trait value: '
+                        + girlCategory + '=' + (girlValue || '?');
+                } else {
+                    reason = 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
+                }
+            }
+            entries.push({
+                id_girl: girl.id_girl, name: girl.name, element: girl.element,
+                mainCarac, status: 'excluded', reason,
+            });
+        }
+
+        entries.sort((a, b) => {
+            const aIn = a.status !== 'excluded';
+            const bIn = b.status !== 'excluded';
+            if (aIn !== bIn) return aIn ? -1 : 1;
+            if (aIn && bIn) return (a.position || 99) - (b.position || 99);
+            return b.mainCarac - a.mainCarac;
+        });
+
+        return entries;
     }
 
     /**


### PR DESCRIPTION
Refs #1573 #1603

## Summary

Algorithm refinements for the league-team selection driven by feedback from Frank (#1573) and Dimka (#1603) on v7.35.24.

## Slot order

Positions 2-7 are filled before the leader. Leader is picked from whatever is left in the pool, so a strong cluster girl can no longer be consumed by leader selection. Leader hierarchy unchanged: mythic preferred, tier-5 priority Shield > Stun > Execute > Reflect, cluster membership and trait match as tiebreakers.

## Mythic coverage

Two slot-fill strategies are now built per cluster and compared by Effective Power:

- cluster-priority: keep the Tier-3 chain intact, only mix in cross-cluster mythics if no other source can fill slots 2-7.
- mythic-priority: cluster mythics first, then cross-cluster mythics, then legendaries.

The variant with the higher `main_sum * (1 + tier3Bonus)` wins. Strong cross-cluster mythics now enter the team when including them beats the cluster-only chain; weak cross-cluster mythics still cannot break a healthy chain. A leader swap step guarantees a mythic leader whenever any mythic exists in the player's class.

## Info box additions

- **Mythic Audit:** every mythic in the player's class with status (leader, in slots 2-7, or excluded with a reason: other cluster, lower stats, wrong class, etc.).
- **Class explainer:** eligible pool size (Mythic + Legendary 5* of the player's class), mythic count, plus per-class breakdown of skipped cross-class girls. Includes the rationale (league math rewards only the main class carac).
- **Main Sum:** sum of the main class carac across the 7 picked girls, shown next to Effective Power, with green/red deltas vs the previous click and vs the other mode.
- **Yellow warning** when the own-class pool drops below 7 girls (legacy fall-back).

## Logging

`Team v2` log line now starts with the player class, the carac used as main stat (carac1/2/3), and the Main Sum, so the optimization target is directly visible in debug logs.

## Tests

- 87 service-level unit tests for `TeamScoringService` and `TeamBuilderService` (was 73). New tests cover:
  - Pos 2-7 filled before leader selection.
  - Cross-cluster mythics included before cross-cluster legendaries.
  - Cluster-only team kept when cross-cluster mythics are weak.
  - Leader swap when slots 2-7 consumed every mythic.
  - Mythic Audit content (leader, pos2to7, excluded with reason).
- Full project test suite: 548 passed.
- Build: `webpack` succeeds.

## Files changed

- `src/Service/TeamBuilderService.ts` -- two-variant slot fill, leader after slots 2-7, leader swap, Mythic Audit, Main Sum
- `src/Service/TeamScoringService.ts` -- (no behaviour change in this PR)
- `src/Module/TeamModule.ts` -- info box: Class explainer, Mythic Audit, Main Sum with delta; logging extended
- `src/Service/FeaturePopupService.ts` -- popup title bumped
- `package.json`, `HHAuto.user.js` -- version 7.35.25
- `README.md` -- v7.35.25 release note
- `docs-internal/team-algorithm-design.md` -- Phase 5 (two-variant slot fill), Phase 6 (leader-after-slots), Phase 7 (Mythic Audit, Class explainer, Main Sum), version history, log format
- `spec/Service/TeamBuilderService.spec.ts` -- new tests
