### PR TITLE
test(fixtures): add league fixtures and shared loader

### DIFF
--- a/spec/fixtures/league/Fixtures.spec.ts
+++ b/spec/fixtures/league/Fixtures.spec.ts
@@ -1,0 +1,66 @@
+import { loadFixture } from "../../testHelpers/Fixtures";
+
+/**
+ * Smoke tests for the league fixtures.
+ *
+ * These confirm that the fixture files load and carry the shape promised
+ * by the sibling README. They are not parser tests; once a real opponent
+ * or reward parser exists (stage 3 decision-logic coverage), these checks
+ * can be retired or merged into the parser test.
+ */
+describe("league fixtures", () => {
+    describe("opponents-mid-tier", () => {
+        it("loads as an array of three entries", () => {
+            const fixture = loadFixture("league", "opponents-mid-tier") as unknown;
+            expect(Array.isArray(fixture)).toBe(true);
+            expect((fixture as unknown[]).length).toBe(3);
+        });
+
+        it("has numeric id_member, level, power, and place on every entry", () => {
+            const opponents = loadFixture("league", "opponents-mid-tier") as Array<{
+                id_member: unknown;
+                level: unknown;
+                power: unknown;
+                place: unknown;
+            }>;
+            for (const o of opponents) {
+                expect(typeof o.id_member).toBe("number");
+                expect(typeof o.level).toBe("number");
+                expect(typeof o.power).toBe("number");
+                expect(typeof o.place).toBe("number");
+            }
+        });
+
+        it("redacts nicknames to the Player_<n> placeholder pattern", () => {
+            const opponents = loadFixture("league", "opponents-mid-tier") as Array<{
+                nickname: unknown;
+                player: { id_fighter: unknown };
+            }>;
+            for (const o of opponents) {
+                expect(typeof o.nickname).toBe("string");
+                expect(o.nickname as string).toMatch(/^Player_\d+$/);
+                expect(typeof o.player.id_fighter).toBe("number");
+            }
+        });
+    });
+
+    describe("league-rewards-tier3", () => {
+        it("loads with the expected rank brackets plus the tier name", () => {
+            const tier = loadFixture("league", "league-rewards-tier3") as Record<string, unknown>;
+            const expectedBrackets = ["1", "4", "15", "30", "45", "60", "75", "200"];
+            for (const b of expectedBrackets) {
+                expect(tier).toHaveProperty(b);
+            }
+            expect(tier).toHaveProperty("name");
+        });
+
+        it("carries a numeric rewards_segment in every rank bracket", () => {
+            const tier = loadFixture("league", "league-rewards-tier3") as Record<string, unknown>;
+            const expectedBrackets = ["1", "4", "15", "30", "45", "60", "75", "200"];
+            for (const b of expectedBrackets) {
+                const bracket = tier[b] as { rewards_segment: unknown };
+                expect(typeof bracket.rewards_segment).toBe("number");
+            }
+        });
+    });
+});

--- a/spec/fixtures/league/README.md
+++ b/spec/fixtures/league/README.md
@@ -1,0 +1,35 @@
+# League fixtures
+
+## Source
+
+- Dump: `INPUT/hhauto_dump_www_hentaiheroes_com_tour_2026-05-05T12-11-40-985Z.json`
+- Capture date: 2026-05-05T12:11:40Z
+- Page index: 1 (`/leagues.html`)
+
+## Files
+
+### `opponents-mid-tier.json`
+
+- Source path: `pages[1].teams.opponents_list`
+- Selection: indices 49-51 (3 entries, mid-tier by league place 50-52, total 100 entries)
+- Fields kept per entry:
+  - Top-level: `id_member` (= `player.id_fighter`), `nickname` (redacted), `level`, `power`, `place`, `country`, `can_fight`
+  - `player`: `{ id_fighter, level, class, current_season_mojo }`
+- Redactions:
+  - `nickname` and `player.nickname` replaced with `Player_1..3`
+  - `player.club` removed (contains club name and member ids)
+- Plan deviation: the strategy plan listed `member.id_country`, `member.lvl`, `team.theme_elements[]`, `team.girls[]`. The actual dump has top-level `level`/`power`/`country`/`nickname` and `team` is an HTML snippet string, not an object. Field selection follows the dump.
+
+### `league-rewards-tier3.json`
+
+- Source path: `pages[1].battle.league_rewards["3"]`
+- Selection: tier 3 in full -- rank brackets `1`, `4`, `15`, `30`, `45`, `60`, `75`, `200`, plus the `name` key
+- Redactions: none (no PII; `shards` arrives as the string sentinel `"[circular]"` from the dump's circular-reference replacer)
+
+## How to refresh
+
+If a fresh dump is captured later:
+
+1. Run the inspection helper from `docs-internal/test-strategy.md` "Data sources" to confirm key paths still match.
+2. Reuse the same indices (49-51) and tier (3). If structural drift breaks that, document the new selection here.
+3. Apply the same redactions: `nickname` -> `Player_<n>`, drop `player.club`.

--- a/spec/fixtures/league/league-rewards-tier3.json
+++ b/spec/fixtures/league/league-rewards-tier3.json
@@ -1,0 +1,109 @@
+{
+  "1": {
+    "label": "1<sup>st</sup>",
+    "rewards_segment": 1,
+    "equipment": false,
+    "gift": false,
+    "hc": 432,
+    "sc": 0,
+    "combativity": 6,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": {
+      "o_m1": 1
+    },
+    "shards": "[circular]"
+  },
+  "4": {
+    "label": "2-4<sup>th</sup>",
+    "rewards_segment": 4,
+    "equipment": false,
+    "gift": false,
+    "hc": 288,
+    "sc": 0,
+    "combativity": 5,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "15": {
+    "label": "5-15<sup>th</sup>",
+    "rewards_segment": 15,
+    "equipment": false,
+    "gift": false,
+    "hc": 174,
+    "sc": 0,
+    "combativity": 4,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "30": {
+    "label": "16-30<sup>th</sup>",
+    "rewards_segment": 30,
+    "equipment": false,
+    "gift": false,
+    "hc": 132,
+    "sc": 0,
+    "combativity": 3,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "45": {
+    "label": "31-45<sup>th</sup>",
+    "rewards_segment": 45,
+    "equipment": false,
+    "gift": false,
+    "hc": 96,
+    "sc": 0,
+    "combativity": 2,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "60": {
+    "label": "46-60<sup>th</sup>",
+    "rewards_segment": 60,
+    "equipment": false,
+    "gift": false,
+    "hc": 66,
+    "sc": 0,
+    "combativity": 1,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "75": {
+    "label": "61-75<sup>th</sup>",
+    "rewards_segment": 75,
+    "equipment": false,
+    "gift": false,
+    "hc": 42,
+    "sc": 0,
+    "combativity": 1,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": "[circular]"
+  },
+  "200": {
+    "label": "76<sup>th</sup>+",
+    "rewards_segment": 200,
+    "equipment": false,
+    "gift": false,
+    "hc": 0,
+    "sc": 0,
+    "combativity": 1,
+    "energy_kiss": 0,
+    "energy_worship": 0,
+    "orbs": [],
+    "shards": []
+  },
+  "name": "Wanker III"
+}

--- a/spec/fixtures/league/opponents-mid-tier.json
+++ b/spec/fixtures/league/opponents-mid-tier.json
@@ -1,0 +1,47 @@
+[
+  {
+    "id_member": 334202,
+    "nickname": "Player_1",
+    "level": 701,
+    "power": 2482758,
+    "place": 50,
+    "country": "US",
+    "can_fight": 0,
+    "player": {
+      "id_fighter": 334202,
+      "level": 701,
+      "class": 2,
+      "current_season_mojo": 6443
+    }
+  },
+  {
+    "id_member": 772285,
+    "nickname": "Player_2",
+    "level": 689,
+    "power": 2435749,
+    "place": 51,
+    "country": "BE",
+    "can_fight": 0,
+    "player": {
+      "id_fighter": 772285,
+      "level": 689,
+      "class": 2,
+      "current_season_mojo": 7393
+    }
+  },
+  {
+    "id_member": 1641859,
+    "nickname": "Player_3",
+    "level": 672,
+    "power": 2768743,
+    "place": 52,
+    "country": "MX",
+    "can_fight": 0,
+    "player": {
+      "id_fighter": 1641859,
+      "level": 672,
+      "class": 1,
+      "current_season_mojo": 5185
+    }
+  }
+]

--- a/spec/testHelpers/Fixtures.ts
+++ b/spec/testHelpers/Fixtures.ts
@@ -1,0 +1,18 @@
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Loader for static JSON fixtures under spec/fixtures/<modulePath>/<name>.json.
+ *
+ * Synchronous on purpose: Jest test setup runs in Node, not in the browser,
+ * and a synchronous read keeps tests easy to reason about.
+ *
+ * @param modulePath  Subdirectory under spec/fixtures (e.g. "league").
+ * @param name        Fixture file basename without the .json extension.
+ * @returns           Parsed JSON content as `unknown`. Callers narrow the type.
+ */
+export function loadFixture(modulePath: string, name: string): unknown {
+    const fixturePath = path.join(__dirname, "..", "fixtures", modulePath, `${name}.json`);
+    const raw = fs.readFileSync(fixturePath, "utf-8");
+    return JSON.parse(raw);
+}


### PR DESCRIPTION
## Summary

Stage 2 entry point: introduces the fixture infrastructure and the first
concrete fixture set (League opponents and league rewards) drawn from the
2026-05-05 dump. Bundles plan tasks 2.1 (directory), 2.2 (League fixtures),
and 2.6 (loader) into a single PR -- the loader is small and the League
fixture is its first concrete consumer, so shipping them apart would mean
infrastructure without a user.

## Changes

- `spec/fixtures/league/opponents-mid-tier.json` -- 3 entries (places
  50-52) extracted from `teams.opponents_list` with PII redacted
  (nicknames replaced with `Player_1..3`, `player.club` removed).
- `spec/fixtures/league/league-rewards-tier3.json` -- tier 3 of
  `battle.league_rewards` in full.
- `spec/fixtures/league/README.md` -- audit trail: source paths,
  selection rationale, redactions, refresh procedure.
- `spec/testHelpers/Fixtures.ts` -- single `loadFixture(modulePath, name)`
  function, synchronous `fs.readFileSync` + `JSON.parse`. Returns
  `unknown`; callers narrow types at the use site.
- `spec/fixtures/league/Fixtures.spec.ts` -- 5 smoke tests covering
  shape promises (entry count, numeric IDs, redaction pattern, expected
  rank brackets, numeric `rewards_segment`).

## Plan deviation

The strategy plan pre-listed `member.id_country`, `member.lvl`,
`team.theme_elements[]`, and `team.girls[]` per opponent. The actual
dump has those fields at top level (`level`, `power`, `country`,
`nickname`) and `team` is an HTML snippet string, not an object. Field
selection in the fixture follows the real dump shape; the README documents
the substitution.

## Verification

- `npm test`: 615 passed (610 + 5), 44 suites, 0 skipped.
- `npm run build`: structural diff only (no src changes); `HHAuto.user.js`
  line-ending drift discarded before commit.
- No production code under `src/` touched.
- No DOM, no jQuery, no `unsafeWindow` in the loader or the smoke tests.

## Out of scope

- Plan tasks 2.3 (HaremGirl), 2.4 (Champion), 2.5 (Event) follow in their
  own PRs and reuse this loader.
- The deferred `parseGirlsFromGameData` from stage 1 task 1.3 is the
  natural pairing with task 2.3 and is not part of this PR.