### PR TITLE
refactor(league): extract decideShouldFight pure function

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -13542,6 +13542,41 @@ LabyrinthAuto.NORMAL = "1";
 LabyrinthAuto.HARD = "2";
 LabyrinthAuto.LABYRINTH_SELECTOR = ['easy', 'normal', 'hard'];
 
+;// CONCATENATED MODULE: ./src/Module/League.pure.ts
+// League.pure.ts -- Pure decision logic for league automation.
+//
+// Extracted from LeagueHelper.isTimeToFight to enable direct unit tests
+// without spying on static methods. No globals, no storage, no jQuery,
+// no DOM. Input = data, output = decision.
+//
+// The impure adapter LeagueHelper.isTimeToFight reads globals and storage,
+// builds a ShouldFightState, and delegates here.
+/**
+ * Decide whether the league module should fight right now.
+ *
+ * Mirrors the original logic of LeagueHelper.isTimeToFight bit by bit:
+ *   - timerExpired:        timerLeft <= 0 (checkTimer returns true once it has
+ *                          run out)
+ *   - energyAboveThreshold: humanLikeRun loosens the upper bound, otherwise
+ *                          energy must exceed max(threshold, runThreshold - 1)
+ *   - paranoiaOverride:    spend any positive amount of paranoia energy as
+ *                          long as energy > 0
+ *   - boosterCheck:        either boosters are not required, or they are
+ *                          required AND equipped
+ *
+ * Returns true if (timer expired AND energy ok AND booster ok) OR paranoia
+ * spending is active.
+ */
+function decideShouldFight(state) {
+    const { energy, threshold, runThreshold, humanLikeRun, timerLeft, paranoiaSpending, boosterRequired, boosterEquipped, } = state;
+    const timerExpired = timerLeft <= 0;
+    const energyAboveThreshold = (humanLikeRun && energy > threshold) ||
+        energy > Math.max(threshold, runThreshold - 1);
+    const paranoiaOverride = energy > 0 && paranoiaSpending > 0;
+    const boosterCheck = (boosterRequired && boosterEquipped) || !boosterRequired;
+    return ((timerExpired && energyAboveThreshold && boosterCheck) || paranoiaOverride);
+}
+
 ;// CONCATENATED MODULE: ./src/Module/League.ts
 var League_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -13563,6 +13598,7 @@ var League_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _a
 // Depends on: BDSMHelper (win probability), TeamModule.ts (team selection)
 // Used by: Service/index.ts (main automation loop), MonthlyCard.ts
 //
+
 
 
 
@@ -13714,15 +13750,30 @@ class LeagueHelper {
             // Last league hour //TODO
             LogUtils_logHHAuto("Last League hour");
         }
-        const energyAboveThreshold = humanLikeRun && LeagueHelper.getEnergy() > threshold || LeagueHelper.getEnergy() > Math.max(threshold, runThreshold - 1);
-        const paranoiaSpending = LeagueHelper.getEnergy() > 0 && ParanoiaService.checkParanoiaSpendings('challenge') > 0;
+        const energy = LeagueHelper.getEnergy();
+        const paranoiaSpending = ParanoiaService.checkParanoiaSpendings('challenge');
         const needBoosterToFight = getStoredValue(HHStoredVarPrefixKey + SK.autoLeaguesBoostedOnly) === "true";
         const haveBoosterEquiped = Booster.haveBoosterEquiped();
-        // logHHAuto('League:', {threshold: threshold, runThreshold:runThreshold, energyAboveThreshold: energyAboveThreshold});
-        if (checkTimer('nextLeaguesTime') && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
+        const timerExpired = checkTimer('nextLeaguesTime');
+        // checkTimer returns true once the timer has run out; convert to the
+        // numeric form the pure function expects (negative or zero = expired).
+        const timerLeft = timerExpired ? 0 : 1;
+        const state = {
+            energy,
+            threshold,
+            runThreshold,
+            humanLikeRun,
+            timerLeft,
+            paranoiaSpending,
+            boosterRequired: needBoosterToFight,
+            boosterEquipped: haveBoosterEquiped,
+        };
+        const energyAboveThreshold = (humanLikeRun && energy > threshold) ||
+            energy > Math.max(threshold, runThreshold - 1);
+        if (timerExpired && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
             LogUtils_logHHAuto('Time for league but no booster equipped');
         }
-        return (checkTimer('nextLeaguesTime') && energyAboveThreshold && (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight)) || paranoiaSpending;
+        return decideShouldFight(state);
     }
     /* static async _refreshSorting(){
         const columnHeadSelector = '.league_content .data-list .data-column[sorting]';

--- a/spec/Module/League.pure.spec.ts
+++ b/spec/Module/League.pure.spec.ts
@@ -1,0 +1,111 @@
+import { decideShouldFight, ShouldFightState } from "../../src/Module/League.pure";
+
+/**
+ * Pure-function tests for the league fight decision.
+ *
+ * These cover the same scenarios as the impure isTimeToFight tests in
+ * League.spec.ts, plus a few edge cases the spy-based tests cannot reach
+ * cleanly (humanLikeRun on/off, paranoia with zero energy).
+ */
+describe("decideShouldFight", () => {
+    const baseState: ShouldFightState = {
+        energy: 1,
+        threshold: 5,
+        runThreshold: 15,
+        humanLikeRun: false,
+        timerLeft: 0,
+        paranoiaSpending: -1,
+        boosterRequired: false,
+        boosterEquipped: false,
+    };
+
+    const withState = (overrides: Partial<ShouldFightState>): ShouldFightState => ({
+        ...baseState,
+        ...overrides,
+    });
+
+    it("returns true when energy is above the threshold and the timer has expired", () => {
+        const state = withState({ energy: 16, timerLeft: 0 });
+        expect(decideShouldFight(state)).toBe(true);
+    });
+
+    it("returns false when energy is below the threshold", () => {
+        const state = withState({ energy: 10, timerLeft: 0 });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("returns false when the next-fight timer is still active", () => {
+        const state = withState({ energy: 20, timerLeft: 10 });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("returns true when paranoia spending is positive and energy is below threshold", () => {
+        const state = withState({ energy: 10, paranoiaSpending: 1 });
+        expect(decideShouldFight(state)).toBe(true);
+    });
+
+    it("returns true when paranoia spending is positive and energy is above threshold", () => {
+        const state = withState({ energy: 16, paranoiaSpending: 1 });
+        expect(decideShouldFight(state)).toBe(true);
+    });
+
+    it("ignores paranoia override when energy is zero", () => {
+        const state = withState({ energy: 0, paranoiaSpending: 5 });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("returns false when boosters are required but not equipped", () => {
+        const state = withState({
+            energy: 19,
+            boosterRequired: true,
+            boosterEquipped: false,
+        });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("returns false when boosters are required, energy is above max, but no booster is equipped", () => {
+        const state = withState({
+            energy: 21,
+            boosterRequired: true,
+            boosterEquipped: false,
+        });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("returns true when boosters are required and equipped", () => {
+        const state = withState({
+            energy: 16,
+            boosterRequired: true,
+            boosterEquipped: true,
+        });
+        expect(decideShouldFight(state)).toBe(true);
+    });
+
+    it("respects humanLikeRun: above plain threshold but at or below runThreshold-1 still allows a fight", () => {
+        // Without humanLikeRun: energy must exceed max(5, 15-1) = 14, so 10 fails.
+        const strict = withState({ energy: 10, humanLikeRun: false });
+        expect(decideShouldFight(strict)).toBe(false);
+
+        // With humanLikeRun: energy > threshold (5) is enough.
+        const relaxed = withState({ energy: 10, humanLikeRun: true });
+        expect(decideShouldFight(relaxed)).toBe(true);
+    });
+
+    it("returns false in the last league hour scenario when energy is insufficient", () => {
+        // Mirrors the impure test "during the last hour ... if energy is insufficient":
+        // threshold and runThreshold pulled up, energy at zero, no paranoia.
+        const state = withState({
+            energy: 0,
+            threshold: 15,
+            runThreshold: 20,
+            paranoiaSpending: -1,
+            timerLeft: 0,
+        });
+        expect(decideShouldFight(state)).toBe(false);
+    });
+
+    it("treats negative timerLeft as expired", () => {
+        const state = withState({ energy: 16, timerLeft: -5 });
+        expect(decideShouldFight(state)).toBe(true);
+    });
+});

--- a/src/Module/League.pure.ts
+++ b/src/Module/League.pure.ts
@@ -1,0 +1,59 @@
+// League.pure.ts -- Pure decision logic for league automation.
+//
+// Extracted from LeagueHelper.isTimeToFight to enable direct unit tests
+// without spying on static methods. No globals, no storage, no jQuery,
+// no DOM. Input = data, output = decision.
+//
+// The impure adapter LeagueHelper.isTimeToFight reads globals and storage,
+// builds a ShouldFightState, and delegates here.
+
+export type ShouldFightState = {
+    energy: number;
+    threshold: number;
+    runThreshold: number;
+    humanLikeRun: boolean;
+    timerLeft: number;
+    paranoiaSpending: number;
+    boosterRequired: boolean;
+    boosterEquipped: boolean;
+};
+
+/**
+ * Decide whether the league module should fight right now.
+ *
+ * Mirrors the original logic of LeagueHelper.isTimeToFight bit by bit:
+ *   - timerExpired:        timerLeft <= 0 (checkTimer returns true once it has
+ *                          run out)
+ *   - energyAboveThreshold: humanLikeRun loosens the upper bound, otherwise
+ *                          energy must exceed max(threshold, runThreshold - 1)
+ *   - paranoiaOverride:    spend any positive amount of paranoia energy as
+ *                          long as energy > 0
+ *   - boosterCheck:        either boosters are not required, or they are
+ *                          required AND equipped
+ *
+ * Returns true if (timer expired AND energy ok AND booster ok) OR paranoia
+ * spending is active.
+ */
+export function decideShouldFight(state: ShouldFightState): boolean {
+    const {
+        energy,
+        threshold,
+        runThreshold,
+        humanLikeRun,
+        timerLeft,
+        paranoiaSpending,
+        boosterRequired,
+        boosterEquipped,
+    } = state;
+
+    const timerExpired = timerLeft <= 0;
+    const energyAboveThreshold =
+        (humanLikeRun && energy > threshold) ||
+        energy > Math.max(threshold, runThreshold - 1);
+    const paranoiaOverride = energy > 0 && paranoiaSpending > 0;
+    const boosterCheck = (boosterRequired && boosterEquipped) || !boosterRequired;
+
+    return (
+        (timerExpired && energyAboveThreshold && boosterCheck) || paranoiaOverride
+    );
+}

--- a/src/Module/League.ts
+++ b/src/Module/League.ts
@@ -34,6 +34,7 @@ import {
     setTimer,
     TimeHelper
 } from '../Helper/index';
+import { decideShouldFight, ShouldFightState } from './League.pure';
 import {
     addNutakuSession,
     autoLoop,
@@ -223,17 +224,35 @@ export class LeagueHelper {
             // Last league hour //TODO
             logHHAuto("Last League hour");
         }
-        const energyAboveThreshold = humanLikeRun && LeagueHelper.getEnergy() > threshold || LeagueHelper.getEnergy() > Math.max(threshold, runThreshold-1);
-        const paranoiaSpending = LeagueHelper.getEnergy() > 0 && ParanoiaService.checkParanoiaSpendings('challenge') > 0;
+        const energy = LeagueHelper.getEnergy();
+        const paranoiaSpending = ParanoiaService.checkParanoiaSpendings('challenge');
         const needBoosterToFight = getStoredValue(HHStoredVarPrefixKey+SK.autoLeaguesBoostedOnly) === "true";
         const haveBoosterEquiped = Booster.haveBoosterEquiped();
-        // logHHAuto('League:', {threshold: threshold, runThreshold:runThreshold, energyAboveThreshold: energyAboveThreshold});
+        const timerExpired = checkTimer('nextLeaguesTime');
+        // checkTimer returns true once the timer has run out; convert to the
+        // numeric form the pure function expects (negative or zero = expired).
+        const timerLeft = timerExpired ? 0 : 1;
 
-        if(checkTimer('nextLeaguesTime') && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
+        const state: ShouldFightState = {
+            energy,
+            threshold,
+            runThreshold,
+            humanLikeRun,
+            timerLeft,
+            paranoiaSpending,
+            boosterRequired: needBoosterToFight,
+            boosterEquipped: haveBoosterEquiped,
+        };
+
+        const energyAboveThreshold =
+            (humanLikeRun && energy > threshold) ||
+            energy > Math.max(threshold, runThreshold - 1);
+
+        if (timerExpired && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
             logHHAuto('Time for league but no booster equipped');
         }
 
-        return (checkTimer('nextLeaguesTime') && energyAboveThreshold && (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight)) || paranoiaSpending;
+        return decideShouldFight(state);
     }
 
     /* static async _refreshSorting(){


### PR DESCRIPTION
Stage 1, task 1.1 from `docs-internal/test-strategy.md`.

## What

Extract the decision logic of `LeagueHelper.isTimeToFight` into a
pure function `decideShouldFight(state)` in
`src/Module/League.pure.ts`. The public API stays identical: the
impure adapter still reads globals, storage and the booster state,
then delegates to the pure function.

## Why

The previous tests relied on `jest.spyOn` against static methods
(finding C-5 in the test strategy). They were brittle and could not
cleanly express edge cases like `humanLikeRun` toggling or paranoia
overrides at zero energy. The pure function takes a typed state
object and is trivially testable.

## Tests

- 554 existing tests stay green.
- 12 new pure-function tests cover default, threshold boundaries,
  timer expired/active/negative, paranoia 3 variants (incl. zero
  energy), boosters 3 variants, humanLikeRun on/off, and the
  last-hour scenario with insufficient energy.
- Total: 566 passed, 0 skipped, 40 suites.

## Bundle

`HHAuto.user.js` rebuilt, diff is purely structural (same logic,
different layout).

## Behaviour delta

`ParanoiaService.checkParanoiaSpendings` is now called even when
energy is zero; previously it was short-circuited away. The function
is read-only, so this is a wash.

## Plan

`docs-internal/test-strategy.md` will be updated post-merge: tick
1.1, bump status block, append change-log row.
