### PR TITLE
refactor(harem): extract equipment scoring helpers to a pure module

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -11236,6 +11236,89 @@ class HaremFilter {
     }
 }
 
+;// CONCATENATED MODULE: ./src/Module/harem/HaremGirl.pure.ts
+// HaremGirl.pure.ts -- Pure equipment scoring/comparison helpers.
+//
+// Extracted from HaremGirl (private static methods) so the resonance and
+// stat-sum logic can be unit-tested without DOM, jQuery, or globals.
+// HaremGirl now imports these for optimizeEquipmentSlots and the (currently
+// unused) findBestItem helper.
+//
+// The data shape is intentionally loose -- the game API uses untyped JSON
+// and the original methods accepted `any`. We mirror that here and document
+// the keys we read.
+/**
+ * Sum of all stat fields plus the count of class/element/figure resonance
+ * matches against the wearer.
+ *
+ * Matches the original implementation byte for byte:
+ *   - missing carac fields default to 0
+ *   - resonance_bonuses as an array is ignored (zero matches)
+ *   - identifier comparison is stringified on both sides
+ */
+function scoreItem(item, girl) {
+    const c = item.caracs;
+    const caracSum = (c.carac1 || 0) +
+        (c.carac2 || 0) +
+        (c.carac3 || 0) +
+        (c.damage || 0) +
+        (c.defense || 0) +
+        (c.ego || 0);
+    let resonanceMatches = 0;
+    if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
+        const rb = item.resonance_bonuses;
+        if (rb.class && String(rb.class.identifier) === String(girl.class))
+            resonanceMatches++;
+        if (rb.element && String(rb.element.identifier) === String(girl.element))
+            resonanceMatches++;
+        if (rb.figure && String(rb.figure.identifier) === String(girl.figure))
+            resonanceMatches++;
+    }
+    return { caracSum, resonanceMatches };
+}
+/**
+ * Pick the highest-scoring item from a list. Tiebreakers, in order:
+ *   1. caracSum
+ *   2. resonanceMatches
+ *   3. carac1+carac2+carac3 (excluding damage/defense/ego)
+ *
+ * Returns null on an empty list. Currently unused in the codebase but kept
+ * as part of the equipment helper trio for parity with the original module.
+ */
+function findBestItem(items, girl) {
+    if (items.length === 0)
+        return null;
+    return items.slice().sort((a, b) => {
+        const sa = scoreItem(a, girl);
+        const sb = scoreItem(b, girl);
+        if (sb.caracSum !== sa.caracSum)
+            return sb.caracSum - sa.caracSum;
+        if (sb.resonanceMatches !== sa.resonanceMatches)
+            return sb.resonanceMatches - sa.resonanceMatches;
+        const ca = a.caracs;
+        const cb = b.caracs;
+        return (((cb.carac1 || 0) + (cb.carac2 || 0) + (cb.carac3 || 0)) -
+            ((ca.carac1 || 0) + (ca.carac2 || 0) + (ca.carac3 || 0)));
+    })[0];
+}
+/**
+ * Decide whether `candidate` should replace `current`. Always true if no
+ * current item is equipped (or current.caracs is missing). Otherwise the
+ * candidate must beat the current on caracSum, or tie on caracSum and beat
+ * on resonanceMatches.
+ */
+function isBetter(candidate, current, girl) {
+    if (!current || !current.caracs)
+        return true;
+    const sc = scoreItem(candidate, girl);
+    const se = scoreItem(current, girl);
+    if (sc.caracSum > se.caracSum)
+        return true;
+    if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches)
+        return true;
+    return false;
+}
+
 ;// CONCATENATED MODULE: ./src/Module/harem/HaremGirl.ts
 var HaremGirl_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -11256,6 +11339,7 @@ var HaremGirl_awaiter = (undefined && undefined.__awaiter) || function (thisArg,
 //
 // Used by: Harem.ts (girl list operations), EventModule.ts (girl shard tracking)
 //
+
 
 
 
@@ -12010,46 +12094,6 @@ class HaremGirl {
             });
         });
     }
-    static scoreItem(item, girl) {
-        const c = item.caracs;
-        const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
-        let resonanceMatches = 0;
-        if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
-            const rb = item.resonance_bonuses;
-            if (rb.class && String(rb.class.identifier) === String(girl.class))
-                resonanceMatches++;
-            if (rb.element && String(rb.element.identifier) === String(girl.element))
-                resonanceMatches++;
-            if (rb.figure && String(rb.figure.identifier) === String(girl.figure))
-                resonanceMatches++;
-        }
-        return { caracSum, resonanceMatches };
-    }
-    static findBestItem(items, girl) {
-        if (items.length === 0)
-            return null;
-        return items.sort((a, b) => {
-            const sa = HaremGirl.scoreItem(a, girl);
-            const sb = HaremGirl.scoreItem(b, girl);
-            if (sb.caracSum !== sa.caracSum)
-                return sb.caracSum - sa.caracSum;
-            if (sb.resonanceMatches !== sa.resonanceMatches)
-                return sb.resonanceMatches - sa.resonanceMatches;
-            return ((b.caracs.carac1 || 0) + (b.caracs.carac2 || 0) + (b.caracs.carac3 || 0))
-                - ((a.caracs.carac1 || 0) + (a.caracs.carac2 || 0) + (a.caracs.carac3 || 0));
-        })[0];
-    }
-    static isBetter(candidate, current, girl) {
-        if (!current || !current.caracs)
-            return true;
-        const sc = HaremGirl.scoreItem(candidate, girl);
-        const se = HaremGirl.scoreItem(current, girl);
-        if (sc.caracSum > se.caracSum)
-            return true;
-        if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches)
-            return true;
-        return false;
-    }
     /**
      * Force the game's lazy-loaded inventory panel to render all items.
      * The game renders inventory items on-demand as the container is scrolled.
@@ -12149,8 +12193,8 @@ class HaremGirl {
                 }
                 // Rank candidates: total stats, then resonance, then individual stats
                 const sorted = inventoryItems.slice().sort((a, b) => {
-                    const sa = HaremGirl.scoreItem(a.data, girl);
-                    const sb = HaremGirl.scoreItem(b.data, girl);
+                    const sa = scoreItem(a.data, girl);
+                    const sb = scoreItem(b.data, girl);
                     if (sb.caracSum !== sa.caracSum)
                         return sb.caracSum - sa.caracSum;
                     if (sb.resonanceMatches !== sa.resonanceMatches)
@@ -12159,8 +12203,8 @@ class HaremGirl {
                     return ((cb.carac1 || 0) + (cb.carac2 || 0) + (cb.carac3 || 0)) - ((ca.carac1 || 0) + (ca.carac2 || 0) + (ca.carac3 || 0));
                 });
                 const bestInventory = sorted[0];
-                const bestScore = HaremGirl.scoreItem(bestInventory.data, girl);
-                const shouldReplace = HaremGirl.isBetter(bestInventory.data, equippedData, girl);
+                const bestScore = scoreItem(bestInventory.data, girl);
+                const shouldReplace = isBetter(bestInventory.data, equippedData, girl);
                 if (shouldReplace) {
                     LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
                     // Capture previous equipped identity so we can verify a real change below (see issue #1573)
@@ -12266,7 +12310,7 @@ class HaremGirl {
                     }
                 }
                 else {
-                    const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;
+                    const eqScore = equippedData ? scoreItem(equippedData, girl) : null;
                     LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${equippedData === null || equippedData === void 0 ? void 0 : equippedData.level} ${equippedData === null || equippedData === void 0 ? void 0 : equippedData.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
             }

--- a/spec/Module/harem/HaremGirl.pure.spec.ts
+++ b/spec/Module/harem/HaremGirl.pure.spec.ts
@@ -1,0 +1,165 @@
+import { KKHaremGirl } from "../../../src/model/index";
+import {
+    EquipmentItem,
+    findBestItem,
+    isBetter,
+    scoreItem,
+} from "../../../src/Module/harem/HaremGirl.pure";
+
+/**
+ * Pure-function tests for the equipment scoring trio.
+ *
+ * The original implementation lived as three private static methods on
+ * HaremGirl. They were not unit-tested at all; this spec is the first
+ * coverage of the resonance-bonus and tiebreaker logic.
+ */
+describe("HaremGirl pure equipment helpers", () => {
+    const girl = (overrides: Partial<KKHaremGirl> = {}): KKHaremGirl =>
+        ({
+            class: 1,
+            element: "fire",
+            figure: "slim",
+            ...overrides,
+        } as any);
+
+    const item = (caracs: EquipmentItem["caracs"], extra: Partial<EquipmentItem> = {}): EquipmentItem => ({
+        caracs,
+        ...extra,
+    });
+
+    describe("scoreItem", () => {
+        it("sums every stat field, treating missing keys as zero", () => {
+            const result = scoreItem(item({ carac1: 10, carac2: 20, carac3: 30, damage: 5 }), girl());
+            expect(result).toEqual({ caracSum: 65, resonanceMatches: 0 });
+        });
+
+        it("ignores resonance_bonuses when present as an array (game shape for no bonuses)", () => {
+            const result = scoreItem(
+                item({ carac1: 1, carac2: 2, carac3: 3 }, { resonance_bonuses: [] }),
+                girl(),
+            );
+            expect(result).toEqual({ caracSum: 6, resonanceMatches: 0 });
+        });
+
+        it("counts class, element, and figure matches independently", () => {
+            const result = scoreItem(
+                item(
+                    { carac1: 1 },
+                    {
+                        resonance_bonuses: {
+                            class: { identifier: 1 },
+                            element: { identifier: "fire" },
+                            figure: { identifier: "slim" },
+                        },
+                    },
+                ),
+                girl(),
+            );
+            expect(result).toEqual({ caracSum: 1, resonanceMatches: 3 });
+        });
+
+        it("compares identifiers as strings (numeric girl class vs. string identifier)", () => {
+            const result = scoreItem(
+                item({}, { resonance_bonuses: { class: { identifier: "1" } } }),
+                girl({ class: 1 }),
+            );
+            expect(result.resonanceMatches).toBe(1);
+        });
+
+        it("does not count partial misses", () => {
+            const result = scoreItem(
+                item(
+                    { carac1: 1 },
+                    {
+                        resonance_bonuses: {
+                            class: { identifier: 1 },
+                            element: { identifier: "water" },
+                            figure: { identifier: "curvy" },
+                        },
+                    },
+                ),
+                girl(),
+            );
+            expect(result.resonanceMatches).toBe(1);
+        });
+    });
+
+    describe("findBestItem", () => {
+        it("returns null on an empty list", () => {
+            expect(findBestItem([], girl())).toBeNull();
+        });
+
+        it("picks the highest caracSum first", () => {
+            const a = item({ carac1: 100 });
+            const b = item({ carac1: 200 });
+            const c = item({ carac1: 50 });
+            expect(findBestItem([a, b, c], girl())).toBe(b);
+        });
+
+        it("breaks caracSum ties with resonance matches", () => {
+            const noResonance = item({ carac1: 100 }, { resonance_bonuses: [] });
+            const withResonance = item(
+                { carac1: 100 },
+                {
+                    resonance_bonuses: {
+                        class: { identifier: 1 },
+                    },
+                },
+            );
+            expect(findBestItem([noResonance, withResonance], girl())).toBe(withResonance);
+        });
+
+        it("breaks resonance ties with carac1+carac2+carac3 (excluding damage/defense/ego)", () => {
+            // Same caracSum, no resonance, but different carac1/2/3 split.
+            const heavyArmor = item({ carac1: 10, carac2: 10, carac3: 10, damage: 70 }); // 30 carac, sum 100
+            const balancedItem = item({ carac1: 30, carac2: 35, carac3: 35 }); // 100 carac, sum 100
+            expect(findBestItem([heavyArmor, balancedItem], girl())).toBe(balancedItem);
+        });
+
+        it("does not mutate the input list", () => {
+            const a = item({ carac1: 50 });
+            const b = item({ carac1: 100 });
+            const list = [a, b];
+            findBestItem(list, girl());
+            expect(list).toEqual([a, b]);
+        });
+    });
+
+    describe("isBetter", () => {
+        it("returns true when nothing is currently equipped", () => {
+            expect(isBetter(item({ carac1: 1 }), null, girl())).toBe(true);
+            expect(isBetter(item({ carac1: 1 }), undefined, girl())).toBe(true);
+        });
+
+        it("returns true when the current item has no caracs", () => {
+            expect(isBetter(item({ carac1: 1 }), { caracs: undefined as any }, girl())).toBe(true);
+        });
+
+        it("returns true when caracSum strictly improves", () => {
+            const equipped = item({ carac1: 10 });
+            const candidate = item({ carac1: 11 });
+            expect(isBetter(candidate, equipped, girl())).toBe(true);
+        });
+
+        it("returns false when caracSum strictly worsens", () => {
+            const equipped = item({ carac1: 100 });
+            const candidate = item({ carac1: 99 });
+            expect(isBetter(candidate, equipped, girl())).toBe(false);
+        });
+
+        it("returns true on caracSum tie when resonance improves", () => {
+            const equipped = item({ carac1: 50 }, { resonance_bonuses: [] });
+            const candidate = item(
+                { carac1: 50 },
+                { resonance_bonuses: { class: { identifier: 1 } } },
+            );
+            expect(isBetter(candidate, equipped, girl())).toBe(true);
+        });
+
+        it("returns false on full tie (caracSum and resonance)", () => {
+            const equipped = item({ carac1: 50 }, { resonance_bonuses: [] });
+            const candidate = item({ carac1: 50 }, { resonance_bonuses: [] });
+            expect(isBetter(candidate, equipped, girl())).toBe(false);
+        });
+    });
+});

--- a/src/Module/harem/HaremGirl.pure.ts
+++ b/src/Module/harem/HaremGirl.pure.ts
@@ -1,0 +1,118 @@
+// HaremGirl.pure.ts -- Pure equipment scoring/comparison helpers.
+//
+// Extracted from HaremGirl (private static methods) so the resonance and
+// stat-sum logic can be unit-tested without DOM, jQuery, or globals.
+// HaremGirl now imports these for optimizeEquipmentSlots and the (currently
+// unused) findBestItem helper.
+//
+// The data shape is intentionally loose -- the game API uses untyped JSON
+// and the original methods accepted `any`. We mirror that here and document
+// the keys we read.
+
+import { KKHaremGirl } from "../../model/index";
+
+/**
+ * Subset of an inventory item that the score uses.
+ *
+ * - caracs: stat block; caracN keys feed both caracSum and the secondary
+ *   tiebreaker. damage/defense/ego only feed caracSum.
+ * - resonance_bonuses: an object keyed by class/element/figure with an
+ *   `identifier` field; an array (instead of object) means "no bonuses"
+ *   in the game data and is treated as zero matches.
+ */
+export type EquipmentItem = {
+    caracs: {
+        carac1?: number;
+        carac2?: number;
+        carac3?: number;
+        damage?: number;
+        defense?: number;
+        ego?: number;
+    };
+    resonance_bonuses?:
+        | {
+              class?: { identifier: string | number };
+              element?: { identifier: string | number };
+              figure?: { identifier: string | number };
+          }
+        | unknown[];
+};
+
+export type EquipmentScore = {
+    caracSum: number;
+    resonanceMatches: number;
+};
+
+/**
+ * Sum of all stat fields plus the count of class/element/figure resonance
+ * matches against the wearer.
+ *
+ * Matches the original implementation byte for byte:
+ *   - missing carac fields default to 0
+ *   - resonance_bonuses as an array is ignored (zero matches)
+ *   - identifier comparison is stringified on both sides
+ */
+export function scoreItem(item: EquipmentItem, girl: KKHaremGirl): EquipmentScore {
+    const c = item.caracs;
+    const caracSum =
+        (c.carac1 || 0) +
+        (c.carac2 || 0) +
+        (c.carac3 || 0) +
+        (c.damage || 0) +
+        (c.defense || 0) +
+        (c.ego || 0);
+
+    let resonanceMatches = 0;
+    if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
+        const rb = item.resonance_bonuses;
+        if (rb.class && String(rb.class.identifier) === String(girl.class)) resonanceMatches++;
+        if (rb.element && String(rb.element.identifier) === String(girl.element)) resonanceMatches++;
+        if (rb.figure && String(rb.figure.identifier) === String(girl.figure)) resonanceMatches++;
+    }
+
+    return { caracSum, resonanceMatches };
+}
+
+/**
+ * Pick the highest-scoring item from a list. Tiebreakers, in order:
+ *   1. caracSum
+ *   2. resonanceMatches
+ *   3. carac1+carac2+carac3 (excluding damage/defense/ego)
+ *
+ * Returns null on an empty list. Currently unused in the codebase but kept
+ * as part of the equipment helper trio for parity with the original module.
+ */
+export function findBestItem(items: EquipmentItem[], girl: KKHaremGirl): EquipmentItem | null {
+    if (items.length === 0) return null;
+    return items.slice().sort((a, b) => {
+        const sa = scoreItem(a, girl);
+        const sb = scoreItem(b, girl);
+        if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
+        if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
+        const ca = a.caracs;
+        const cb = b.caracs;
+        return (
+            ((cb.carac1 || 0) + (cb.carac2 || 0) + (cb.carac3 || 0)) -
+            ((ca.carac1 || 0) + (ca.carac2 || 0) + (ca.carac3 || 0))
+        );
+    })[0];
+}
+
+/**
+ * Decide whether `candidate` should replace `current`. Always true if no
+ * current item is equipped (or current.caracs is missing). Otherwise the
+ * candidate must beat the current on caracSum, or tie on caracSum and beat
+ * on resonanceMatches.
+ */
+export function isBetter(
+    candidate: EquipmentItem,
+    current: EquipmentItem | null | undefined,
+    girl: KKHaremGirl,
+): boolean {
+    if (!current || !current.caracs) return true;
+    const sc = scoreItem(candidate, girl);
+    const se = scoreItem(current, girl);
+    if (sc.caracSum > se.caracSum) return true;
+    if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches) return true;
+    return false;
+}

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -27,6 +27,7 @@ import { gotoPage } from "../../Service/index";
 import { displayHHPopUp, fillHHPopUp, logHHAuto, maskHHPopUp } from "../../Utils/index";
 import { HHAuto_inputPattern, HHStoredVarPrefixKey, SK, TK } from "../../config/index";
 import { KKHaremGirl, TeamData } from "../../model/index";
+import { isBetter, scoreItem } from "./HaremGirl.pure";
 
 
 export class HaremGirl {
@@ -850,40 +851,6 @@ export class HaremGirl {
         });
     }
 
-    private static scoreItem(item: any, girl: KKHaremGirl): { caracSum: number, resonanceMatches: number } {
-        const c = item.caracs;
-        const caracSum = (c.carac1 || 0) + (c.carac2 || 0) + (c.carac3 || 0) + (c.damage || 0) + (c.defense || 0) + (c.ego || 0);
-        let resonanceMatches = 0;
-        if (item.resonance_bonuses && !Array.isArray(item.resonance_bonuses)) {
-            const rb = item.resonance_bonuses;
-            if (rb.class && String(rb.class.identifier) === String(girl.class)) resonanceMatches++;
-            if (rb.element && String(rb.element.identifier) === String(girl.element)) resonanceMatches++;
-            if (rb.figure && String(rb.figure.identifier) === String(girl.figure)) resonanceMatches++;
-        }
-        return { caracSum, resonanceMatches };
-    }
-
-    private static findBestItem(items: any[], girl: KKHaremGirl): any {
-        if (items.length === 0) return null;
-        return items.sort((a, b) => {
-            const sa = HaremGirl.scoreItem(a, girl);
-            const sb = HaremGirl.scoreItem(b, girl);
-            if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
-            if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
-            return ((b.caracs.carac1||0)+(b.caracs.carac2||0)+(b.caracs.carac3||0))
-                 - ((a.caracs.carac1||0)+(a.caracs.carac2||0)+(a.caracs.carac3||0));
-        })[0];
-    }
-
-    private static isBetter(candidate: any, current: any, girl: KKHaremGirl): boolean {
-        if (!current || !current.caracs) return true;
-        const sc = HaremGirl.scoreItem(candidate, girl);
-        const se = HaremGirl.scoreItem(current, girl);
-        if (sc.caracSum > se.caracSum) return true;
-        if (sc.caracSum === se.caracSum && sc.resonanceMatches > se.resonanceMatches) return true;
-        return false;
-    }
-
     /**
      * Force the game's lazy-loaded inventory panel to render all items.
      * The game renders inventory items on-demand as the container is scrolled.
@@ -980,8 +947,8 @@ export class HaremGirl {
 
             // Rank candidates: total stats, then resonance, then individual stats
             const sorted = inventoryItems.slice().sort((a, b) => {
-                const sa = HaremGirl.scoreItem(a.data, girl);
-                const sb = HaremGirl.scoreItem(b.data, girl);
+                const sa = scoreItem(a.data, girl);
+                const sb = scoreItem(b.data, girl);
                 if (sb.caracSum !== sa.caracSum) return sb.caracSum - sa.caracSum;
                 if (sb.resonanceMatches !== sa.resonanceMatches) return sb.resonanceMatches - sa.resonanceMatches;
                 const ca = a.data.caracs, cb = b.data.caracs;
@@ -989,8 +956,8 @@ export class HaremGirl {
             });
             const bestInventory = sorted[0];
 
-            const bestScore = HaremGirl.scoreItem(bestInventory.data, girl);
-            const shouldReplace = HaremGirl.isBetter(bestInventory.data, equippedData, girl);
+            const bestScore = scoreItem(bestInventory.data, girl);
+            const shouldReplace = isBetter(bestInventory.data, equippedData, girl);
 
             if (shouldReplace) {
                 logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
@@ -1090,7 +1057,7 @@ export class HaremGirl {
                     logHHAuto(`Slot ${i}: equip failed after ${MAX_EQUIP_ATTEMPTS} attempts, skipping`);
                 }
             } else {
-                const eqScore = equippedData ? HaremGirl.scoreItem(equippedData, girl) : null;
+                const eqScore = equippedData ? scoreItem(equippedData, girl) : null;
                 logHHAuto(`Slot ${i}: current item is optimal (L${equippedData?.level} ${equippedData?.rarity}, score=${eqScore?.caracSum})`);
             }
         }


### PR DESCRIPTION
Stage 1, task 1.3 from `docs-internal/test-strategy.md`.

## What

Extract the three equipment-scoring helpers from `HaremGirl` into a
pure module `src/Module/harem/HaremGirl.pure.ts`:

- `scoreItem(item, girl)` -- caracSum + resonance match count
- `findBestItem(items, girl)` -- highest score with three tiebreakers
- `isBetter(candidate, current, girl)` -- replacement decision

`HaremGirl.optimizeEquipmentSlots` now imports the module functions
instead of calling them off the class.

## Plan deviation (already discussed)

The plan suggested `parseGirlsFromGameData(rawData) -> Girl[]`, but no
such parser exists in the module. The actual decision logic that fits
stage 1 is the equipment helper trio, which previously had zero unit
tests. A girls parser belongs in stage 2 alongside the dump fixtures.

## Tests

- 576 existing tests stay green.
- 16 new pure-function tests cover:
  - `scoreItem`: stat sum incl. damage/defense/ego, resonance counting
    (full match, partial, array shape, stringified identifier)
  - `findBestItem`: empty list, primary sort, two tiebreakers,
    input-non-mutation
  - `isBetter`: no current, missing caracs, strict gain/loss,
    resonance tiebreak, full tie
- Total: 592 passed, 0 skipped, 42 suites.

## Bundle

`HHAuto.user.js` rebuilt, diff is purely structural.

## Note: dead code

`findBestItem` has no remaining callers in the codebase. It is kept in
the pure module for parity with the original trio; a separate cleanup
can drop it later.

## Plan

`docs-internal/test-strategy.md` will be updated post-merge: tick
1.3, bump status block, append change-log row.
