### PR TITLE
refactor(autoloop): extract decideBurst and shouldRunStandardHandler

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -23477,6 +23477,48 @@ class AdsService {
     }
 }
 
+;// CONCATENATED MODULE: ./src/Service/AutoLoop.pure.ts
+// AutoLoop.pure.ts -- Pure decision logic for the auto-loop scheduler.
+//
+// Two helpers:
+//   - decideBurst: replicates the storage/DOM-reading guard at the top
+//     of getBurst(). The DOM reads (sMenu visibility, nav content
+//     visibility) stay in the adapter; this function takes booleans.
+//   - shouldRunStandardHandler: replicates the pre-condition cascade
+//     at the top of runStandardHandler. The actual handler invocation
+//     and ctx mutation stay impure.
+//
+// Both are extracted byte-for-byte. Refactor, not a behaviour change.
+/**
+ * Replicates getBurst() except the DOM reads.
+ *
+ * Returns false if either UI overlay is showing (sMenu or nav content),
+ * otherwise:
+ *     master AND (NOT paranoia OR burst)
+ *
+ * Bit-for-bit equivalent to the original short-circuit.
+ */
+function decideBurst(state) {
+    if (state.sMenuVisible)
+        return false;
+    if (state.navContentBlock)
+        return false;
+    return state.master && (!state.paranoia || state.burst);
+}
+function shouldRunStandardHandler(g) {
+    if (g.ctxBusy)
+        return false;
+    if (g.requiresAutoLoop !== false && !g.autoLoopActive)
+        return false;
+    if (g.requiresCompetition && !g.competitionActive)
+        return false;
+    if (g.lastActionPerformed !== "none" && g.lastActionPerformed !== g.handlerAction)
+        return false;
+    if (!g.isReady)
+        return false;
+    return true;
+}
+
 ;// CONCATENATED MODULE: ./src/Service/AutoLoopActions.ts
 // AutoLoopActions.ts
 //
@@ -23510,6 +23552,7 @@ var AutoLoopActions_awaiter = (undefined && undefined.__awaiter) || function (th
 
 
 
+
 // ---------------------------------------------------------------------------
 //  Standard handler utility – reduces boilerplate for simple module handlers
 // ---------------------------------------------------------------------------
@@ -23520,15 +23563,17 @@ var AutoLoopActions_awaiter = (undefined && undefined.__awaiter) || function (th
  */
 function runStandardHandler(ctx, d) {
     return AutoLoopActions_awaiter(this, void 0, void 0, function* () {
-        if (ctx.busy)
-            return;
-        if (d.requiresAutoLoop !== false && !isAutoLoopActive())
-            return;
-        if (d.requiresCompetition && !ctx.canCollectCompetitionActive)
-            return;
-        if (ctx.lastActionPerformed !== "none" && ctx.lastActionPerformed !== d.action)
-            return;
-        if (!d.isReady())
+        const shouldRun = shouldRunStandardHandler({
+            ctxBusy: ctx.busy,
+            autoLoopActive: isAutoLoopActive(),
+            competitionActive: ctx.canCollectCompetitionActive,
+            lastActionPerformed: ctx.lastActionPerformed,
+            requiresAutoLoop: d.requiresAutoLoop,
+            requiresCompetition: d.requiresCompetition,
+            handlerAction: d.action,
+            isReady: d.isReady(),
+        });
+        if (!shouldRun)
             return;
         LogUtils_logHHAuto(d.name);
         const result = yield d.execute();
@@ -25070,22 +25115,20 @@ var AutoLoop_awaiter = (undefined && undefined.__awaiter) || function (thisArg, 
 
 
 
+
 let busy = false;
 function getBurst() {
     const sMenu = document.getElementById('sMenu');
-    if (sMenu != null) {
-        if (sMenu.style.display !== 'none') // && !document.getElementById("DebugDialog").open)
-         {
-            return false;
-        }
-    }
-    if ($('#contains_all>nav>[rel=content]').length > 0) {
-        if ($('#contains_all>nav>[rel=content]')[0].style.display === "block") // && !document.getElementById("DebugDialog").open)
-         {
-            return false;
-        }
-    }
-    return getStoredValue(HHStoredVarPrefixKey + SK.master) === "true" && (!(getStoredValue(HHStoredVarPrefixKey + SK.paranoia) === "true") || getStoredValue(HHStoredVarPrefixKey + TK.burst) === "true");
+    const sMenuVisible = sMenu != null && sMenu.style.display !== 'none';
+    const $navContent = $('#contains_all>nav>[rel=content]');
+    const navContentBlock = $navContent.length > 0 && $navContent[0].style.display === 'block';
+    return decideBurst({
+        sMenuVisible,
+        navContentBlock,
+        master: getStoredValue(HHStoredVarPrefixKey + SK.master) === "true",
+        paranoia: getStoredValue(HHStoredVarPrefixKey + SK.paranoia) === "true",
+        burst: getStoredValue(HHStoredVarPrefixKey + TK.burst) === "true",
+    });
 }
 function CheckSpentPoints() {
     let oldValues = getStoredJSON(HHStoredVarPrefixKey + TK.CheckSpentPoints, -1);

--- a/spec/Service/AutoLoop.pure.spec.ts
+++ b/spec/Service/AutoLoop.pure.spec.ts
@@ -1,0 +1,141 @@
+import {
+    BurstState,
+    decideBurst,
+    shouldRunStandardHandler,
+    StandardHandlerGuard,
+} from "../../src/Service/AutoLoop.pure";
+
+describe("decideBurst", () => {
+    const burstState = (overrides: Partial<BurstState> = {}): BurstState => ({
+        sMenuVisible: false,
+        navContentBlock: false,
+        master: true,
+        paranoia: false,
+        burst: false,
+        ...overrides,
+    });
+
+    it("returns false when the sMenu overlay is visible", () => {
+        expect(decideBurst(burstState({ sMenuVisible: true }))).toBe(false);
+    });
+
+    it("returns false when the nav content overlay is showing block", () => {
+        expect(decideBurst(burstState({ navContentBlock: true }))).toBe(false);
+    });
+
+    it("returns false when master is off, regardless of paranoia/burst", () => {
+        expect(decideBurst(burstState({ master: false }))).toBe(false);
+        expect(decideBurst(burstState({ master: false, burst: true }))).toBe(false);
+    });
+
+    it("returns true when master is on and paranoia is off", () => {
+        expect(decideBurst(burstState({ master: true, paranoia: false }))).toBe(true);
+    });
+
+    it("returns false when master is on, paranoia is on, but burst is off", () => {
+        expect(
+            decideBurst(burstState({ master: true, paranoia: true, burst: false })),
+        ).toBe(false);
+    });
+
+    it("returns true when master is on, paranoia is on, and burst is on", () => {
+        expect(
+            decideBurst(burstState({ master: true, paranoia: true, burst: true })),
+        ).toBe(true);
+    });
+
+    it("UI overlays beat the master/paranoia/burst combination", () => {
+        expect(
+            decideBurst(burstState({ sMenuVisible: true, master: true, burst: true })),
+        ).toBe(false);
+    });
+});
+
+describe("shouldRunStandardHandler", () => {
+    const guard = (overrides: Partial<StandardHandlerGuard> = {}): StandardHandlerGuard => ({
+        ctxBusy: false,
+        autoLoopActive: true,
+        competitionActive: false,
+        lastActionPerformed: "none",
+        requiresAutoLoop: undefined,
+        requiresCompetition: undefined,
+        handlerAction: "myhandler",
+        isReady: true,
+        ...overrides,
+    });
+
+    it("returns true on a clean baseline (defaults)", () => {
+        expect(shouldRunStandardHandler(guard())).toBe(true);
+    });
+
+    it("returns false when ctx is already busy", () => {
+        expect(shouldRunStandardHandler(guard({ ctxBusy: true }))).toBe(false);
+    });
+
+    it("returns false when AutoLoop is inactive and the handler requires it (default)", () => {
+        expect(shouldRunStandardHandler(guard({ autoLoopActive: false }))).toBe(false);
+    });
+
+    it("returns true when AutoLoop is inactive but the handler opts out via requiresAutoLoop=false", () => {
+        expect(
+            shouldRunStandardHandler(
+                guard({ autoLoopActive: false, requiresAutoLoop: false }),
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when requiresCompetition is on but no competition is active", () => {
+        expect(
+            shouldRunStandardHandler(guard({ requiresCompetition: true })),
+        ).toBe(false);
+    });
+
+    it("returns true when requiresCompetition is on and competition is active", () => {
+        expect(
+            shouldRunStandardHandler(
+                guard({ requiresCompetition: true, competitionActive: true }),
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when another action is already in progress this loop", () => {
+        expect(
+            shouldRunStandardHandler(
+                guard({ lastActionPerformed: "otherAction", handlerAction: "myhandler" }),
+            ),
+        ).toBe(false);
+    });
+
+    it("returns true when lastActionPerformed matches this handlers own action (loop continuation)", () => {
+        expect(
+            shouldRunStandardHandler(
+                guard({ lastActionPerformed: "myhandler", handlerAction: "myhandler" }),
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when isReady is false (descriptor guard)", () => {
+        expect(shouldRunStandardHandler(guard({ isReady: false }))).toBe(false);
+    });
+
+    it("evaluates guards in the original order: ctxBusy beats autoLoopActive", () => {
+        // ctx.busy must short-circuit before any other check, including
+        // requiresAutoLoop/autoLoopActive.
+        expect(
+            shouldRunStandardHandler(
+                guard({ ctxBusy: true, autoLoopActive: false }),
+            ),
+        ).toBe(false);
+    });
+
+    it("requiresAutoLoop=true is equivalent to undefined (default behaviour)", () => {
+        const explicit = shouldRunStandardHandler(
+            guard({ requiresAutoLoop: true, autoLoopActive: false }),
+        );
+        const implicit = shouldRunStandardHandler(
+            guard({ requiresAutoLoop: undefined, autoLoopActive: false }),
+        );
+        expect(explicit).toBe(false);
+        expect(implicit).toBe(false);
+    });
+});

--- a/src/Service/AutoLoop.pure.ts
+++ b/src/Service/AutoLoop.pure.ts
@@ -1,0 +1,74 @@
+// AutoLoop.pure.ts -- Pure decision logic for the auto-loop scheduler.
+//
+// Two helpers:
+//   - decideBurst: replicates the storage/DOM-reading guard at the top
+//     of getBurst(). The DOM reads (sMenu visibility, nav content
+//     visibility) stay in the adapter; this function takes booleans.
+//   - shouldRunStandardHandler: replicates the pre-condition cascade
+//     at the top of runStandardHandler. The actual handler invocation
+//     and ctx mutation stay impure.
+//
+// Both are extracted byte-for-byte. Refactor, not a behaviour change.
+
+export type BurstState = {
+    /** sMenu element exists AND is visible (display !== "none"). */
+    sMenuVisible: boolean;
+    /** #contains_all>nav>[rel=content] exists AND its first match has display === "block". */
+    navContentBlock: boolean;
+    /** Setting_master === "true". */
+    master: boolean;
+    /** Setting_paranoia === "true". */
+    paranoia: boolean;
+    /** Temp_burst === "true". */
+    burst: boolean;
+};
+
+/**
+ * Replicates getBurst() except the DOM reads.
+ *
+ * Returns false if either UI overlay is showing (sMenu or nav content),
+ * otherwise:
+ *     master AND (NOT paranoia OR burst)
+ *
+ * Bit-for-bit equivalent to the original short-circuit.
+ */
+export function decideBurst(state: BurstState): boolean {
+    if (state.sMenuVisible) return false;
+    if (state.navContentBlock) return false;
+    return state.master && (!state.paranoia || state.burst);
+}
+
+/**
+ * The pre-condition cascade from runStandardHandler. Returns true if
+ * the handler should fire, false if any guard rejects.
+ *
+ * Original cascade order is preserved so logging order in the impure
+ * adapter stays unchanged when this function is wired in.
+ */
+export type StandardHandlerGuard = {
+    /** ctx.busy at the moment the handler is evaluated. */
+    ctxBusy: boolean;
+    /** Result of isAutoLoopActive(). */
+    autoLoopActive: boolean;
+    /** ctx.canCollectCompetitionActive. */
+    competitionActive: boolean;
+    /** ctx.lastActionPerformed. */
+    lastActionPerformed: string;
+    /** Descriptor.requiresAutoLoop -- undefined defaults to true. */
+    requiresAutoLoop: boolean | undefined;
+    /** Descriptor.requiresCompetition -- undefined defaults to false. */
+    requiresCompetition: boolean | undefined;
+    /** Descriptor.action. */
+    handlerAction: string;
+    /** Descriptor.isReady() result. */
+    isReady: boolean;
+};
+
+export function shouldRunStandardHandler(g: StandardHandlerGuard): boolean {
+    if (g.ctxBusy) return false;
+    if (g.requiresAutoLoop !== false && !g.autoLoopActive) return false;
+    if (g.requiresCompetition && !g.competitionActive) return false;
+    if (g.lastActionPerformed !== "none" && g.lastActionPerformed !== g.handlerAction) return false;
+    if (!g.isReady) return false;
+    return true;
+}

--- a/src/Service/AutoLoop.ts
+++ b/src/Service/AutoLoop.ts
@@ -92,6 +92,7 @@ import {
     handleBossBangFight,
     handleGoHome,
 } from './AutoLoopActions';
+import { decideBurst } from './AutoLoop.pure';
 import { handlePageSpecific } from './AutoLoopPageHandlers';
 import { scheduler } from './Scheduler';
 
@@ -101,21 +102,18 @@ export let busy = false;
 export function getBurst()
 {
     const sMenu = document.getElementById('sMenu');
-    if (sMenu != null)
-    {
-        if (sMenu.style.display!=='none' )// && !document.getElementById("DebugDialog").open)
-        {
-            return false;
-        }
-    }
-    if ($('#contains_all>nav>[rel=content]').length >0)
-    {
-        if ($('#contains_all>nav>[rel=content]')[0].style.display === "block")// && !document.getElementById("DebugDialog").open)
-        {
-            return false;
-        }
-    }
-    return getStoredValue(HHStoredVarPrefixKey+SK.master) ==="true"&&(!(getStoredValue(HHStoredVarPrefixKey+SK.paranoia) ==="true") || getStoredValue(HHStoredVarPrefixKey+TK.burst) ==="true");
+    const sMenuVisible = sMenu != null && sMenu.style.display !== 'none';
+
+    const $navContent = $('#contains_all>nav>[rel=content]');
+    const navContentBlock = $navContent.length > 0 && ($navContent[0] as HTMLElement).style.display === 'block';
+
+    return decideBurst({
+        sMenuVisible,
+        navContentBlock,
+        master: getStoredValue(HHStoredVarPrefixKey + SK.master) === "true",
+        paranoia: getStoredValue(HHStoredVarPrefixKey + SK.paranoia) === "true",
+        burst: getStoredValue(HHStoredVarPrefixKey + TK.burst) === "true",
+    });
 }
 
 

--- a/src/Service/AutoLoopActions.ts
+++ b/src/Service/AutoLoopActions.ts
@@ -17,6 +17,7 @@
 
 import { AutoLoopContext } from './AutoLoopContext';
 import { ModuleHandlerDescriptor } from '../model/IModule';
+import { shouldRunStandardHandler } from './AutoLoop.pure';
 import {
     checkTimer,
     checkTimerMustExist,
@@ -91,11 +92,17 @@ import { isAutoLoopActive } from './AutoLoop';
  * → check lastAction → check isReady → log → execute → update busy & lastAction.
  */
 export async function runStandardHandler(ctx: AutoLoopContext, d: ModuleHandlerDescriptor): Promise<void> {
-    if (ctx.busy) return;
-    if (d.requiresAutoLoop !== false && !isAutoLoopActive()) return;
-    if (d.requiresCompetition && !ctx.canCollectCompetitionActive) return;
-    if (ctx.lastActionPerformed !== "none" && ctx.lastActionPerformed !== d.action) return;
-    if (!d.isReady()) return;
+    const shouldRun = shouldRunStandardHandler({
+        ctxBusy: ctx.busy,
+        autoLoopActive: isAutoLoopActive(),
+        competitionActive: ctx.canCollectCompetitionActive,
+        lastActionPerformed: ctx.lastActionPerformed,
+        requiresAutoLoop: d.requiresAutoLoop,
+        requiresCompetition: d.requiresCompetition,
+        handlerAction: d.action,
+        isReady: d.isReady(),
+    });
+    if (!shouldRun) return;
 
     logHHAuto(d.name);
     const result = await d.execute();


### PR DESCRIPTION
Stage 1, task 1.4 from `docs-internal/test-strategy.md`.

## What

Two decision-only helpers extracted into a new pure module
`src/Service/AutoLoop.pure.ts`:

- `decideBurst(state)` -- replicates the post-DOM tail of `getBurst()`.
  The DOM reads (sMenu visibility, nav content visibility) stay in the
  adapter; the function takes booleans for both overlays plus the
  three storage flags.
- `shouldRunStandardHandler(guard)` -- replicates the pre-condition
  cascade at the top of `runStandardHandler`. The handler invocation
  and ctx mutation stay impure.

## Plan deviation (already discussed)

The plan suggested a single `pickNextAction(state)` selector, but
AutoLoop is a sequential handler pipeline, not a one-shot picker.
Each handler has its own pre-conditions; only the
`runStandardHandler` entry has a unified guard cascade worth
extracting today. The remaining ~30 hand-rolled handlers each follow
a slightly different pattern and are deferred to stage 3.

## Tests

- 592 existing tests stay green.
- 18 new pure-function tests cover:
  - `decideBurst` (7 cases): each UI overlay, master-off,
    paranoia-without-burst, paranoia-with-burst, UI overlay beats
    settings.
  - `shouldRunStandardHandler` (11 cases): baseline, ctxBusy,
    requiresAutoLoop default vs explicit, requiresCompetition on/off,
    lastActionPerformed match/mismatch, isReady=false, guard
    short-circuit order.
- Total: 610 passed, 0 skipped, 43 suites.

## Bit-for-bit equivalence

- Guard order preserved (ctxBusy -> autoLoop -> competition ->
  lastAction -> isReady).
- `requiresAutoLoop=undefined` still treated as default-true.
- `decideBurst` short-circuits on either overlay before reading the
  master/paranoia/burst combo.

## Bundle

`HHAuto.user.js` rebuilt, diff is purely structural.

## Plan

`docs-internal/test-strategy.md` will be updated post-merge: tick
1.4, bump status block, append change-log row.
