### PR TITLE
refactor(champion): extract decideNextChampionTime pure function

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1957,6 +1957,58 @@ class Bundles {
     }
 }
 
+;// CONCATENATED MODULE: ./src/Module/Champion.pure.ts
+// Champion.pure.ts -- Pure decision logic for the champions auto module.
+//
+// Extracted from Champion.findNextChamptionTime so the timer scan can be
+// unit-tested without DOM access, jQuery, randomInterval, or the timer
+// helper. Input = a list of champion decision rows + the relevant
+// settings; output = the deterministic tuple (minTime, minTimeEnded)
+// that the impure adapter feeds into randomInterval and _setTimer.
+//
+// The variable naming is preserved from the original implementation:
+// despite the name, both fields hold MAX values for the entries that
+// match their respective bucket. minTime is the largest entry below
+// 1800s, minTimeEnded is the largest known positive timer overall.
+// We do not change this contract here -- only extract it.
+/**
+ * Reproduce the existing findNextChamptionTime scan bit by bit. The input
+ * list is iterated in order; the first ready (timer === 0) or
+ * force-start-eligible entry short-circuits with minTime=0/minTimeEnded=-1.
+ *
+ * Bit-for-bit equivalence to the in-place loop is the explicit goal -- the
+ * inner > comparison (instead of <) and the early break are preserved on
+ * purpose so that the adapter behaviour does not shift.
+ */
+function decideNextChampionTime(champions, autoChampsForceStart) {
+    let minTime = -1;
+    let minTimeEnded = -1;
+    for (const champion of champions) {
+        if (!champion.inFilter) {
+            continue;
+        }
+        const currTime = champion.timer;
+        if (currTime === 0) {
+            return { minTime: 0, minTimeEnded: -1 };
+        }
+        if (currTime > 0) {
+            if (currTime > minTimeEnded) {
+                minTimeEnded = currTime;
+            }
+            // Original wording (preserved): largest timer below 1800s.
+            if (currTime > minTime && currTime < 1800) {
+                minTime = currTime;
+            }
+            continue;
+        }
+        // currTime < 0
+        if (!champion.started && autoChampsForceStart) {
+            return { minTime: 0, minTimeEnded: -1 };
+        }
+    }
+    return { minTime, minTimeEnded };
+}
+
 ;// CONCATENATED MODULE: ./src/Module/Events/CumbackContests.ts
 // CumbackContests.ts -- Cumback Contest event handling and auto-collection.
 //
@@ -5360,6 +5412,7 @@ var Champion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, 
 
 
 
+
 class Champion {
     run() {
     }
@@ -5823,38 +5876,11 @@ class Champion {
     }
     static findNextChamptionTime(championMap = undefined) {
         if (getPage() == ConfigHelper.getHHScriptVars("pagesIDChampionsMap")) {
-            const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
             const autoChampsForceStart = getStoredValue(HHStoredVarPrefixKey + SK.autoChampsForceStart) === "true";
-            var minTime = -1; // less than 15min
-            var minTimeEnded = -1;
-            var currTime;
             if (championMap == undefined) {
                 championMap = Champion.getChampionListFromMap();
             }
-            // if (debugEnabled) logHHAuto('championMap: ', championMap);
-            for (let i = 0; i < championMap.length; i++) {
-                if (championMap[i].inFilter) {
-                    currTime = championMap[i].timer;
-                    if (currTime === 0) {
-                        minTime = 0;
-                        minTimeEnded = -1; // end loop so value is not accurate
-                        break;
-                    }
-                    else if (currTime > 0) {
-                        if (currTime > minTimeEnded) {
-                            minTimeEnded = currTime;
-                        }
-                        if (currTime > minTime && currTime < 1800) {
-                            minTime = currTime;
-                        } // less than 30min
-                    }
-                    else if (!championMap[i].started && autoChampsForceStart) {
-                        minTime = 0;
-                        minTimeEnded = -1; // end loop so value is not accurate
-                        break;
-                    }
-                }
-            }
+            const { minTime, minTimeEnded } = decideNextChampionTime(championMap, autoChampsForceStart);
             //fetching min
             let nextChampionTime;
             LogUtils_logHHAuto('minTimeEnded: ' + minTimeEnded + ', minTime:' + minTime);

--- a/spec/Module/Champion.pure.spec.ts
+++ b/spec/Module/Champion.pure.spec.ts
@@ -1,0 +1,138 @@
+import {
+    ChampionTimerEntry,
+    decideNextChampionTime,
+} from "../../src/Module/Champion.pure";
+
+/**
+ * Pure-function tests for the champion timer scan.
+ *
+ * The scan returns a deterministic (minTime, minTimeEnded) tuple. The
+ * impure adapter in Champion.findNextChamptionTime feeds that tuple into
+ * randomInterval and the timer helper -- those layers stay impure on
+ * purpose, so this spec stops at the deterministic boundary.
+ *
+ * Naming oddity preserved from the original code: minTime holds the
+ * LARGEST entry below 1800s, not the smallest. minTimeEnded holds the
+ * largest known positive timer overall. The pure function is bit-for-bit
+ * compatible with the original loop, including this contract.
+ */
+describe("decideNextChampionTime", () => {
+    const entry = (overrides: Partial<ChampionTimerEntry>): ChampionTimerEntry => ({
+        inFilter: true,
+        timer: -1,
+        started: false,
+        ...overrides,
+    });
+
+    it("returns the empty result when no champions are eligible", () => {
+        expect(decideNextChampionTime([], false)).toEqual({
+            minTime: -1,
+            minTimeEnded: -1,
+        });
+    });
+
+    it("ignores entries that are not in the filter", () => {
+        const champions = [
+            entry({ inFilter: false, timer: 0 }),
+            entry({ inFilter: false, timer: 600 }),
+            entry({ inFilter: false, timer: -1 }),
+        ];
+        expect(decideNextChampionTime(champions, true)).toEqual({
+            minTime: -1,
+            minTimeEnded: -1,
+        });
+    });
+
+    it("short-circuits to ready when any entry has timer 0", () => {
+        const champions = [
+            entry({ timer: 600 }),
+            entry({ timer: 0 }),
+            entry({ timer: 1500 }),
+        ];
+        expect(decideNextChampionTime(champions, false)).toEqual({
+            minTime: 0,
+            minTimeEnded: -1,
+        });
+    });
+
+    it("returns minTime = -1 and minTimeEnded = max timer when every entry is above 1800s", () => {
+        const champions = [
+            entry({ timer: 1800 }),
+            entry({ timer: 2400 }),
+            entry({ timer: 5400 }),
+        ];
+        expect(decideNextChampionTime(champions, false)).toEqual({
+            minTime: -1,
+            minTimeEnded: 5400,
+        });
+    });
+
+    it("captures the largest timer below 1800s as minTime", () => {
+        // Original wording: largest, not smallest, despite the name.
+        const champions = [
+            entry({ timer: 300 }),
+            entry({ timer: 1500 }),
+            entry({ timer: 900 }),
+        ];
+        expect(decideNextChampionTime(champions, false)).toEqual({
+            minTime: 1500,
+            minTimeEnded: 1500,
+        });
+    });
+
+    it("keeps minTimeEnded as the largest positive timer even when one is below 1800s", () => {
+        const champions = [
+            entry({ timer: 1500 }),
+            entry({ timer: 3600 }),
+        ];
+        expect(decideNextChampionTime(champions, false)).toEqual({
+            minTime: 1500,
+            minTimeEnded: 3600,
+        });
+    });
+
+    it("ignores negative timers when force-start is off", () => {
+        const champions = [
+            entry({ timer: -1, started: false }),
+            entry({ timer: 1200, started: true }),
+        ];
+        expect(decideNextChampionTime(champions, false)).toEqual({
+            minTime: 1200,
+            minTimeEnded: 1200,
+        });
+    });
+
+    it("force-starts an unstarted entry when autoChampsForceStart is on", () => {
+        const champions = [
+            entry({ timer: 1500, started: true }),
+            entry({ timer: -1, started: false }),
+        ];
+        expect(decideNextChampionTime(champions, true)).toEqual({
+            minTime: 0,
+            minTimeEnded: -1,
+        });
+    });
+
+    it("does not force-start an already-started but expired entry", () => {
+        const champions = [
+            entry({ timer: -1, started: true }),
+            entry({ timer: 600, started: true }),
+        ];
+        expect(decideNextChampionTime(champions, true)).toEqual({
+            minTime: 600,
+            minTimeEnded: 600,
+        });
+    });
+
+    it("ready short-circuit beats both force-start and large timers later in the list", () => {
+        const champions = [
+            entry({ timer: 0 }),
+            entry({ timer: -1, started: false }),
+            entry({ timer: 1200, started: true }),
+        ];
+        expect(decideNextChampionTime(champions, true)).toEqual({
+            minTime: 0,
+            minTimeEnded: -1,
+        });
+    });
+});

--- a/src/Module/Champion.pure.ts
+++ b/src/Module/Champion.pure.ts
@@ -1,0 +1,90 @@
+// Champion.pure.ts -- Pure decision logic for the champions auto module.
+//
+// Extracted from Champion.findNextChamptionTime so the timer scan can be
+// unit-tested without DOM access, jQuery, randomInterval, or the timer
+// helper. Input = a list of champion decision rows + the relevant
+// settings; output = the deterministic tuple (minTime, minTimeEnded)
+// that the impure adapter feeds into randomInterval and _setTimer.
+//
+// The variable naming is preserved from the original implementation:
+// despite the name, both fields hold MAX values for the entries that
+// match their respective bucket. minTime is the largest entry below
+// 1800s, minTimeEnded is the largest known positive timer overall.
+// We do not change this contract here -- only extract it.
+
+export type ChampionTimerEntry = {
+    /**
+     * inFilter == false -> ignored entirely (matches original behaviour).
+     */
+    inFilter: boolean;
+    /**
+     * timer === 0      -> ready right now
+     * timer >  0       -> running, with that many seconds left
+     * timer <  0       -> no timer (encounter never started or already over)
+     */
+    timer: number;
+    /**
+     * started == false combined with autoChampsForceStart triggers an
+     * immediate-act result, mirroring the original break.
+     */
+    started: boolean;
+};
+
+export type ChampionTimerDecision = {
+    /**
+     * -1: no eligible champion is ready or running below 1800s.
+     *  0: at least one entry is ready right now (or force-start applies).
+     * >0: the largest running timer below 1800s.
+     */
+    minTime: number;
+    /**
+     * -1: either no entry has a positive timer, or the loop short-circuited
+     *     on a ready/force-start entry (in which case the original code
+     *     intentionally drops this signal).
+     * >0: the largest positive timer across all eligible entries.
+     */
+    minTimeEnded: number;
+};
+
+/**
+ * Reproduce the existing findNextChamptionTime scan bit by bit. The input
+ * list is iterated in order; the first ready (timer === 0) or
+ * force-start-eligible entry short-circuits with minTime=0/minTimeEnded=-1.
+ *
+ * Bit-for-bit equivalence to the in-place loop is the explicit goal -- the
+ * inner > comparison (instead of <) and the early break are preserved on
+ * purpose so that the adapter behaviour does not shift.
+ */
+export function decideNextChampionTime(
+    champions: ChampionTimerEntry[],
+    autoChampsForceStart: boolean,
+): ChampionTimerDecision {
+    let minTime = -1;
+    let minTimeEnded = -1;
+
+    for (const champion of champions) {
+        if (!champion.inFilter) {
+            continue;
+        }
+        const currTime = champion.timer;
+        if (currTime === 0) {
+            return { minTime: 0, minTimeEnded: -1 };
+        }
+        if (currTime > 0) {
+            if (currTime > minTimeEnded) {
+                minTimeEnded = currTime;
+            }
+            // Original wording (preserved): largest timer below 1800s.
+            if (currTime > minTime && currTime < 1800) {
+                minTime = currTime;
+            }
+            continue;
+        }
+        // currTime < 0
+        if (!champion.started && autoChampsForceStart) {
+            return { minTime: 0, minTimeEnded: -1 };
+        }
+    }
+
+    return { minTime, minTimeEnded };
+}

--- a/src/Module/Champion.ts
+++ b/src/Module/Champion.ts
@@ -27,6 +27,7 @@ import { gotoPage } from "../Service/index";
 import { getHHAjax, isJSON, logHHAuto, safeJsonParse } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { ChampionModel } from "../model/index";
+import { decideNextChampionTime } from './Champion.pure';
 import { EventModule } from "./Events/index";
 import { QuestHelper } from "./Quest";
 
@@ -541,34 +542,14 @@ export class Champion {
 
     static findNextChamptionTime(championMap: ChampionModel[]=undefined) {
         if (getPage() == ConfigHelper.getHHScriptVars("pagesIDChampionsMap")) {
-            const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
             const autoChampsForceStart = getStoredValue(HHStoredVarPrefixKey+SK.autoChampsForceStart) === "true";
-            var minTime = -1; // less than 15min
-            var minTimeEnded = -1;
-            var currTime: number;
 
             if (championMap == undefined) {
                 championMap = Champion.getChampionListFromMap();
             }
-            // if (debugEnabled) logHHAuto('championMap: ', championMap);
-            for (let i=0;i<championMap.length;i++)
-            {
-                if(championMap[i].inFilter) {
-                    currTime = championMap[i].timer;
-                    if(currTime === 0) {
-                        minTime = 0;
-                        minTimeEnded = -1; // end loop so value is not accurate
-                        break;
-                    }else if (currTime > 0) {
-                        if (currTime > minTimeEnded) {minTimeEnded = currTime;}
-                        if (currTime > minTime && currTime < 1800) {minTime = currTime;} // less than 30min
-                    } else if (!championMap[i].started && autoChampsForceStart) {
-                        minTime = 0;
-                        minTimeEnded = -1; // end loop so value is not accurate
-                        break;
-                    }
-                }
-            }
+
+            const { minTime, minTimeEnded } = decideNextChampionTime(championMap, autoChampsForceStart);
+
             //fetching min
             let nextChampionTime: number;
 


### PR DESCRIPTION
Stage 1, task 1.2 from `docs-internal/test-strategy.md`.

## What

Extract the timer scan from `Champion.findNextChamptionTime` into a pure
function `decideNextChampionTime(champions, autoChampsForceStart)` in
`src/Module/Champion.pure.ts`. The DOM read in `getChampionListFromMap`
and the `randomInterval`/`_setTimer` wrapping stay impure on purpose.

The pure function returns the deterministic `(minTime, minTimeEnded)`
tuple. Adapter behaviour is unchanged: same short-circuit on a ready
entry, same force-start path, same `>` comparison that selects the
LARGEST timer below 1800s as `minTime` (preserved verbatim despite the
misleading variable name -- this is a refactor, not a bug fix).

## Plan deviation (already discussed)

The plan suggested `selectNextChampion(champions, settings, level)`,
but the existing logic does not select a champion -- it only decides
WHEN the adapter should look again. New signature reflects that.

## Tests

- 566 existing tests stay green.
- 10 new pure-function tests cover empty list, all-filtered-out, ready
  short-circuit, all timers above 1800s, largest-below-1800,
  force-start on/off, force-start vs already-started entries, and
  the ready short-circuit beating force-start.
- Total: 576 passed, 0 skipped, 41 suites.

## Bundle

`HHAuto.user.js` rebuilt, diff is purely structural. Also drops an
unused `debugEnabled` local that the loop no longer needs.

## Plan

`docs-internal/test-strategy.md` will be updated post-merge: tick
1.2, bump status block, append change-log row.
