### PR TITLE
chore: ignore local docs-internal/diagrams renderings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ _logs_*/
 *.bak
 *.orig
 *.tmp
+
+# Lokale Diagramm-Renderings (nicht im Repo)
+docs-internal/diagrams/


### PR DESCRIPTION
Add docs-internal/diagrams/ to .gitignore.

Local Mermaid renderings (PNG + .mmd source) for the team-selection algorithm explainer live in this folder. Useful for community posts and quick reference, but not authoritative -- the source of truth stays in docs-internal/team-algorithm-design.md. Renderings can be regenerated on demand from the Mermaid sources.

Keeping them out of the repo avoids large PNG diffs and stale renderings.
