### PR TITLE
chore(test): stage 0 hygiene -- unfocus, revive xits, mock helpers, coverage reporters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ _logs_*/
 
 # Lokale Diagramm-Renderings (nicht im Repo)
 docs-internal/diagrams/
+
+# Jest test-run artefacts (local --json outputs)
+jest-*.json

--- a/docs-internal/session-handoff-test-strategy.md
+++ b/docs-internal/session-handoff-test-strategy.md
@@ -1,0 +1,93 @@
+# Session handoff -- HHAuto test strategy
+
+Status: 2026-05-07. The previous session analysed the test inventory, ran a
+review with sub-agents, and produced the plan. The plan file lives at
+`docs-internal/test-strategy.md` and is the source of truth.
+
+## Prompt for a new session (copy and paste)
+
+```
+We are continuing the HHAuto test strategy. Preparation from the previous
+session is finished, the plan is at `docs-internal/test-strategy.md`.
+
+== Language and style ==
+German output, terse, no filler. Direct and factual responses.
+Workspace rules apply (Git identity oldron1977@gmail.com, workflow,
+agent anonymity, file writes via Python+UTF8 only -- see workspace rule
+05_File_Write_Workaround).
+
+Repository content (commits, PR/issue text, code comments) is in English.
+
+== Path ==
+c:\\Users\\StephanMesser\\.kiro\\Arbeitsplatz\\HHAuto
+
+== First action ==
+1. Read `docs-internal/test-strategy.md`. The status block on top tells
+   you where we are.
+2. Check whether questions A, B, C in the \"Open questions\" section have
+   been answered. If any field is empty: ask the user, update the plan,
+   only then start stage 0.
+3. If everything is answered: continue with the next unchecked task.
+
+== Pending answers (user must answer if still open) ==
+
+A) Inventory the xit tests? Effort 5 min, no code change.
+   Answer: \"Inventory\" or \"Skip\"
+
+B) Inventory the tests hidden by fdescribe in Champion.spec.ts?
+   Effort 2 min, no code change.
+   Answer: \"Inventory\" or \"Skip\"
+
+C) Subjective findings 3, 4, 5 -- for each:
+   - C-3 Pachinko string-mapping tests: a drop / b keep / c defer
+   - C-4 Pipeline.config value asserts: a values out + schema stays /
+         b keep all / c defer
+   - C-5 League jest.spyOn on static methods: a drop /
+         b keep until stage 1 replaces them / c rewrite immediately
+
+   Default recommendation from the review: C-3a, C-4a, C-5b.
+
+== Workflow per task ==
+1. Branch (`chore/test-hygiene`, `refactor/pure-functions-<module>`,
+   `feat/test-fixtures-<module>` etc.)
+2. Implement
+3. `npm test` and where appropriate `npm run build` locally
+4. Commit (no AI mention, no Co-Authored-By)
+5. Push
+6. Wait for user approval
+7. Open PR, merge with `gh pr merge --rebase --delete-branch`
+8. Tick the checkbox in `docs-internal/test-strategy.md`,
+   update the status block, append to the change log
+
+== Important ==
+- Do NOT auto-add tests without a plan reference.
+- For every finding provide evidence (file + line) before patching.
+- When in doubt: ask the user, do not guess.
+- The plan file is the single source of truth. Update its status there.
+
+== Data ==
+- `INPUT/hhauto_dump_*.json` (41 MB, 2026-05-05, 30 pages)
+- `INPUT/HH_DebugLog_*.log` (3 files, ~10h old)
+- Inspector script if a fresh dump is needed:
+  `bonus-scripts/HHAuto_debug_inspector.user.js` v4.5.0
+```
+
+## What this session produced
+
+- Test inventory analysed: 39 specs, 556 tests, coverage 30/17/24%.
+- Review with 6 sub-agents (3 pro / 3 contra).
+- Roadmap with 5 stages (0-4); blocked: snapshots, Stryker,
+  fast-check as a phase, coverage gate, full dump split.
+- 8 findings documented with evidence (Champion.spec.ts fdescribe is the
+  most severe).
+- Plan file `docs-internal/test-strategy.md` created with tasks,
+  checkboxes, open questions, xit inventory table, fdescribe inventory
+  table.
+
+## Open before stage 0
+
+1. Question A: inventory xit yes/no
+2. Question B: inventory fdescribe-hidden tests yes/no
+3. Question C: 3 sub-decisions on Pachinko / Pipeline.config / League
+
+Stage 0 cannot start until these are answered.

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ and add the date plus commit hash in the Status field.
 ## Status
 
 - Current stage: **0 (immediate hygiene)** -- in progress
-- Last completed task: 0.4 (MockHelper extended)
+- Last completed task: 0.5 (coverage reporters enabled)
 - Last commit: <set in commit message>
-- Next step: task 0.5 (enable coverage reporters)
+- Next step: task 0.6 (open GitHub issue for CI coverage reporting)
 
 ## Context
 
@@ -118,10 +118,12 @@ because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
   - `mockGameGlobals({ heroLevel, energies, settings })` -- world setup
   - File: spec/testHelpers/MockHelpers.ts (143 lines added)
   - Note: storage prefixes pulled from src/config (HHStoredVarPrefixKey, TK) instead of hardcoded literals
-- [ ] **0.5** Enable coverage reporters (HTML + lcov)
-  - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
+- [x] **0.5** Coverage reporters enabled (2026-05-07)
+  - jest.config.ts: coverageReporters = text, text-summary, lcov, clover, html
   - No threshold gate
-  - Verification: `npm test`, then open `coverage/lcov-report/index.html`
+  - text-summary prints at the end of every npm test run
+  - HTML report at coverage/lcov-report/index.html
+  - Current values: 28.92% statements / 17.11% branches / 24.10% functions / 29.60% lines
 - [ ] **0.6** Coverage reporting via GitHub Action (issue as reminder)
   - Open an issue titled \"Coverage reporting in CI\"
   - Do not implement now, just track
@@ -281,3 +283,4 @@ findNextChamptionTime with 1 test.
 | 2026-05-07 | Task 0.1 done: fdescribe -> describe. Tests: 549 passed / 7 skipped / 556 total |
 | 2026-05-07 | Tasks 0.2 + 0.3 done: every xit handled. Tests: 554 passed / 0 skipped / 554 total |
 | 2026-05-07 | Task 0.4 done: MockHelper +5 functions. Tests stay 554 passed |
+| 2026-05-07 | Task 0.5 done: coverage reporters enabled |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -5,10 +5,10 @@ and add the date plus commit hash in the Status field.
 
 ## Status
 
-- Current stage: **0 (immediate hygiene)** -- in progress
-- Last completed task: 0.5 (coverage reporters enabled)
+- Current stage: **0 (immediate hygiene)** -- finished, push and PR pending
+- Last completed task: 0.7 (stage 0 finished)
 - Last commit: <set in commit message>
-- Next step: task 0.6 (open GitHub issue for CI coverage reporting)
+- Next step: push + PR review + merge, then stage 1 (pure-function extraction)
 
 ## Context
 
@@ -124,13 +124,14 @@ because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
   - text-summary prints at the end of every npm test run
   - HTML report at coverage/lcov-report/index.html
   - Current values: 28.92% statements / 17.11% branches / 24.10% functions / 29.60% lines
-- [ ] **0.6** Coverage reporting via GitHub Action (issue as reminder)
-  - Open an issue titled \"Coverage reporting in CI\"
+- [x] **0.6** Coverage reporting via GitHub Action (issue as reminder, 2026-05-07)
+  - Issue: https://github.com/OldRon1977/HHauto/issues/1614 (\"Coverage reporting in CI\")
+  - Body references this plan
   - Do not implement now, just track
-- [ ] **0.7** Stage 0 finished -- commit `chore(test): hygiene + mock-helper`
+- [x] **0.7** Stage 0 finished (2026-05-07)
+  - Branch: chore/test-hygiene with 7 commits
   - No version bump (tests only)
-  - Branch: `chore/test-hygiene`
-  - Push + PR + merge per workflow rules
+  - Push + PR + merge per workflow rules: in progress (PR pending)
 
 ### Stage 1 -- pure-function extraction (2-3 days, high ROI)
 
@@ -284,3 +285,5 @@ findNextChamptionTime with 1 test.
 | 2026-05-07 | Tasks 0.2 + 0.3 done: every xit handled. Tests: 554 passed / 0 skipped / 554 total |
 | 2026-05-07 | Task 0.4 done: MockHelper +5 functions. Tests stay 554 passed |
 | 2026-05-07 | Task 0.5 done: coverage reporters enabled |
+| 2026-05-07 | Task 0.6 done: issue #1614 opened |
+| 2026-05-07 | Stage 0 finished (tasks 0.1-0.7), branch ready for push |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ and add the date plus commit hash in the Status field.
 ## Status
 
 - Current stage: **0 (immediate hygiene)** -- in progress
-- Last completed task: 0.3 (subjective findings handled)
+- Last completed task: 0.4 (MockHelper extended)
 - Last commit: <set in commit message>
-- Next step: task 0.4 (extend MockHelper)
+- Next step: task 0.5 (enable coverage reporters)
 
 ## Context
 
@@ -110,13 +110,14 @@ because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
   - C-3c (Pachinko string mapping): defer to the Pachinko refactor
   - C-4c (Pipeline.config value asserts): defer to the next Pipeline change
   - C-5b (League jest.spyOn): keep until stage 1 (pure-function extraction replaces them)
-- [ ] **0.4** Extend MockHelper with:
-  - `mockBoosterInventory(boosters)` -- writes Temp_boosterStatus
+- [x] **0.4** MockHelper extended (2026-05-07)
+  - `mockBoosterInventory({normal, mythic})` -- localStorage Temp_boosterStatus
   - `mockSetting(key, value)` -- localStorage Setting_*
-  - `mockTimer(name, secondsLeft)` -- TimerHelper wrapper
-  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- hh_ajax mock
-  - `mockGameGlobals({ heroLevel, energies, settings, ... })` -- world setup
-  - File: `spec/testHelpers/MockHelpers.ts` (exists)
+  - `mockTimer(name, secondsLeft)` -- localStorage Temp_Timers; <=0 clears
+  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- shared.general.hh_ajax
+  - `mockGameGlobals({ heroLevel, energies, settings })` -- world setup
+  - File: spec/testHelpers/MockHelpers.ts (143 lines added)
+  - Note: storage prefixes pulled from src/config (HHStoredVarPrefixKey, TK) instead of hardcoded literals
 - [ ] **0.5** Enable coverage reporters (HTML + lcov)
   - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
   - No threshold gate
@@ -279,3 +280,4 @@ findNextChamptionTime with 1 test.
 | 2026-05-07 | Initial draft, state before stage 0 |
 | 2026-05-07 | Task 0.1 done: fdescribe -> describe. Tests: 549 passed / 7 skipped / 556 total |
 | 2026-05-07 | Tasks 0.2 + 0.3 done: every xit handled. Tests: 554 passed / 0 skipped / 554 total |
+| 2026-05-07 | Task 0.4 done: MockHelper +5 functions. Tests stay 554 passed |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -5,10 +5,10 @@ and add the date plus commit hash in the Status field.
 
 ## Status
 
-- Current stage: **0 (immediate hygiene)** -- not started
-- Last completed task: --
-- Last commit: --
-- Next step: stage 0 task 0.1 (fdescribe -> describe in Champion.spec.ts)
+- Current stage: **0 (immediate hygiene)** -- in progress
+- Last completed task: 0.1 (fdescribe -> describe in Champion.spec.ts)
+- Last commit: <set in commit message>
+- Next step: task 0.2 (handle xit tests)
 
 ## Context
 
@@ -95,7 +95,7 @@ because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
 
 ### Stage 0 -- immediate hygiene (1-2h, no risk)
 
-- [ ] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:37`
+- [x] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:37` (2026-05-07)
   - Precondition: question B answered, hidden tests known
   - Verification: `npm test` shows more passing tests than before
   - If tests turn red: decide individually (fix or xit)
@@ -270,3 +270,4 @@ findNextChamptionTime with 1 test.
 | Date | Change |
 |---|---|
 | 2026-05-07 | Initial draft, state before stage 0 |
+| 2026-05-07 | Task 0.1 done: fdescribe -> describe. Tests: 549 passed / 7 skipped / 556 total |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -1,0 +1,272 @@
+# Test Strategy HHAuto
+
+Status: 2026-05-07. Living document. When a task is finished, tick the checkbox
+and add the date plus commit hash in the Status field.
+
+## Status
+
+- Current stage: **0 (immediate hygiene)** -- not started
+- Last completed task: --
+- Last commit: --
+- Next step: stage 0 task 0.1 (fdescribe -> describe in Champion.spec.ts)
+
+## Context
+
+- Repo: OldRon1977/HHauto, userscript for a browser game.
+- 28k LoC TypeScript, 39 spec files / 556 tests.
+- Coverage: 30% statements / 17% branches / 24% functions.
+- Test stack: Jest + ts-jest + jsdom + mock-local-storage.
+- Path: `c:\\Users\\StephanMesser\\.kiro\\Arbeitsplatz\\HHAuto`
+- File writes only via Python+UTF8 (workspace rule 05_File_Write_Workaround).
+
+## Review consensus (5:1 or better)
+
+### Blocked
+- Snapshot tests for HTML
+- Mutation testing (Stryker)
+- Property-based testing as its own phase (one or two targeted tests at most)
+- Coverage threshold as a CI gate (reporting yes, gate no)
+- Splitting the 41 MB dump into 30 page JSONs
+- Pre-commit hook (use a GitHub Action instead)
+- Trivial tests for one-line `isEnabled` getters
+
+### Accepted
+- Pure-function extraction before decision-logic tests
+- Curated mini fixtures from the dump (one or two per module, 5-20 lines of JSON)
+- AJAX schema tests against real dump responses
+- Storage migration tests
+- Extended MockHelper (world setup helper)
+
+## Open questions answered before stage 0
+
+### Question A -- inventory of `xit` tests
+
+Locate every disabled `xit(...)` test in the spec tree and list it with
+file/line/test name? Effort: 5 minutes, plain grep, no code change.
+
+**Answer:** Inventory.
+
+### Question B -- inventory of tests hidden by `fdescribe`
+
+List the tests in `spec/Module/Champion.spec.ts` that currently do not run
+because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
+
+**Answer:** Inventory.
+
+### Question C -- handling of subjective findings 3, 4, 5
+
+#### C-3 Pachinko.spec.ts (string-mapping tautology, ~12 it cases)
+- a) Drop
+- b) Keep
+- c) Defer to the Pachinko refactor
+
+**Answer:** c
+
+#### C-4 Pipeline.config.spec.ts (config-value asserts like `priority === 13`)
+- a) Drop value asserts, keep schema asserts
+- b) Keep everything
+- c) Defer to the next Pipeline change
+
+**Answer:** c
+
+#### C-5 League.spec.ts::isTimeToFight (`jest.spyOn` on static methods)
+- a) Drop
+- b) Keep until stage 1 (pure-function extraction replaces them)
+- c) Rewrite immediately to constructor injection / function parameters
+
+**Answer:** b (originally c, revised to avoid conflict with stage 1 task 1.1)
+
+**Default recommendation from the review:** C-3a, C-4a, C-5b.
+
+## Findings with evidence
+
+| # | Finding | Evidence | Verdict |
+|---|---|---|---|
+| 1 | `fdescribe` skips one sibling describe in the same file | `spec/Module/Champion.spec.ts:39` | objective bug |
+| 2 | 8 xit tests in limbo | Jest reports `pendingTests=8` | objective gap |
+| 3 | Pachinko string-mapping tautology | full `spec/Module/Pachinko.spec.ts` | subjective (consensus) |
+| 4 | Pipeline.config asserts hardcode config values | `spec/Service/Pipeline.config.spec.ts` handler-specific blocks | subjective (consensus) |
+| 5 | League `jest.spyOn` on static methods -- brittle | `spec/Module/League.spec.ts:71-73` | subjective (refactoring architect) |
+| 6 | Coverage spread is highly uneven | `coverage/clover.xml`: HaremGirl 5%, League 8%, Champion 4% | objective |
+| 7 | Dump contains 30 real game pages with game state | `INPUT/hhauto_dump_*.json` | usable for mini fixtures |
+| 8 | Log files contain action traces (TeamModule, Generator.next) | `INPUT/HH_DebugLog_*.log` key `HHAuto_Temp_Logging` | reliability hints |
+
+## Roadmap
+
+### Stage 0 -- immediate hygiene (1-2h, no risk)
+
+- [ ] **0.1** `fdescribe` -> `describe` in `spec/Module/Champion.spec.ts:37`
+  - Precondition: question B answered, hidden tests known
+  - Verification: `npm test` shows more passing tests than before
+  - If tests turn red: decide individually (fix or xit)
+- [ ] **0.2** Handle xit tests according to answer A
+  - On \"Inventory\": list under \"xit inventory\" below
+  - Per test: fix, drop, or leave xit'd with a GitHub-issue link
+- [ ] **0.3** Apply findings 3/4/5 according to answer C
+- [ ] **0.4** Extend MockHelper with:
+  - `mockBoosterInventory(boosters)` -- writes Temp_boosterStatus
+  - `mockSetting(key, value)` -- localStorage Setting_*
+  - `mockTimer(name, secondsLeft)` -- TimerHelper wrapper
+  - `mockAjaxSuccess(response)` / `mockAjaxError(error)` -- hh_ajax mock
+  - `mockGameGlobals({ heroLevel, energies, settings, ... })` -- world setup
+  - File: `spec/testHelpers/MockHelpers.ts` (exists)
+- [ ] **0.5** Enable coverage reporters (HTML + lcov)
+  - In `jest.config.ts`: `coverageReporters: ['text', 'text-summary', 'lcov', 'clover', 'html']`
+  - No threshold gate
+  - Verification: `npm test`, then open `coverage/lcov-report/index.html`
+- [ ] **0.6** Coverage reporting via GitHub Action (issue as reminder)
+  - Open an issue titled \"Coverage reporting in CI\"
+  - Do not implement now, just track
+- [ ] **0.7** Stage 0 finished -- commit `chore(test): hygiene + mock-helper`
+  - No version bump (tests only)
+  - Branch: `chore/test-hygiene`
+  - Push + PR + merge per workflow rules
+
+### Stage 1 -- pure-function extraction (2-3 days, high ROI)
+
+Goal: extract decision logic out of the large modules into pure functions.
+Input = data, output = decision. No globals, no jQuery, no storage reads in
+the core.
+
+- [ ] **1.1** League: `decideShouldFight(state) -> bool`
+  - Extract from `LeagueHelper.isTimeToFight`
+  - State type: `{ heroLevel, energy, energyMax, threshold, runThreshold,
+    timerLeft, leagueEndTime, paranoia, boosterRequired, boosterEquipped }`
+  - Public API of the class stays, internally calls the pure function
+  - Tests: 8-12 concrete cases with expected bool
+  - If question C-5 answered with \"b\": replace the old spy tests now
+- [ ] **1.2** Champion: `selectNextChampion(champions, settings, level) -> champion?`
+  - Extract filter + sort logic from the Champion module
+  - Tests: walk through filter settings, hero-level thresholds
+- [ ] **1.3** HaremGirl: `parseGirlsFromGameData(rawData) -> Girl[]`
+  - Pure parser from `unsafeWindow.shared.Hero.girls` -> typed `Girl[]`
+  - Input fixtures from the dump (stage 2 backfills them)
+  - Tests: synthetic mini inputs (3 girls, varied rarities)
+- [ ] **1.4** AutoLoopActions: `pickNextAction(state) -> action`
+  - State: active modules, timers, energy values, settings
+  - Output: one of the action types
+  - Hardest extraction -- may need to be split into sub-functions
+- [ ] **1.5** Stage 1 finished -- one commit per module, branch per module
+  - Branch: `refactor/pure-functions-<module>`
+
+### Stage 2 -- mini fixtures from the dump (3-4 days)
+
+- [ ] **2.1** Create fixture directory: `spec/fixtures/<module>/`
+- [ ] **2.2** Extract League fixtures from the dump
+  - Source: `INPUT/hhauto_dump_*.json` page index 1 (`/leagues.html`)
+  - Fields: `teams.opponents_list[0..2]`, `battle.league_rewards`, `hero.shared.Hero.energies.challenge`
+  - Files: `spec/fixtures/league/opponents-mid-tier.json`, `league-rewards-tier3.json`
+  - Tests: `parseOpponents(fixture) -> Opponent[]`, `parseLeagueRewards(fixture) -> RewardTier[]`
+- [ ] **2.3** HaremGirl fixtures
+  - Source: page index 0 (`/home.html`) `girls_full.game.shared.Hero`
+  - Selection: 3 girls (1 mythic 6/6, 1 legendary 5/5, 1 common)
+  - File: `spec/fixtures/haremGirl/sample-girls.json`
+  - Tests: `parseGirlsFromGameData`, `calculateSalary`, filter functions
+- [ ] **2.4** Champion fixtures
+  - Source: page index 8 (`/champions-map.html`)
+  - Files: `spec/fixtures/champion/champion-map.json`, `active-champion.json`
+- [ ] **2.5** EventModule fixtures
+  - Source: page index 13 (`/event.html`)
+  - File: `spec/fixtures/event/event-detection.json`
+- [ ] **2.6** Fixture loader helper
+  - File: `spec/testHelpers/Fixtures.ts`
+  - Function: `loadFixture(module, name) -> any`
+- [ ] **2.7** Stage 2 finished -- one commit per module, branch `feat/test-fixtures-<module>`
+
+### Stage 3 -- decision-logic coverage (2-3 days)
+
+For each `isTimeToX` / `shouldRunY` / `getNextZTime`: 4-8 tests covering
+default, boundaries, setting-off, hero-level too low, timer active,
+energy edge, AJAX error.
+
+Precondition: stage 1 has produced a pure function for the respective
+module.
+
+- [ ] **3.1** ClubChampion -- isTimeToFight, getNextChampionTime
+- [ ] **3.2** Pantheon -- isEnabled (real logic, not trivial), isTimeToFight
+- [ ] **3.3** MonthlyCard -- shouldClaim, getNextClaimTime
+- [ ] **3.4** LabyrinthAuto -- entire decision pipeline
+- [ ] **3.5** Bundles -- visibility / trigger
+- [ ] **3.6** LivelyScene, BossBang -- isAvailable, timer reset
+- [ ] **3.7** Stage 3 finished -- branch `feat/test-decision-logic`
+
+### Stage 4 -- reliability layer (1-2 days)
+
+- [ ] **4.1** AJAX schema tests
+  - Real responses from the dump as fixtures (e.g. `live_blessings_api.live`)
+  - One validator test per response type: `parseResponse(realResponse)` does not crash
+- [ ] **4.2** Storage migration tests
+  - Old storage values from earlier versions as fixtures
+  - Test: reader does not crash, default value kicks in
+  - Source: `INPUT/HH_DebugLog_*.log` contains current storage snapshots
+- [ ] **4.3** Multi-domain smoke
+  - Per domain clone (hentaiheroes, gayharem, comixharem, mangarpg, ...) one
+    test for `domain.includes()` and ConfigHelper domain detection
+  - File: `spec/config/Domain.spec.ts`
+- [ ] **4.4** Stage 4 finished -- branch `feat/test-reliability`
+
+## Deliberately dropped (do not implement)
+
+- Snapshot tests for HTML
+- Mutation testing with Stryker
+- Property-based testing as a whole phase
+- Coverage threshold as a CI gate
+- Splitting the 41 MB dump into 30 page JSONs
+- Pre-commit hook
+- Trivial tests for one-line `isEnabled` getters
+
+## xit inventory
+
+Status: 2026-05-07. 7 xit tests found (the plan's initial estimate was 8).
+
+| # | File | Line | Test name |
+|---|---|---|---|
+| 1 | spec/Helper/TimeHelper.spec.ts | 70 | default |
+| 2 | spec/Helper/TimeHelper.spec.ts | 76 | default |
+| 3 | spec/Module/Events/Season.spec.ts | 231 | low mojo |
+| 4 | spec/Module/Events/Season.spec.ts | 255 | low mojo, energy not max with cards |
+| 5 | spec/Module/harem/HaremGirl.spec.ts | 55 | Button and no girl |
+| 6 | spec/Module/League.spec.ts | 149 | should return false during the last hour of the league if energy is insufficient |
+| 7 | spec/Service/PageNavigationService.spec.ts | 74 | should log an error if Nutaku is detected but no session is found |
+
+## Tests hidden by fdescribe
+
+Status: 2026-05-07. `fdescribe(\"_setTimer\")` in Champion.spec.ts:37 focuses
+on 7 tests inside the _setTimer block and therefore hides the sibling block
+findNextChamptionTime with 1 test.
+
+| File | fdescribe block (line) | hidden describe block | tests skipped |
+|---|---|---|---|
+| spec/Module/Champion.spec.ts | _setTimer (37) | findNextChamptionTime | 1: \"default\" |
+
+## Data sources
+
+- `INPUT/hhauto_dump_*.json` (41 MB, 2026-05-05, 30 pages)
+  - Pages: home, leagues, season-arena, penta-drill-arena, penta-drill,
+    labyrinth (2x), club-champion, champions-map, shop, clubs, pantheon,
+    season, event, seasonal, path-of-glory, path-of-valor, pachinko, map,
+    waifu, activities (5x), hero/profile, member-progression, teams,
+    edit-team, characters/1
+  - Fields per page: girls_full, hero, teams, battle, market_equipment,
+    hh_namespace, shared_namespace, local_storage, dom_data_attributes,
+    live_blessings_api
+- `INPUT/HH_DebugLog_*.log` (3 files, ~10h old)
+  - Settings snapshot per file
+  - Key `HHAuto_Temp_Logging` carries time-stamped action traces
+    (TeamModule, Harem, Generator.next with slot equipment)
+- If a fresh dump is needed: ask the user (inspector script:
+  `bonus-scripts/HHAuto_debug_inspector.user.js` v4.5.0)
+
+## Workflow reminder
+
+- Branch -> implement -> commit -> push -> test -> approval -> PR -> merge
+- Identity: `oldron1977@gmail.com`, user: `OldRon1977`
+- No AI / agent mention in commits
+- File writes only via Python+UTF8 (workspace rule 05)
+- README entry on a version bump (not required for this stage)
+
+## Change log
+
+| Date | Change |
+|---|---|
+| 2026-05-07 | Initial draft, state before stage 0 |

--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ and add the date plus commit hash in the Status field.
 ## Status
 
 - Current stage: **0 (immediate hygiene)** -- in progress
-- Last completed task: 0.1 (fdescribe -> describe in Champion.spec.ts)
+- Last completed task: 0.3 (subjective findings handled)
 - Last commit: <set in commit message>
-- Next step: task 0.2 (handle xit tests)
+- Next step: task 0.4 (extend MockHelper)
 
 ## Context
 
@@ -99,10 +99,17 @@ because of `fdescribe(\"_setTimer\", ...)`. Effort: 2 minutes, read only.
   - Precondition: question B answered, hidden tests known
   - Verification: `npm test` shows more passing tests than before
   - If tests turn red: decide individually (fix or xit)
-- [ ] **0.2** Handle xit tests according to answer A
-  - On \"Inventory\": list under \"xit inventory\" below
-  - Per test: fix, drop, or leave xit'd with a GitHub-issue link
-- [ ] **0.3** Apply findings 3/4/5 according to answer C
+- [x] **0.2** Handle xit tests according to answer A (2026-05-07)
+  - 7 xit tests inventoried, 5 reactivated (all green), 2 empty stubs removed
+  - TimeHelper: canCollectCompetitionActive + getSecondsLeftBeforeNewCompetition (stubs removed)
+  - Season: 2 low-mojo tests reactivated, with `Setting_autoSeasonSkipLowMojo=true` set in the tests
+  - HaremGirl: \"Button and no girl\" reactivated, green without further changes
+  - League: \"should return false during the last hour...\" reactivated, green without further changes
+  - PageNavigationService: `toHaveBeenCalledWith` -> `expect.stringContaining` (test bug, timestamp prefix)
+- [x] **0.3** Findings 3/4/5 per answer C: nothing to do in stage 0
+  - C-3c (Pachinko string mapping): defer to the Pachinko refactor
+  - C-4c (Pipeline.config value asserts): defer to the next Pipeline change
+  - C-5b (League jest.spyOn): keep until stage 1 (pure-function extraction replaces them)
 - [ ] **0.4** Extend MockHelper with:
   - `mockBoosterInventory(boosters)` -- writes Temp_boosterStatus
   - `mockSetting(key, value)` -- localStorage Setting_*
@@ -271,3 +278,4 @@ findNextChamptionTime with 1 test.
 |---|---|
 | 2026-05-07 | Initial draft, state before stage 0 |
 | 2026-05-07 | Task 0.1 done: fdescribe -> describe. Tests: 549 passed / 7 skipped / 556 total |
+| 2026-05-07 | Tasks 0.2 + 0.3 done: every xit handled. Tests: 554 passed / 0 skipped / 554 total |

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,13 +35,10 @@ const config: Config = {
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",
 
-  // A list of reporter names that Jest uses when writing coverage reports
-  // coverageReporters: [
-  //   "json",
-  //   "text",
-  //   "lcov",
-  //   "clover"
-  // ],
+  // A list of reporter names that Jest uses when writing coverage reports.
+  // text-summary prints a condensed table at the bottom of the run; html
+  // emits coverage/lcov-report/index.html for browser inspection.
+  coverageReporters: ["text", "text-summary", "lcov", "clover", "html"],
 
   // An object that configures minimum threshold enforcement for coverage results
   // coverageThreshold: undefined,

--- a/spec/Helper/TimeHelper.spec.ts
+++ b/spec/Helper/TimeHelper.spec.ts
@@ -66,15 +66,4 @@ describe("Time Helper", function () {
         });
     });
 
-    describe("canCollectCompetitionActive", function () {
-        xit("default", function () {
-            //expect(TimeHelper.canCollectCompetitionActive()).toBeTruthy()
-        });
-    });
-
-    describe("getSecondsLeftBeforeNewCompetition", function () {
-        xit("default", function () {
-            //expect(TimeHelper.getSecondsLeftBeforeNewCompetition()).toBe(0);
-        });
-    });
 });

--- a/spec/Module/Champion.spec.ts
+++ b/spec/Module/Champion.spec.ts
@@ -34,7 +34,7 @@ describe("Champion module", function () {
     });
 
 
-    fdescribe("_setTimer", function () {
+    describe("_setTimer", function () {
         const TIME_1 = 123;
         const TIME_2 = 456;
         const TIME_COOLDOWN = 3600;

--- a/spec/Module/Events/Season.spec.ts
+++ b/spec/Module/Events/Season.spec.ts
@@ -228,8 +228,9 @@ describe("Season event", function () {
     });
 
     describe("getBestOppo low mojo", function () {
-        xit("low mojo", function () {
+        it("low mojo", function () {
             mockSeasonTierLevel(20);
+            localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoSeasonSkipLowMojo", "true");
             const OPPO_AA = { ...OPPO_A };
             OPPO_AA.mojo = 5;
             let result = Season.getBestOppo([OPPO_AA, OPPO_AA, OPPO_AA]);
@@ -252,8 +253,9 @@ describe("Season event", function () {
             expect(result.chosenIndex).toBe(0);
         });
 
-        xit("low mojo, energy not max with cards", function () {
+        it("low mojo, energy not max with cards", function () {
             mockSeasonTierLevel(20);
+            localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoSeasonSkipLowMojo", "true");
             const OPPO_AA = { ...OPPO_A };
             OPPO_AA.mojo = 5;
             let result = Season.getBestOppo([OPPO_AA, OPPO_AA, OPPO_AA], 11, 15);

--- a/spec/Module/League.spec.ts
+++ b/spec/Module/League.spec.ts
@@ -146,7 +146,7 @@ describe("League", function () {
             expect(result).toBeTruthy();
         });
 
-        xit("should return false during the last hour of the league if energy is insufficient", function () {
+        it("should return false during the last hour of the league if energy is insufficient", function () {
             jest.spyOn(LeagueHelper, "getLeagueEndTime").mockReturnValue(3500); // 1 hour left
             localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoLeaguesThreshold", "15");
             localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoLeaguesRunThreshold", "20");

--- a/spec/Module/harem/HaremGirl.spec.ts
+++ b/spec/Module/harem/HaremGirl.spec.ts
@@ -52,7 +52,7 @@ describe("HaremGirl", function () {
             mockGirl();
             expect(HaremGirl.canGiftGirl()).toBeFalsy();
         });
-        xit("Button and no girl", function () {
+        it("Button and no girl", function () {
             document.body.innerHTML = HTML_START + AFF_BUTTON;
             expect(HaremGirl.canGiftGirl()).toBeFalsy();
         });

--- a/spec/Service/PageNavigationService.spec.ts
+++ b/spec/Service/PageNavigationService.spec.ts
@@ -71,7 +71,7 @@ describe("PageNavigationService", function () {
             expect(result).toEqual(originalObject);
         });
 
-        xit("should log an error if Nutaku is detected but no session is found", function () {
+        it("should log an error if Nutaku is detected but no session is found", function () {
             const originalUrl = "/some/path";
             Object.defineProperty(window, 'location', {
                 value: {
@@ -84,7 +84,7 @@ describe("PageNavigationService", function () {
 
             addNutakuSession(originalUrl);
 
-            expect(logSpy).toHaveBeenCalledWith("ERROR Nutaku detected and no session found");
+            expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("ERROR Nutaku detected and no session found"));
 
             logSpy.mockRestore();
         });

--- a/spec/testHelpers/MockHelpers.ts
+++ b/spec/testHelpers/MockHelpers.ts
@@ -1,3 +1,5 @@
+import { HHStoredVarPrefixKey, TK } from '../../src/config/index';
+
 export class MockHelper{
 
     static mockDomain(domain: string = 'www.hentaiheroes.com', page: string = '', search:string = '') {
@@ -75,5 +77,144 @@ export class MockHelper{
             amount: amount,
             max_regen_amount: max
         };
+    }
+    /**
+     * Mocks the booster status in localStorage.
+     * Two parallel inventories: 'normal' (timed, with item.identifier and endAt epoch ms)
+     * and 'mythic' (untimed, only item.identifier).
+     *
+     * Example:
+     *   MockHelper.mockBoosterInventory({
+     *     normal: [{ identifier: 'GS3', secondsLeft: 3600 }],
+     *     mythic: ['MGS5']
+     *   });
+     */
+    static mockBoosterInventory(boosters: { normal?: Array<{ identifier: string; secondsLeft?: number }>; mythic?: string[] } = {}) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        const serverNow = Math.floor(Date.now() / 1000);
+        unsafeWindow.server_now_ts = serverNow;
+
+        const normal = (boosters.normal || []).map(b => ({
+            item: { identifier: b.identifier },
+            endAt: serverNow + (b.secondsLeft ?? 3600)
+        }));
+        const mythic = (boosters.mythic || []).map(id => ({
+            item: { identifier: id }
+        }));
+
+        const status = { normal, mythic };
+        localStorage.setItem(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(status));
+    }
+
+    /**
+     * Sets a single setting value in localStorage with the HHAuto_Setting_ prefix.
+     * For Boolean-typed settings, pass 'true' or 'false' as a string (matching production storage format).
+     *
+     * Example:
+     *   MockHelper.mockSetting('autoLeaguesBoostedOnly', 'true');
+     */
+    static mockSetting(key: string, value: string) {
+        localStorage.setItem(HHStoredVarPrefixKey + 'Setting_' + key, value);
+    }
+
+    /**
+     * Wraps setTimer for tests, expressing intent more clearly than direct setTimer calls.
+     * secondsLeft <= 0 means the timer is expired (or never set).
+     *
+     * Example:
+     *   MockHelper.mockTimer('nextLeaguesTime', 0);   // expired
+     *   MockHelper.mockTimer('nextSeasonTime', 60);   // 60s remaining
+     */
+    static mockTimer(name: string, secondsLeft: number) {
+        // Direct localStorage write instead of importing setTimer to avoid circular helper dependency.
+        // Production setTimer stores future epoch ms in unsafeWindow Timers and persists JSON to storage.
+        const raw = localStorage.getItem(HHStoredVarPrefixKey + TK.Timers);
+        const timers = raw ? JSON.parse(raw) : {};
+        if (secondsLeft <= 0) {
+            delete timers[name];
+        } else {
+            timers[name] = Date.now() + secondsLeft * 1000;
+        }
+        localStorage.setItem(HHStoredVarPrefixKey + TK.Timers, JSON.stringify(timers));
+    }
+
+    /**
+     * Mocks getHHAjax() to call the success callback with the supplied response.
+     * Production signature: getHHAjax()(params, successCallback).
+     *
+     * Example:
+     *   MockHelper.mockAjaxSuccess({ success: true, league_rewards: [] });
+     */
+    static mockAjaxSuccess(response: any) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        if (!unsafeWindow.shared.general) unsafeWindow.shared.general = {} as any;
+        unsafeWindow.shared.general.hh_ajax = (_params: any, successCb: (data: any) => void) => {
+            successCb(response);
+        };
+    }
+
+    /**
+     * Mocks getHHAjax() to throw the given error from the synchronous call site.
+     * Production code typically does not pass an error callback; modules wrap in try/catch.
+     *
+     * Example:
+     *   MockHelper.mockAjaxError(new Error('network down'));
+     */
+    static mockAjaxError(error: Error) {
+        if (!unsafeWindow.shared) unsafeWindow.shared = {} as any;
+        if (!unsafeWindow.shared.general) unsafeWindow.shared.general = {} as any;
+        unsafeWindow.shared.general.hh_ajax = () => {
+            throw error;
+        };
+    }
+
+    /**
+     * One-shot world setup combining hero level, energies, and arbitrary settings.
+     * Each parameter is optional; only provided fields are touched.
+     *
+     * Example:
+     *   MockHelper.mockGameGlobals({
+     *     heroLevel: 500,
+     *     energies: { challenge: { amount: 16, max: 20 } },
+     *     settings: { autoLeaguesThreshold: '5', autoLeaguesBoostedOnly: 'true' }
+     *   });
+     */
+    static mockGameGlobals(globals: {
+        heroLevel?: number;
+        energies?: Partial<{
+            fight: { amount: number; max: number };
+            challenge: { amount: number; max: number };
+            kiss: { amount: number; max: number };
+            quest: { amount: number; max: number };
+            worship: { amount: number; max: number };
+            drill: { amount: number; max: number };
+        }>;
+        settings?: Record<string, string>;
+    } = {}) {
+        if (globals.heroLevel !== undefined) {
+            MockHelper.mockHeroLevel(globals.heroLevel);
+        } else if (!unsafeWindow.shared?.Hero) {
+            // Ensure baseline structure so energy mocks do not NPE.
+            MockHelper.mockHeroLevel(1);
+        }
+
+        const energyMockers = {
+            fight: MockHelper.mockEnergiesFight,
+            challenge: MockHelper.mockEnergiesChallenge,
+            kiss: MockHelper.mockEnergiesKiss,
+            quest: MockHelper.mockEnergiesQuest,
+            worship: MockHelper.mockEnergiesWorship,
+            drill: MockHelper.mockEnergiesDrill,
+        };
+        for (const [key, energy] of Object.entries(globals.energies || {})) {
+            const mocker = (energyMockers as any)[key];
+            if (mocker && energy) {
+                mocker(energy.amount, energy.max);
+            }
+        }
+
+        for (const [key, value] of Object.entries(globals.settings || {})) {
+            MockHelper.mockSetting(key, value);
+        }
     }
 }


### PR DESCRIPTION
﻿Stage 0 of the test strategy (see `docs-internal/test-strategy.md`). Hygiene work without any behaviour change in the userscript -- only tests, mocks, test infrastructure, and plan documentation.

## Changes

### Tests freed up
- Champion: `fdescribe` -> `describe` (one previously hidden test runs again).
- 5 of 7 `xit` tests reactivated and green.
  - Season: 2 tests (`Setting_autoSeasonSkipLowMojo` had to be set in the tests).
  - HaremGirl, League: pass directly without further changes.
  - PageNavigationService: `expect.stringContaining` instead of an exact string match.
- 2 empty stub tests in TimeHelper removed (`canCollectCompetitionActive`, `getSecondsLeftBeforeNewCompetition`).

### Test infrastructure
- MockHelper extended with: `mockBoosterInventory`, `mockSetting`, `mockTimer`, `mockAjaxSuccess`, `mockAjaxError`, `mockGameGlobals`.
- Coverage reporters set explicitly: text, text-summary, lcov, clover, html.

### Cleanup
- `jest-*.json` added to `.gitignore` (test-run artefacts).

### Docs
- `docs-internal/test-strategy.md` with stage 0 results and stages 1-4 as the roadmap.
- `docs-internal/session-handoff-test-strategy.md` for follow-up sessions.

## Test count

- Before: 549 passed / 7 skipped / 556 total.
- After:  554 passed / 0 skipped / 554 total.

## Coverage (now visible automatically after every run)

- Statements: 28.92%
- Branches:   17.11%
- Functions:  24.10%
- Lines:      29.60%

Refs #1614 (Coverage reporting in CI -- reminder for the next stage)