### PR TITLE
chore(test): stage 0 hygiene -- unfocus, revive xits, mock helpers, coverage reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ _logs_*/
 
 # Lokale Diagramm-Renderings (nicht im Repo)
 docs-internal/diagrams/
+
+# Jest Test-Run Artefakte (lokale --json Outputs)
+jest-*.json

--- a/docs-internal/session-handoff-test-strategy.md
+++ b/docs-internal/session-handoff-test-strategy.md
@@ -1,0 +1,89 @@
+# Session-Handoff Test-Strategie HHAuto
+
+Stand: 2026-05-07. Vorherige Session hat Test-Bestand analysiert,
+Gremium-Review durchgefuehrt, Plan erstellt. Plan-Datei liegt unter
+`docs-internal/test-strategy.md` und ist die Source-of-Truth.
+
+## Prompt fuer neue Session (kopieren und einfuegen)
+
+```
+Wir setzen die HHAuto-Test-Strategie um. Vorarbeit aus Vorgaenger-Session ist
+abgeschlossen, Plan liegt unter `docs-internal/test-strategy.md`.
+
+== Sprache und Stil ==
+Deutsch, knackig, keine Floskeln. Antwort direkt und sachlich.
+Workspace-Rules gelten (Git-Identitaet oldron1977@gmail.com, Workflow,
+Anonymitaet, Datei-Schreiben NUR via Python+UTF8 -- siehe Workspace-Rule
+05_File_Write_Workaround).
+
+== Pfad ==
+c:\Users\StephanMesser\.kiro\Arbeitsplatz\HHAuto
+
+== Erste Aktion ==
+1. Lies `docs-internal/test-strategy.md`. Status-Block oben sagt, wo wir stehen.
+2. Pruefe ob die offenen Fragen A, B, C im Abschnitt "Offene Fragen" beantwortet
+   sind. Falls Felder leer: vom User Antworten einholen, Plan-Datei aktualisieren,
+   dann erst Stufe 0 starten.
+3. Wenn alle Fragen beantwortet: weiter mit erster nicht-abgehakter Task.
+
+== Ausstehende Antworten (User muss beantworten falls noch offen) ==
+
+A) xit-Tests inventarisieren? Aufwand 5min, kein Code-Change.
+   Antwort: "Inventarisiere" oder "Skip"
+
+B) fdescribe-versteckte Tests in Champion.spec.ts inventarisieren?
+   Aufwand 2min, kein Code-Change.
+   Antwort: "Inventarisiere" oder "Skip"
+
+C) Subjektive Findings 3, 4, 5 -- jeweils:
+   - C-3 Pachinko String-Mapping-Tests: a streichen / b behalten / c spaeter
+   - C-4 Pipeline.config Konfigwert-Asserts: a Werte raus + Schema bleibt /
+         b komplett behalten / c spaeter
+   - C-5 League jest.spyOn auf statische Methoden: a streichen /
+         b behalten bis Stufe 1 ersetzt sie / c sofort umschreiben
+
+   Default-Empfehlung des Gremiums: C-3a, C-4a, C-5b.
+
+== Workflow pro Task ==
+1. Branch anlegen (`chore/test-hygiene`, `refactor/pure-functions-<modul>`,
+   `feat/test-fixtures-<modul>` etc.)
+2. Implementieren
+3. `npm test` und ggf. `npm run build` lokal ausfuehren
+4. Commit (ohne KI-Erwaehnung, ohne Co-Authored-By)
+5. Push
+6. Auf User-Freigabe warten
+7. PR erstellen, mergen via `gh pr merge --rebase --delete-branch`
+8. In `docs-internal/test-strategy.md` Checkbox abhaken,
+   Status-Block aktualisieren, Aenderungs-Log ergaenzen
+
+== Wichtig ==
+- KEINE Tests automatisch hinzufuegen ohne Plan-Bezug.
+- Bei jedem Finding den Beleg liefern (Datei + Zeile), bevor gepatcht wird.
+- Bei Unsicherheit: Frage stellen, nicht raten.
+- Plan-Datei ist single source of truth. Status dort aktualisieren.
+
+== Datenlage ==
+- `INPUT/hhauto_dump_*.json` (41 MB, 5.5.2026, 30 Pages)
+- `INPUT/HH_DebugLog_*.log` (3 Files, 0,4 Tage alt)
+- Inspector-Skript falls neuer Dump noetig:
+  `bonus-scripts/HHAuto_debug_inspector.user.js` v4.5.0
+```
+
+## Was diese Session geleistet hat
+
+- Test-Bestand analysiert: 39 Specs, 556 Tests, Coverage 30/17/24%.
+- Gremium-Review mit 6 Sub-Agenten (3 Pro / 3 Contra).
+- Roadmap mit 5 Stufen (0-4) erarbeitet, geblockt: Snapshots, Stryker,
+  fast-check als Phase, Coverage-Gate, voller Dump-Split.
+- 8 Findings mit Belegen dokumentiert (Champion.spec.ts fdescribe als
+  schwerwiegendster).
+- Plan-Datei `docs-internal/test-strategy.md` erstellt mit Tasks,
+  Checkboxen, offenen Fragen, xit-Inventar-Tabelle, fdescribe-Inventar-Tabelle.
+
+## Offen vor Stufe-0-Start
+
+1. Frage A: xit inventarisieren ja/nein
+2. Frage B: fdescribe-versteckte Tests inventarisieren ja/nein
+3. Frage C: 3 Sub-Entscheidungen zu Pachinko / Pipeline.config / League
+
+Erst nach Beantwortung kann Stufe 0 starten.

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -5,10 +5,10 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 
 ## Status
 
-- Aktuelle Stufe: **0 (Sofort-Hygiene)** -- noch nicht gestartet
-- Letzte abgeschlossene Task: --
-- Letzter Commit: --
-- Naechster Schritt: Stufe 0 Task 0.1 (fdescribe -> describe in Champion.spec.ts)
+- Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
+- Letzte abgeschlossene Task: 0.1 (fdescribe -> describe in Champion.spec.ts)
+- Letzter Commit: 6fa1e64 (Branch chore/test-hygiene, lokal -- Push offen)
+- Naechster Schritt: Task 0.2 (xit-Tests behandeln) ODER PR fuer 0.1 oeffnen, je nach Praeferenz
 
 ## Kontext
 
@@ -106,7 +106,7 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
 
 ### Stufe 0 -- Sofort-Hygiene (1-2h, kein Risiko)
 
-- [ ] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:39`
+- [x] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:37` (commit 6fa1e64, 2026-05-07)
   - Vorbedingung: Frage B beantwortet, Liste der versteckten Tests bekannt
   - Verifikation: `npm test` zeigt mehr passed Tests als vorher
   - Wenn Tests rot werden: einzeln entscheiden (fix oder xit)
@@ -284,3 +284,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | Erstanlage, Stand vor Stufe 0 |
 | 2026-05-07 | Antworten A=Inv, B=Inv, C-3c/C-4c/C-5c eingetragen, xit/fdescribe inventarisiert |
 | 2026-05-07 | C-5 revidiert auf b (Konflikt-Vermeidung mit Stufe 1) |
+| 2026-05-07 | Task 0.1 erledigt: fdescribe -> describe (commit 6fa1e64). Tests: 549 passed / 7 skipped / 556 total |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 ## Status
 
 - Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
-- Letzte abgeschlossene Task: 0.1 (fdescribe -> describe in Champion.spec.ts)
-- Letzter Commit: 6fa1e64 (Branch chore/test-hygiene, lokal -- Push offen)
-- Naechster Schritt: Task 0.2 (xit-Tests behandeln) ODER PR fuer 0.1 oeffnen, je nach Praeferenz
+- Letzte abgeschlossene Task: 0.2 (alle xit-Tests behandelt, 0 skipped)
+- Letzter Commit: 0d1aee3 (Branch chore/test-hygiene, lokal -- Push offen)
+- Naechster Schritt: Task 0.3 (Findings 3/4/5 -- C-3c, C-4c, C-5b: alle 'spaeter' bzw. 'bis Stufe 1', daher in Stufe 0 nichts zu tun -> direkt zu 0.4)
 
 ## Kontext
 
@@ -110,10 +110,17 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
   - Vorbedingung: Frage B beantwortet, Liste der versteckten Tests bekannt
   - Verifikation: `npm test` zeigt mehr passed Tests als vorher
   - Wenn Tests rot werden: einzeln entscheiden (fix oder xit)
-- [ ] **0.2** xit-Tests behandeln gemaess Antwort A
-  - Wenn "Inventarisiere": Liste in dieser Datei unter "xit-Inventar" eintragen
-  - Pro Test: reparieren, loeschen, oder mit GitHub-Issue-Link xit lassen
-- [ ] **0.3** Findings 3/4/5 gemaess Antwort C umsetzen
+- [x] **0.2** xit-Tests behandeln gemaess Antwort A (commit 0d1aee3, 2026-05-07)
+  - 7 xit-Tests inventarisiert, 5 reaktiviert (alle gruen), 2 leere Stubs entfernt
+  - TimeHelper: canCollectCompetitionActive + getSecondsLeftBeforeNewCompetition (Stubs entfernt)
+  - Season: 2 low-mojo-Tests reaktiviert + Setting autoSeasonSkipLowMojo=true im Test gesetzt
+  - HaremGirl: "Button and no girl" reaktiviert, gruen ohne weitere Aenderung
+  - League: "should return false during the last hour..." reaktiviert, gruen ohne weitere Aenderung
+  - PageNavigationService: toHaveBeenCalledWith -> expect.stringContaining (Test-Bug, Zeitstempel-Praefix)
+- [x] **0.3** Findings 3/4/5 gemaess Antwort C: in Stufe 0 nichts zu tun
+  - C-3c (Pachinko String-Mapping): spaeter beim Pachinko-Refactor
+  - C-4c (Pipeline.config Konfigwert-Asserts): spaeter beim Pipeline-Anfassen
+  - C-5b (League jest.spyOn): bleibt bis Stufe 1 (Pure-Function-Extraktion ersetzt sie)
 - [ ] **0.4** MockHelper erweitern um:
   - `mockBoosterInventory(boosters)` -- setzt sessionStorage Temp_haveBooster
   - `mockSettings(key, value)` -- localStorage HHAuto_Setting_*
@@ -285,3 +292,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | Antworten A=Inv, B=Inv, C-3c/C-4c/C-5c eingetragen, xit/fdescribe inventarisiert |
 | 2026-05-07 | C-5 revidiert auf b (Konflikt-Vermeidung mit Stufe 1) |
 | 2026-05-07 | Task 0.1 erledigt: fdescribe -> describe (commit 6fa1e64). Tests: 549 passed / 7 skipped / 556 total |
+| 2026-05-07 | Task 0.2 erledigt: alle xit behandelt (commit 0d1aee3). Tests: 554 passed / 0 skipped / 554 total |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -1,0 +1,286 @@
+# Test-Strategie HHAuto
+
+Stand: 2026-05-07. Lebende Datei. Bei jeder erledigten Task Checkbox abhaken
+und Datum + Commit-Hash im "Status"-Feld nachtragen.
+
+## Status
+
+- Aktuelle Stufe: **0 (Sofort-Hygiene)** -- noch nicht gestartet
+- Letzte abgeschlossene Task: --
+- Letzter Commit: --
+- Naechster Schritt: Stufe 0 Task 0.1 (fdescribe -> describe in Champion.spec.ts)
+
+## Kontext
+
+- Repo: OldRon1977/HHauto, Userscript fuer Browsergame.
+- 28k LoC TypeScript, 39 Spec-Files / 556 Tests.
+- Coverage: 30% Stmt / 17% Cond / 24% Methods.
+- Test-Stack: Jest + ts-jest + jsdom + mock-local-storage.
+- Pfad: `c:\Users\StephanMesser\.kiro\Arbeitsplatz\HHAuto`
+- Datei-Schreiben NUR via Python+UTF8 (Workspace-Rule 05_File_Write_Workaround).
+
+## Gremium-Konsens (5:1 oder besser)
+
+### Geblockt
+- Snapshot-Tests fuer HTML
+- Mutation Testing (Stryker)
+- Property-Based Testing als eigene Phase (max 1-2 Tests punktuell)
+- Coverage-Threshold als CI-Gate (Reporting ja, Gate nein)
+- 41-MB-Dump in 30 Page-JSONs aufsplitten
+- Pre-Commit-Hook (stattdessen GitHub Action)
+- Trivial-Tests fuer isEnabled-Einzeiler
+
+### Akzeptiert
+- Pure-Function-Extraktion vor Decision-Logic-Tests
+- Kuratierte Mini-Fixtures aus Dump (1-2 pro Modul, 5-20 Zeilen JSON)
+- AJAX-Schema-Tests gegen echte Dump-Responses
+- Storage-Migration-Tests
+- MockHelper erweitern (Welt-Setup-Funktion)
+
+## Offene Fragen vor Stufe-0-Start
+
+Diese Fragen MUSS der User vor Stufe 0 beantworten. Die Antworten landen
+hier in dieser Datei und steuern, was passiert.
+
+### Frage A -- Inventur der 8 xit-Tests
+
+Sollen alle 8 deaktivierten `xit(...)` -Tests im Spec-Verzeichnis lokalisiert
+und mit Datei/Zeile/Test-Name aufgelistet werden?
+
+- Aufwand: 5 Min, reines Grep, kein Code-Change
+- Bekannt: `spec/Service/PageNavigationService.spec.ts:84`,
+  `spec/Module/League.spec.ts` (letzter Test in isTimeToFight)
+- Offen: 6 weitere
+
+**Antwort:** Inventarisiere
+
+### Frage B -- Inventur der durch fdescribe versteckten Tests
+
+Sollen die Test-Cases in `spec/Module/Champion.spec.ts` aufgelistet werden,
+die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
+
+- Aufwand: 2 Min, reines Lesen, kein Code-Change
+- Wirkt sich auf Stufe 0 Task 0.1 aus (was wird wieder gruen/rot beim Fix)
+
+**Antwort:** Inventarisiere
+
+### Frage C -- Umgang mit subjektiven Findings 3, 4, 5
+
+#### C-3 Pachinko.spec.ts (String-Mapping-Tautologie, ~12 it-Cases)
+- a) Streichen
+- b) Behalten
+- c) Spaeter beim Pachinko-Refactor
+
+**Antwort:** c
+
+#### C-4 Pipeline.config.spec.ts (Konfigwert-Asserts wie priority===13)
+- a) Konkrete Wert-Asserts streichen, Schema-Asserts behalten
+- b) Komplett behalten
+- c) Spaeter beim Pipeline-Anfassen
+
+**Antwort:** c
+
+#### C-5 League.spec.ts::isTimeToFight (jest.spyOn auf statische Methoden)
+- a) Streichen
+- b) Behalten bis Stufe 1 (Pure-Function-Extraktion ersetzt sie)
+- c) Sofort umschreiben auf Constructor-Injection / Funktions-Parameter
+
+**Antwort:** b (urspruenglich c, revidiert wegen Konflikt mit Stufe 1 Task 1.1)
+
+**Default-Empfehlung des Gremiums:** C-3a, C-4a, C-5b.
+
+## Findings mit Belegen
+
+| # | Finding | Beleg | Bewertung |
+|---|---|---|---|
+| 1 | `fdescribe` skippt 1 anderen describe-Block in derselben Datei | `spec/Module/Champion.spec.ts:39` | objektiver Bug |
+| 2 | 8 xit-Tests in der Schwebe | Jest meldet `pendingTests=8` | objektiver Mangel |
+| 3 | Pachinko String-Mapping-Tautologie | `spec/Module/Pachinko.spec.ts` komplett | subjektiv (Gremium-Konsens) |
+| 4 | Pipeline.config Konfigwert-Asserts zementieren | `spec/Service/Pipeline.config.spec.ts` handler-spezifische Bloecke | subjektiv (Gremium-Konsens) |
+| 5 | League jest.spyOn auf statische Methoden -- brittle | `spec/Module/League.spec.ts:71-73` | subjektiv (Refactoring-Architekt) |
+| 6 | Coverage-Verteilung extrem ungleich | `coverage/clover.xml`: HaremGirl 5%, League 8%, Champion 4% | objektiv |
+| 7 | Dump enthaelt 30 echte Spielseiten mit Game-State | `INPUT/hhauto_dump_*.json` | nutzbar fuer Mini-Fixtures |
+| 8 | Logfiles enthalten Action-Traces (TeamModule, Generator.next) | `INPUT/HH_DebugLog_*.log` Schluessel `HHAuto_Temp_Logging` | Reliability-Hinweise |
+
+## Roadmap mit Tasks
+
+### Stufe 0 -- Sofort-Hygiene (1-2h, kein Risiko)
+
+- [ ] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:39`
+  - Vorbedingung: Frage B beantwortet, Liste der versteckten Tests bekannt
+  - Verifikation: `npm test` zeigt mehr passed Tests als vorher
+  - Wenn Tests rot werden: einzeln entscheiden (fix oder xit)
+- [ ] **0.2** xit-Tests behandeln gemaess Antwort A
+  - Wenn "Inventarisiere": Liste in dieser Datei unter "xit-Inventar" eintragen
+  - Pro Test: reparieren, loeschen, oder mit GitHub-Issue-Link xit lassen
+- [ ] **0.3** Findings 3/4/5 gemaess Antwort C umsetzen
+- [ ] **0.4** MockHelper erweitern um:
+  - `mockBoosterInventory(boosters)` -- setzt sessionStorage Temp_haveBooster
+  - `mockSettings(key, value)` -- localStorage HHAuto_Setting_*
+  - `mockTimer(name, secondsLeft)` -- TimerHelper-Wrapper
+  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- hh_ajax-Mock
+  - `mockGameGlobals({ heroLevel, energies, settings, ... })` -- Welt-Setup
+  - Datei: `spec/testHelpers/MockHelpers.ts` (existiert)
+- [ ] **0.5** Coverage-Reporter aktivieren (HTML + lcov)
+  - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
+  - Kein Threshold-Gate
+  - Verifikation: `npm test`, dann `coverage/lcov-report/index.html` im Browser
+- [ ] **0.6** Coverage-Reporting via GitHub Action (Issue als Reminder)
+  - Issue im Repo anlegen mit Titel "Coverage-Reporting in CI"
+  - Nicht jetzt umsetzen, nur Reminder
+- [ ] **0.7** Stufe 0 abgeschlossen -- Commit `chore(test): hygiene + mock-helper`
+  - Kein Versions-Bump (nur Tests)
+  - Branch: `chore/test-hygiene`
+  - Push + PR + Merge gemaess Workflow-Rules
+
+### Stufe 1 -- Pure-Function-Extraktion (2-3 Tage, hoher ROI)
+
+Ziel: Aus den grossen Modulen die Entscheidungs-Logik in pure Funktionen
+extrahieren. Eingabe = Daten, Ausgabe = Entscheidung. Keine Globals,
+kein jQuery, kein Storage-Read im Kern.
+
+- [ ] **1.1** League: `decideShouldFight(state) -> bool`
+  - Aus `LeagueHelper.isTimeToFight` extrahieren
+  - State-Type: `{ heroLevel, energy, energyMax, threshold, runThreshold,
+    timerLeft, leagueEndTime, paranoia, boosterRequired, boosterEquipped }`
+  - Public API der Klasse bleibt, ruft intern die pure Funktion
+  - Tests: 8-12 konkrete Cases mit erwartetem bool
+  - Wenn Frage C-5 mit "b" beantwortet: alte spy-Tests jetzt ersetzen
+- [ ] **1.2** Champion: `selectNextChampion(champions, settings, level) -> champion?`
+  - Filter + Sort-Logik aus Champion-Modul extrahieren
+  - Tests: Filter-Settings durchspielen, Hero-Level-Schwellen
+- [ ] **1.3** HaremGirl: `parseGirlsFromGameData(rawData) -> Girl[]`
+  - Pure Parser aus `unsafeWindow.shared.Hero.girls` -> typed `Girl[]`
+  - Eingabe-Fixtures aus Dump (Stufe 2 zieht das nach)
+  - Tests: Mit synthetischen Mini-Eingaben (3 Girls, verschiedene Rarities)
+- [ ] **1.4** AutoLoopActions: `pickNextAction(state) -> action`
+  - State enthaelt: aktive Module, Timer, Energie-Werte, Settings
+  - Output: einer der Action-Typen
+  - Schwierigste Extraktion -- evtl in Teil-Funktionen splitten
+- [ ] **1.5** Stufe 1 abgeschlossen -- Commit pro Modul, Branch je Modul
+  - Branch: `refactor/pure-functions-<modulname>`
+
+### Stufe 2 -- Mini-Fixtures aus Dump (3-4 Tage)
+
+- [ ] **2.1** Fixture-Verzeichnis anlegen: `spec/fixtures/<modul>/`
+- [ ] **2.2** League-Fixtures aus Dump extrahieren
+  - Quelle: `INPUT/hhauto_dump_*.json` Page-Index 1 (`/leagues.html`)
+  - Felder: `teams.opponents_list[0..2]`, `battle.league_rewards`, `hero.shared.Hero.energies.challenge`
+  - Datei: `spec/fixtures/league/opponents-mid-tier.json`, `league-rewards-tier3.json`
+  - Tests: `parseOpponents(fixture) -> Opponent[]`, `parseLeagueRewards(fixture) -> RewardTier[]`
+- [ ] **2.3** HaremGirl-Fixtures
+  - Quelle: Page-Index 0 (`/home.html`) `girls_full.game.shared.Hero`
+  - Auswahl: 3 Girls (1 Mythic 6/6, 1 Legendary 5/5, 1 Common)
+  - Datei: `spec/fixtures/haremGirl/sample-girls.json`
+  - Tests: `parseGirlsFromGameData`, `calculateSalary`, Filter-Funktionen
+- [ ] **2.4** Champion-Fixtures
+  - Quelle: Page-Index 8 (`/champions-map.html`)
+  - Datei: `spec/fixtures/champion/champion-map.json`, `active-champion.json`
+- [ ] **2.5** EventModule-Fixtures
+  - Quelle: Page-Index 13 (`/event.html`)
+  - Datei: `spec/fixtures/event/event-detection.json`
+- [ ] **2.6** Fixture-Loader-Helper
+  - Datei: `spec/testHelpers/Fixtures.ts`
+  - Funktion: `loadFixture(modul, name) -> any`
+- [ ] **2.7** Stufe 2 abgeschlossen -- Commit pro Modul, Branch `feat/test-fixtures-<modul>`
+
+### Stufe 3 -- Decision-Logic-Coverage (2-3 Tage)
+
+Pro `isTimeToX` / `shouldRunY` / `getNextZTime`-Funktion: 4-8 Tests fuer
+Default, Boundaries, Settings-Aus, Level-zu-niedrig, Timer-aktiv,
+Energy-Grenze, AJAX-Error.
+
+Vorbedingung: Stufe 1 hat den Refactor in pure Funktionen erledigt fuer
+das jeweilige Modul.
+
+- [ ] **3.1** ClubChampion -- isTimeToFight, getNextChampionTime
+- [ ] **3.2** Pantheon -- isEnabled (echte Logik, nicht trivial), isTimeToFight
+- [ ] **3.3** MonthlyCard -- shouldClaim, getNextClaimTime
+- [ ] **3.4** LabyrinthAuto -- gesamte Decision-Pipeline
+- [ ] **3.5** Bundles -- Sichtbarkeit/Trigger
+- [ ] **3.6** LivelyScene, BossBang -- isAvailable, Timer-Reset
+- [ ] **3.7** Stufe 3 abgeschlossen -- Branch `feat/test-decision-logic`
+
+### Stufe 4 -- Reliability-Layer (1-2 Tage)
+
+- [ ] **4.1** AJAX-Schema-Tests
+  - Echte Responses aus dem Dump als Fixture (z.B. `live_blessings_api.live`)
+  - Pro Response-Typ ein Validator-Test: `parseResponse(realResponse)` ohne Crash
+- [ ] **4.2** Storage-Migration-Tests
+  - Alte Storage-Werte aus frueheren Versionen als Fixtures
+  - Test: Reader nicht crashen, Default-Wert greifen
+  - Quelle: `INPUT/HH_DebugLog_*.log` enthaelt aktuelle Storage-Snapshots
+- [ ] **4.3** Multi-Domain-Smoke
+  - Pro Domain-Klon (hentaiheroes, gayharem, comixharem, mangarpg, ...) ein
+    Test fuer `domain.includes()` und ConfigHelper-Domain-Erkennung
+  - Datei: `spec/config/Domain.spec.ts`
+- [ ] **4.4** Stufe 4 abgeschlossen -- Branch `feat/test-reliability`
+
+## Bewusst gestrichen (nicht umsetzen)
+
+- Snapshot-Tests fuer HTML
+- Mutation Testing mit Stryker
+- Property-Based Testing als ganze Phase
+- Coverage-Threshold als CI-Gate
+- 41-MB-Dump in 30 Page-JSONs aufsplitten
+- Pre-Commit-Hook
+- Trivial-Tests fuer isEnabled-Einzeiler
+
+## xit-Inventar
+
+(Wird gefuellt nach Frage A. Format: Datei | Zeile | Test-Name | letzter Commit)
+
+Stand: 2026-05-07. 7 xit-Tests gefunden (Plan-Schaetzung war 8).
+
+| # | Datei | Zeile | Test-Name |
+|---|---|---|---|
+| 1 | spec/Helper/TimeHelper.spec.ts | 70 | default |
+| 2 | spec/Helper/TimeHelper.spec.ts | 76 | default |
+| 3 | spec/Module/Events/Season.spec.ts | 231 | low mojo |
+| 4 | spec/Module/Events/Season.spec.ts | 255 | low mojo, energy not max with cards |
+| 5 | spec/Module/harem/HaremGirl.spec.ts | 55 | Button and no girl |
+| 6 | spec/Module/League.spec.ts | 149 | should return false during the last hour of the league if energy is insufficient |
+| 7 | spec/Service/PageNavigationService.spec.ts | 74 | should log an error if Nutaku is detected but no session is found |
+
+## fdescribe-versteckte Tests
+
+Stand: 2026-05-07. `fdescribe("_setTimer")` in Champion.spec.ts:37 fokussiert
+auf 7 Tests innerhalb des _setTimer-Blocks und versteckt damit den
+Schwester-Block findNextChamptionTime mit 1 Test.
+
+| Datei | fdescribe-Block (Zeile) | versteckter describe-Block | Tests skipped |
+|---|---|---|---|
+| spec/Module/Champion.spec.ts | _setTimer (37) | findNextChamptionTime | 1: "default" |
+
+## Datenlage
+
+- `INPUT/hhauto_dump_*.json` (41 MB, 5.5.2026, 30 Pages)
+  - Pages: home, leagues, season-arena, penta-drill-arena, penta-drill,
+    labyrinth (2x), club-champion, champions-map, shop, clubs, pantheon,
+    season, event, seasonal, path-of-glory, path-of-valor, pachinko, map,
+    waifu, activities (5x), hero/profile, member-progression, teams,
+    edit-team, characters/1
+  - Felder pro Page: girls_full, hero, teams, battle, market_equipment,
+    hh_namespace, shared_namespace, local_storage, dom_data_attributes,
+    live_blessings_api
+- `INPUT/HH_DebugLog_*.log` (3 Files, 0,4 Tage alt)
+  - Settings-Snapshot pro File
+  - Schluessel `HHAuto_Temp_Logging` enthaelt zeitgestempelte Action-Traces
+    (TeamModule, Harem, Generator.next mit Slot-Equipment)
+- Bei Bedarf: User um neuen Dump bitten (Inspector-Skript: `bonus-scripts/HHAuto_debug_inspector.user.js` v4.5.0)
+
+## Workflow-Regeln (Erinnerung)
+
+- Branch -> Implementieren -> Commit -> Push -> Test -> Freigabe -> PR -> Merge
+- Identitaet: `oldron1977@gmail.com`, User: `OldRon1977`
+- Keine KI-/Agenten-Erwaehnung in Commits
+- Datei-Schreiben NUR via Python+UTF8 (Workspace-Rule 05)
+- README-Eintrag bei Versions-Bump (nicht in dieser Stufe noetig)
+
+## Aenderungs-Log dieser Datei
+
+| Datum | Aenderung |
+|---|---|
+| 2026-05-07 | Erstanlage, Stand vor Stufe 0 |
+| 2026-05-07 | Antworten A=Inv, B=Inv, C-3c/C-4c/C-5c eingetragen, xit/fdescribe inventarisiert |
+| 2026-05-07 | C-5 revidiert auf b (Konflikt-Vermeidung mit Stufe 1) |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 ## Status
 
 - Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
-- Letzte abgeschlossene Task: 0.2 (alle xit-Tests behandelt, 0 skipped)
-- Letzter Commit: 0d1aee3 (Branch chore/test-hygiene, lokal -- Push offen)
-- Naechster Schritt: Task 0.3 (Findings 3/4/5 -- C-3c, C-4c, C-5b: alle 'spaeter' bzw. 'bis Stufe 1', daher in Stufe 0 nichts zu tun -> direkt zu 0.4)
+- Letzte abgeschlossene Task: 0.4 (MockHelper erweitert um 5 Helper)
+- Letzter Commit: 756004a (Branch chore/test-hygiene, lokal -- Push offen)
+- Naechster Schritt: Task 0.5 (Coverage-Reporter aktivieren)
 
 ## Kontext
 
@@ -121,13 +121,14 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
   - C-3c (Pachinko String-Mapping): spaeter beim Pachinko-Refactor
   - C-4c (Pipeline.config Konfigwert-Asserts): spaeter beim Pipeline-Anfassen
   - C-5b (League jest.spyOn): bleibt bis Stufe 1 (Pure-Function-Extraktion ersetzt sie)
-- [ ] **0.4** MockHelper erweitern um:
-  - `mockBoosterInventory(boosters)` -- setzt sessionStorage Temp_haveBooster
-  - `mockSettings(key, value)` -- localStorage HHAuto_Setting_*
-  - `mockTimer(name, secondsLeft)` -- TimerHelper-Wrapper
-  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- hh_ajax-Mock
-  - `mockGameGlobals({ heroLevel, energies, settings, ... })` -- Welt-Setup
-  - Datei: `spec/testHelpers/MockHelpers.ts` (existiert)
+- [x] **0.4** MockHelper erweitert (commit 756004a, 2026-05-07)
+  - `mockBoosterInventory({normal, mythic})` -- localStorage Temp_boosterStatus
+  - `mockSetting(key, value)` -- localStorage Setting_*
+  - `mockTimer(name, secondsLeft)` -- localStorage Temp_Timers; <=0 clears
+  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- shared.general.hh_ajax
+  - `mockGameGlobals({heroLevel, energies, settings})` -- Welt-Setup
+  - Datei: spec/testHelpers/MockHelpers.ts (143 Zeilen erweitert)
+  - Anmerkung: Hartkodierte Storage-Praefixe abloest durch Imports aus src/config (HHStoredVarPrefixKey, TK)
 - [ ] **0.5** Coverage-Reporter aktivieren (HTML + lcov)
   - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
   - Kein Threshold-Gate
@@ -293,3 +294,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | C-5 revidiert auf b (Konflikt-Vermeidung mit Stufe 1) |
 | 2026-05-07 | Task 0.1 erledigt: fdescribe -> describe (commit 6fa1e64). Tests: 549 passed / 7 skipped / 556 total |
 | 2026-05-07 | Task 0.2 erledigt: alle xit behandelt (commit 0d1aee3). Tests: 554 passed / 0 skipped / 554 total |
+| 2026-05-07 | Task 0.4 erledigt: MockHelper +5 Funktionen (commit 756004a). Tests bleiben 554 passed |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 ## Status
 
 - Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
-- Letzte abgeschlossene Task: 0.4 (MockHelper erweitert um 5 Helper)
-- Letzter Commit: 756004a (Branch chore/test-hygiene, lokal -- Push offen)
-- Naechster Schritt: Task 0.5 (Coverage-Reporter aktivieren)
+- Letzte abgeschlossene Task: 0.5 (Coverage-Reporter aktiviert)
+- Letzter Commit: 2b48603 (Branch chore/test-hygiene, lokal -- Push offen)
+- Naechster Schritt: Task 0.6 (GitHub-Issue fuer CI-Coverage-Reporting anlegen)
 
 ## Kontext
 
@@ -129,10 +129,12 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
   - `mockGameGlobals({heroLevel, energies, settings})` -- Welt-Setup
   - Datei: spec/testHelpers/MockHelpers.ts (143 Zeilen erweitert)
   - Anmerkung: Hartkodierte Storage-Praefixe abloest durch Imports aus src/config (HHStoredVarPrefixKey, TK)
-- [ ] **0.5** Coverage-Reporter aktivieren (HTML + lcov)
-  - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
+- [x] **0.5** Coverage-Reporter aktiviert (commit 2b48603, 2026-05-07)
+  - jest.config.ts: coverageReporters = text, text-summary, lcov, clover, html
   - Kein Threshold-Gate
-  - Verifikation: `npm test`, dann `coverage/lcov-report/index.html` im Browser
+  - text-summary erscheint am Ende jedes npm-test-Laufs
+  - HTML-Report unter coverage/lcov-report/index.html
+  - Aktuelle Werte: 28.92% Stmt / 17.11% Cond / 24.10% Methods / 29.60% Lines
 - [ ] **0.6** Coverage-Reporting via GitHub Action (Issue als Reminder)
   - Issue im Repo anlegen mit Titel "Coverage-Reporting in CI"
   - Nicht jetzt umsetzen, nur Reminder
@@ -295,3 +297,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | Task 0.1 erledigt: fdescribe -> describe (commit 6fa1e64). Tests: 549 passed / 7 skipped / 556 total |
 | 2026-05-07 | Task 0.2 erledigt: alle xit behandelt (commit 0d1aee3). Tests: 554 passed / 0 skipped / 554 total |
 | 2026-05-07 | Task 0.4 erledigt: MockHelper +5 Funktionen (commit 756004a). Tests bleiben 554 passed |
+| 2026-05-07 | Task 0.5 erledigt: Coverage-Reporter aktiviert (commit 2b48603) |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -5,10 +5,10 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 
 ## Status
 
-- Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
-- Letzte abgeschlossene Task: 0.6 (GitHub-Issue #1612 fuer CI-Coverage-Reporting angelegt)
-- Letzter Commit: 7f83ccd (Branch chore/test-hygiene, lokal -- Push offen)
-- Naechster Schritt: Task 0.7 (Push, PR, Merge gemaess Workflow-Rules)
+- Aktuelle Stufe: **0 (Sofort-Hygiene)** -- abgeschlossen, Push und PR ausstehend
+- Letzte abgeschlossene Task: 0.7 (Stufe 0 abgeschlossen)
+- Letzter Commit: <wird beim Push gesetzt> (Branch chore/test-hygiene, 12 Commits, lokal)
+- Naechster Schritt: Push + PR-Review + Merge, danach Stufe 1 (Pure-Function-Extraktion)
 
 ## Kontext
 
@@ -139,10 +139,10 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
   - Issue: https://github.com/OldRon1977/HHauto/issues/1612 ("Coverage-Reporting in CI")
   - Body referenziert diesen Plan
   - Nicht jetzt umsetzen, nur Reminder
-- [ ] **0.7** Stufe 0 abgeschlossen -- Commit `chore(test): hygiene + mock-helper`
+- [x] **0.7** Stufe 0 abgeschlossen (2026-05-07)
+  - Branch: chore/test-hygiene mit 12 Commits
   - Kein Versions-Bump (nur Tests)
-  - Branch: `chore/test-hygiene`
-  - Push + PR + Merge gemaess Workflow-Rules
+  - Push + PR + Merge gemaess Workflow-Rules: in Arbeit (PR ausstehend)
 
 ### Stufe 1 -- Pure-Function-Extraktion (2-3 Tage, hoher ROI)
 
@@ -300,3 +300,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | Task 0.4 erledigt: MockHelper +5 Funktionen (commit 756004a). Tests bleiben 554 passed |
 | 2026-05-07 | Task 0.5 erledigt: Coverage-Reporter aktiviert (commit 2b48603) |
 | 2026-05-07 | Task 0.6 erledigt: Issue #1612 angelegt |
+| 2026-05-07 | Stufe 0 abgeschlossen (Tasks 0.1-0.7), Branch bereit fuer Push |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ und Datum + Commit-Hash im "Status"-Feld nachtragen.
 ## Status
 
 - Aktuelle Stufe: **0 (Sofort-Hygiene)** -- in Arbeit
-- Letzte abgeschlossene Task: 0.5 (Coverage-Reporter aktiviert)
-- Letzter Commit: 2b48603 (Branch chore/test-hygiene, lokal -- Push offen)
-- Naechster Schritt: Task 0.6 (GitHub-Issue fuer CI-Coverage-Reporting anlegen)
+- Letzte abgeschlossene Task: 0.6 (GitHub-Issue #1612 fuer CI-Coverage-Reporting angelegt)
+- Letzter Commit: 7f83ccd (Branch chore/test-hygiene, lokal -- Push offen)
+- Naechster Schritt: Task 0.7 (Push, PR, Merge gemaess Workflow-Rules)
 
 ## Kontext
 
@@ -135,8 +135,9 @@ die wegen `fdescribe("_setTimer",...)` aktuell nicht laufen?
   - text-summary erscheint am Ende jedes npm-test-Laufs
   - HTML-Report unter coverage/lcov-report/index.html
   - Aktuelle Werte: 28.92% Stmt / 17.11% Cond / 24.10% Methods / 29.60% Lines
-- [ ] **0.6** Coverage-Reporting via GitHub Action (Issue als Reminder)
-  - Issue im Repo anlegen mit Titel "Coverage-Reporting in CI"
+- [x] **0.6** Coverage-Reporting via GitHub Action (Issue als Reminder, 2026-05-07)
+  - Issue: https://github.com/OldRon1977/HHauto/issues/1612 ("Coverage-Reporting in CI")
+  - Body referenziert diesen Plan
   - Nicht jetzt umsetzen, nur Reminder
 - [ ] **0.7** Stufe 0 abgeschlossen -- Commit `chore(test): hygiene + mock-helper`
   - Kein Versions-Bump (nur Tests)
@@ -298,3 +299,4 @@ Schwester-Block findNextChamptionTime mit 1 Test.
 | 2026-05-07 | Task 0.2 erledigt: alle xit behandelt (commit 0d1aee3). Tests: 554 passed / 0 skipped / 554 total |
 | 2026-05-07 | Task 0.4 erledigt: MockHelper +5 Funktionen (commit 756004a). Tests bleiben 554 passed |
 | 2026-05-07 | Task 0.5 erledigt: Coverage-Reporter aktiviert (commit 2b48603) |
+| 2026-05-07 | Task 0.6 erledigt: Issue #1612 angelegt |

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,13 +35,10 @@ const config: Config = {
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",
 
-  // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
+  // A list of reporter names that Jest uses when writing coverage reports.
+  // text-summary prints a condensed table at the bottom of the run; html
+  // emits coverage/lcov-report/index.html for browser inspection.
+  coverageReporters: ["text", "text-summary", "lcov", "clover", "html"],
 
   // An object that configures minimum threshold enforcement for coverage results
   // coverageThreshold: undefined,

--- a/spec/Helper/TimeHelper.spec.ts
+++ b/spec/Helper/TimeHelper.spec.ts
@@ -66,15 +66,4 @@ describe("Time Helper", function () {
         });
     });
 
-    describe("canCollectCompetitionActive", function () {
-        xit("default", function () {
-            //expect(TimeHelper.canCollectCompetitionActive()).toBeTruthy()
-        });
-    });
-
-    describe("getSecondsLeftBeforeNewCompetition", function () {
-        xit("default", function () {
-            //expect(TimeHelper.getSecondsLeftBeforeNewCompetition()).toBe(0);
-        });
-    });
 });

--- a/spec/Module/Champion.spec.ts
+++ b/spec/Module/Champion.spec.ts
@@ -34,7 +34,7 @@ describe("Champion module", function () {
     });
 
 
-    fdescribe("_setTimer", function () {
+    describe("_setTimer", function () {
         const TIME_1 = 123;
         const TIME_2 = 456;
         const TIME_COOLDOWN = 3600;

--- a/spec/Module/Events/Season.spec.ts
+++ b/spec/Module/Events/Season.spec.ts
@@ -228,8 +228,9 @@ describe("Season event", function () {
     });
 
     describe("getBestOppo low mojo", function () {
-        xit("low mojo", function () {
+        it("low mojo", function () {
             mockSeasonTierLevel(20);
+            localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoSeasonSkipLowMojo", "true");
             const OPPO_AA = { ...OPPO_A };
             OPPO_AA.mojo = 5;
             let result = Season.getBestOppo([OPPO_AA, OPPO_AA, OPPO_AA]);
@@ -252,8 +253,9 @@ describe("Season event", function () {
             expect(result.chosenIndex).toBe(0);
         });
 
-        xit("low mojo, energy not max with cards", function () {
+        it("low mojo, energy not max with cards", function () {
             mockSeasonTierLevel(20);
+            localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoSeasonSkipLowMojo", "true");
             const OPPO_AA = { ...OPPO_A };
             OPPO_AA.mojo = 5;
             let result = Season.getBestOppo([OPPO_AA, OPPO_AA, OPPO_AA], 11, 15);

--- a/spec/Module/League.spec.ts
+++ b/spec/Module/League.spec.ts
@@ -146,7 +146,7 @@ describe("League", function () {
             expect(result).toBeTruthy();
         });
 
-        xit("should return false during the last hour of the league if energy is insufficient", function () {
+        it("should return false during the last hour of the league if energy is insufficient", function () {
             jest.spyOn(LeagueHelper, "getLeagueEndTime").mockReturnValue(3500); // 1 hour left
             localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoLeaguesThreshold", "15");
             localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoLeaguesRunThreshold", "20");

--- a/spec/Module/harem/HaremGirl.spec.ts
+++ b/spec/Module/harem/HaremGirl.spec.ts
@@ -52,7 +52,7 @@ describe("HaremGirl", function () {
             mockGirl();
             expect(HaremGirl.canGiftGirl()).toBeFalsy();
         });
-        xit("Button and no girl", function () {
+        it("Button and no girl", function () {
             document.body.innerHTML = HTML_START + AFF_BUTTON;
             expect(HaremGirl.canGiftGirl()).toBeFalsy();
         });

--- a/spec/Service/PageNavigationService.spec.ts
+++ b/spec/Service/PageNavigationService.spec.ts
@@ -71,7 +71,7 @@ describe("PageNavigationService", function () {
             expect(result).toEqual(originalObject);
         });
 
-        xit("should log an error if Nutaku is detected but no session is found", function () {
+        it("should log an error if Nutaku is detected but no session is found", function () {
             const originalUrl = "/some/path";
             Object.defineProperty(window, 'location', {
                 value: {
@@ -84,7 +84,7 @@ describe("PageNavigationService", function () {
 
             addNutakuSession(originalUrl);
 
-            expect(logSpy).toHaveBeenCalledWith("ERROR Nutaku detected and no session found");
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR Nutaku detected and no session found"));
 
             logSpy.mockRestore();
         });

--- a/spec/testHelpers/MockHelpers.ts
+++ b/spec/testHelpers/MockHelpers.ts
@@ -1,3 +1,5 @@
+import { HHStoredVarPrefixKey, TK } from '../../src/config/index';
+
 export class MockHelper{
 
     static mockDomain(domain: string = 'www.hentaiheroes.com', page: string = '', search:string = '') {
@@ -75,5 +77,146 @@ export class MockHelper{
             amount: amount,
             max_regen_amount: max
         };
+    }
+    /**
+     * Mocks the booster status in localStorage.
+     * Two parallel inventories: 'normal' (timed, with item.identifier and endAt epoch ms)
+     * and 'mythic' (untimed, only item.identifier).
+     *
+     * Example:
+     *   MockHelper.mockBoosterInventory({
+     *     normal: [{ identifier: 'GS3', secondsLeft: 3600 }],
+     *     mythic: ['MGS5']
+     *   });
+     */
+    static mockBoosterInventory(boosters: { normal?: Array<{ identifier: string; secondsLeft?: number }>; mythic?: string[] } = {}) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        const serverNow = Math.floor(Date.now() / 1000);
+        unsafeWindow.server_now_ts = serverNow;
+
+        const normal = (boosters.normal || []).map(b => ({
+            item: { identifier: b.identifier },
+            endAt: serverNow + (b.secondsLeft ?? 3600)
+        }));
+        const mythic = (boosters.mythic || []).map(id => ({
+            item: { identifier: id }
+        }));
+
+        const status = { normal, mythic };
+        // Storage key matches HHStoredVarPrefixKey + TK.boosterStatus.
+        // Imports are deferred to the test file to keep this helper dependency-free.
+        localStorage.setItem(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(status));
+    }
+
+    /**
+     * Sets a single setting value in localStorage with the HHAuto_Setting_ prefix.
+     * For Boolean-typed settings, pass 'true' or 'false' as a string (matching production storage format).
+     *
+     * Example:
+     *   MockHelper.mockSetting('autoLeaguesBoostedOnly', 'true');
+     */
+    static mockSetting(key: string, value: string) {
+        localStorage.setItem(HHStoredVarPrefixKey + 'Setting_' + key, value);
+    }
+
+    /**
+     * Wraps setTimer for tests, expressing intent more clearly than direct setTimer calls.
+     * secondsLeft <= 0 means the timer is expired (or never set).
+     *
+     * Example:
+     *   MockHelper.mockTimer('nextLeaguesTime', 0);   // expired
+     *   MockHelper.mockTimer('nextSeasonTime', 60);   // 60s remaining
+     */
+    static mockTimer(name: string, secondsLeft: number) {
+        // Direct localStorage write instead of importing setTimer to avoid circular helper dependency.
+        // Production setTimer stores future epoch ms in unsafeWindow Timers and persists JSON to storage.
+        const raw = localStorage.getItem(HHStoredVarPrefixKey + TK.Timers);
+        const timers = raw ? JSON.parse(raw) : {};
+        if (secondsLeft <= 0) {
+            delete timers[name];
+        } else {
+            timers[name] = Date.now() + secondsLeft * 1000;
+        }
+        localStorage.setItem(HHStoredVarPrefixKey + TK.Timers, JSON.stringify(timers));
+    }
+
+    /**
+     * Mocks getHHAjax() to call the success callback with the supplied response.
+     * Production signature: getHHAjax()(params, successCallback).
+     *
+     * Example:
+     *   MockHelper.mockAjaxSuccess({ success: true, league_rewards: [] });
+     */
+    static mockAjaxSuccess(response: any) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        if (!unsafeWindow.shared.general) unsafeWindow.shared.general = {} as any;
+        unsafeWindow.shared.general.hh_ajax = (_params: any, successCb: (data: any) => void) => {
+            successCb(response);
+        };
+    }
+
+    /**
+     * Mocks getHHAjax() to throw the given error from the synchronous call site.
+     * Production code typically does not pass an error callback; modules wrap in try/catch.
+     *
+     * Example:
+     *   MockHelper.mockAjaxError(new Error('network down'));
+     */
+    static mockAjaxError(error: Error) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        if (!unsafeWindow.shared.general) unsafeWindow.shared.general = {} as any;
+        unsafeWindow.shared.general.hh_ajax = () => {
+            throw error;
+        };
+    }
+
+    /**
+     * One-shot world setup combining hero level, energies, and arbitrary settings.
+     * Each parameter is optional; only provided fields are touched.
+     *
+     * Example:
+     *   MockHelper.mockGameGlobals({
+     *     heroLevel: 500,
+     *     energies: { challenge: { amount: 16, max: 20 } },
+     *     settings: { autoLeaguesThreshold: '5', autoLeaguesBoostedOnly: 'true' }
+     *   });
+     */
+    static mockGameGlobals(globals: {
+        heroLevel?: number;
+        energies?: Partial<{
+            fight: { amount: number; max: number };
+            challenge: { amount: number; max: number };
+            kiss: { amount: number; max: number };
+            quest: { amount: number; max: number };
+            worship: { amount: number; max: number };
+            drill: { amount: number; max: number };
+        }>;
+        settings?: Record<string, string>;
+    } = {}) {
+        if (globals.heroLevel !== undefined) {
+            MockHelper.mockHeroLevel(globals.heroLevel);
+        } else if (!unsafeWindow.shared?.Hero) {
+            // Ensure baseline structure so energy mocks don't NPE.
+            MockHelper.mockHeroLevel(1);
+        }
+
+        const energyMockers = {
+            fight: MockHelper.mockEnergiesFight,
+            challenge: MockHelper.mockEnergiesChallenge,
+            kiss: MockHelper.mockEnergiesKiss,
+            quest: MockHelper.mockEnergiesQuest,
+            worship: MockHelper.mockEnergiesWorship,
+            drill: MockHelper.mockEnergiesDrill,
+        };
+        for (const [key, energy] of Object.entries(globals.energies || {})) {
+            const mocker = (energyMockers as any)[key];
+            if (mocker && energy) {
+                mocker(energy.amount, energy.max);
+            }
+        }
+
+        for (const [key, value] of Object.entries(globals.settings || {})) {
+            MockHelper.mockSetting(key, value);
+        }
     }
 }


### PR DESCRIPTION
﻿Stufe 0 der Test-Strategie (siehe docs-internal/test-strategy.md).
Hygiene-Massnahmen ohne Verhaltensaenderung am Userscript -- nur Tests,
Mocks, Test-Infrastruktur, Plan-Doku.

## Aenderungen

### Tests freigegeben
- Champion: fdescribe -> describe (1 versteckter Test laeuft wieder)
- 5 von 7 xit-Tests reaktiviert und gruen
  - Season: 2 Tests (Setting autoSeasonSkipLowMojo musste in den Tests gesetzt werden)
  - HaremGirl, League: laufen direkt gruen
  - PageNavigationService: stringContaining statt exaktem String-Match
- 2 leere Stub-Tests in TimeHelper entfernt (canCollectCompetitionActive, getSecondsLeftBeforeNewCompetition)

### Test-Infrastruktur
- MockHelper um Methoden erweitert: mockBoosterInventory, mockSetting, mockTimer, mockAjaxSuccess, mockAjaxError, mockGameGlobals
- Coverage-Reporter explizit gesetzt: text, text-summary, lcov, clover, html

### Aufraeumen
- jest-*.json zu .gitignore (Test-Run-Artefakte)

### Doku
- docs-internal/test-strategy.md mit Stufe-0-Bilanz und Stufen 1-4 als Roadmap
- docs-internal/session-handoff-test-strategy.md fuer kommende Sessions

## Test-Bilanz

- Vorher: 549 passed / 7 skipped / 556 total
- Nachher: 554 passed / 0 skipped / 554 total

## Coverage (jetzt automatisch nach jedem Lauf sichtbar)

- Statements: 28.92%
- Branches:   17.11%
- Functions:  24.10%
- Lines:      29.60%

Refs #1612 (Coverage-Reporting in CI -- Reminder fuer naechste Stufe)