### PR TITLE
test(fixtures): add haremGirl sample-girls fixture and smoke tests

### DIFF
--- a/spec/fixtures/haremGirl/Fixtures.spec.ts
+++ b/spec/fixtures/haremGirl/Fixtures.spec.ts
@@ -1,0 +1,105 @@
+import { loadFixture } from "../../testHelpers/Fixtures";
+
+/**
+ * Smoke tests for the haremGirl fixture.
+ *
+ * Confirms that the fixture file loads and carries the shape promised
+ * by the sibling README. These are not parser tests; once
+ * parseGirlsFromGameData (deferred from stage 1 task 1.3) lands in
+ * stage 3, these checks can be retired or merged into the parser test.
+ */
+describe("haremGirl fixtures", () => {
+    describe("sample-girls", () => {
+        it("loads as an array of three entries", () => {
+            const fixture = loadFixture("haremGirl", "sample-girls") as unknown;
+            expect(Array.isArray(fixture)).toBe(true);
+            expect((fixture as unknown[]).length).toBe(3);
+        });
+
+        it("covers the rarity slots required by the plan", () => {
+            const girls = loadFixture("haremGirl", "sample-girls") as Array<{
+                rarity: unknown;
+                nb_grades: unknown;
+            }>;
+            const summaries = girls.map((g) => ({
+                rarity: g.rarity,
+                nb_grades: g.nb_grades,
+            }));
+            expect(summaries).toEqual(
+                expect.arrayContaining([
+                    { rarity: "mythic", nb_grades: 6 },
+                    { rarity: "legendary", nb_grades: 5 },
+                    { rarity: "common", nb_grades: 5 },
+                ]),
+            );
+        });
+
+        it("has numeric core ids and progress fields on every entry", () => {
+            const girls = loadFixture("haremGirl", "sample-girls") as Array<{
+                id_girl: unknown;
+                id_girl_ref: unknown;
+                level: unknown;
+                xp: unknown;
+                shards: unknown;
+                caracs_sum: unknown;
+            }>;
+            for (const g of girls) {
+                expect(typeof g.id_girl).toBe("number");
+                expect(typeof g.id_girl_ref).toBe("number");
+                expect(typeof g.level).toBe("number");
+                expect(typeof g.xp).toBe("number");
+                expect(typeof g.shards).toBe("number");
+                expect(typeof g.caracs_sum).toBe("number");
+            }
+        });
+
+        it("carries a caracs object with the three primary stats", () => {
+            const girls = loadFixture("haremGirl", "sample-girls") as Array<{
+                carac1: unknown;
+                carac2: unknown;
+                carac3: unknown;
+                caracs: Record<string, unknown>;
+            }>;
+            for (const g of girls) {
+                expect(typeof g.carac1).toBe("number");
+                expect(typeof g.carac2).toBe("number");
+                expect(typeof g.carac3).toBe("number");
+                expect(typeof g.caracs).toBe("object");
+                expect(g.caracs).not.toBeNull();
+            }
+        });
+
+        it("carries the salary fields needed by future parser tests", () => {
+            const girls = loadFixture("haremGirl", "sample-girls") as Array<{
+                salary: unknown;
+                salary_per_hour: unknown;
+                pay_time: unknown;
+            }>;
+            for (const g of girls) {
+                expect(typeof g.salary).toBe("number");
+                expect(typeof g.salary_per_hour).toBe("number");
+                expect(typeof g.pay_time).toBe("number");
+            }
+        });
+
+        it("strips asset urls and metadata that the whitelist drops", () => {
+            const girls = loadFixture("haremGirl", "sample-girls") as Array<Record<string, unknown>>;
+            const dropped = [
+                "avatar",
+                "default_avatar",
+                "black_avatar",
+                "ico",
+                "preview",
+                "images",
+                "scene_paths",
+                "release_date",
+                "date_added",
+            ];
+            for (const g of girls) {
+                for (const f of dropped) {
+                    expect(g).not.toHaveProperty(f);
+                }
+            }
+        });
+    });
+});

--- a/spec/fixtures/haremGirl/README.md
+++ b/spec/fixtures/haremGirl/README.md
@@ -1,0 +1,61 @@
+# HaremGirl fixtures
+
+## Source
+
+- Dump: `INPUT/hhauto_dump_www_hentaiheroes_com_tour_2026-05-05T12-11-40-985Z.json`
+- Capture date: 2026-05-05T12:11:40Z
+- Page index: 19 (`/waifu.html`)
+
+## Plan deviation
+
+The strategy plan specified page index 0 (`/home.html`) and the path
+`girls_full.game.shared.Hero` for the harem. The actual dump has the
+harem on page 19 (`/waifu.html`) under the dotted-key path
+`girls_full["game.girls_data_list"]`. Fields are extracted from the
+real path; the plan task notes the substitution.
+
+## Files
+
+### `sample-girls.json`
+
+- Source path: `pages[19].girls_full["game.girls_data_list"]`
+- Selection: 3 girls covering the rarity / max-grade range used by the
+  plan
+  - `id_girl=118565805` (Untamed Levitya, mythic, `nb_grades=6`,
+    `level=750`)
+  - `id_girl=118816` (Fanny & Fione, legendary, `nb_grades=5`,
+    `level=750`)
+  - `id_girl=5` (Princess Agate, common, `nb_grades=5`, `level=750`)
+- Fields kept per girl (whitelist):
+  - Ids / classification: `id_girl`, `id_girl_ref`, `id_member`,
+    `name`, `class`, `figure`, `element`, `rarity`
+  - Progress: `level`, `xp`, `nb_grades`, `graded`, `graded2`,
+    `Graded`, `shards`, `affection`, `awakening_level`, `armor`
+  - Caracs: `carac1`, `carac2`, `carac3`, `caracs`, `caracs_sum`
+  - Salary: `salary`, `salary_per_hour`, `salary_timer`, `pay_in`,
+    `pay_time`, `ts_pay`, `orgasm`
+  - Element / blessing: `element_data`, `blessed_attributes`,
+    `blessing_bonuses`, `can_be_blessed`, `can_be_blessed_pvp4`
+  - Skills / grade offsets: `skill_tiers_info`, `grade_offset_values`,
+    `grade_offsets`
+- Fields dropped (asset URLs and metadata without parser value):
+  `avatar`, `default_avatar`, `black_avatar`, `ico`, `preview`,
+  `images`, `position_img`, `scene_paths`, `grade_skins`,
+  `animated_grades`, `eye_color1/2`, `hair_color1/2`, `style`,
+  `zodiac`, `anniversary`, `release_date`, `date_added`, `id_world`,
+  `id_quest_get`, `id_role`, `id_places_of_power`, `fav_graded`,
+  `upgrade_quests`.
+- Redactions: none. `name` is a character name (game asset), not the
+  player. `id_member` is the same player id already kept in the league
+  fixture.
+
+## How to refresh
+
+If a fresh dump is captured later:
+
+1. Confirm the harem is still on the `/waifu.html` capture (page 19 in
+   the 2026-05-05 dump).
+2. Pick the same `id_girl` values if they are still owned. If a girl
+   has rotated out of the harem, swap to the closest equivalent in the
+   same rarity / max-grade slot and document the substitution here.
+3. Apply the same field whitelist.

--- a/spec/fixtures/haremGirl/sample-girls.json
+++ b/spec/fixtures/haremGirl/sample-girls.json
@@ -1,0 +1,388 @@
+[
+  {
+    "id_girl": 118565805,
+    "id_girl_ref": 111,
+    "id_member": 183406,
+    "name": "Untamed Levitya",
+    "class": 2,
+    "figure": 5,
+    "element": "darkness",
+    "rarity": "mythic",
+    "level": 750,
+    "xp": 1432338,
+    "nb_grades": 6,
+    "graded": 6,
+    "graded2": "<g ></g><g ></g><g ></g><g ></g><g ></g><g ></g>",
+    "Graded": "★★★★★★",
+    "shards": 100,
+    "affection": 437635,
+    "awakening_level": 10,
+    "armor": [],
+    "carac1": 4620,
+    "carac2": 11550,
+    "carac3": 5250,
+    "caracs": {
+      "carac1": 4620,
+      "carac2": 11550,
+      "carac3": 5250
+    },
+    "caracs_sum": 21420,
+    "salary": 40950,
+    "salary_per_hour": 5850,
+    "salary_timer": 420,
+    "pay_in": 8778,
+    "pay_time": 25200,
+    "ts_pay": 1777991756,
+    "orgasm": 599760,
+    "element_data": {
+      "type": "darkness",
+      "weakness": "psychic",
+      "domination": "light",
+      "domination_ego_bonus_percent": 10,
+      "domination_damage_bonus_percent": 10,
+      "domination_critical_chance_bonus_percent": 20,
+      "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+      "flavor": "Dominatrix"
+    },
+    "blessed_attributes": [],
+    "blessing_bonuses": [],
+    "can_be_blessed": false,
+    "can_be_blessed_pvp4": false,
+    "skill_tiers_info": {
+      "1": {
+        "tier": 1,
+        "icon": "cash",
+        "skill_points_used": 0,
+        "icon_path": "/images/pictures/design/girl_skills/cash_icon.png"
+      },
+      "2": {
+        "tier": 2,
+        "icon": "stats_boost",
+        "skill_points_used": 0,
+        "icon_path": "/images/pictures/design/girl_skills/stats_boost_icon.png"
+      },
+      "3": {
+        "tier": 3,
+        "icon": "eye_color",
+        "skill_points_used": 0,
+        "icon_path": "https://hh2.hh-content.com/pictures/design/blessings_icons/eye_colors/eye_color_CCC.png"
+      },
+      "4": {
+        "tier": 4,
+        "icon": "special_passives",
+        "skill_points_used": 0,
+        "icon_path": "/images/pictures/design/girl_skills/special_passives_icon.png"
+      },
+      "5": {
+        "tier": 5,
+        "icon": "active_skills",
+        "skill_points_used": 0,
+        "icon_path": "/images/pictures/design/girl_skills/active_skills_icon.png"
+      }
+    },
+    "grade_offset_values": [
+      [
+        170,
+        260
+      ],
+      [
+        176
+      ],
+      [
+        162
+      ],
+      [
+        216
+      ],
+      [
+        161
+      ],
+      [
+        195
+      ],
+      [
+        1176
+      ]
+    ],
+    "grade_offsets": {
+      "static": [
+        170,
+        176,
+        162,
+        216,
+        161,
+        195,
+        1176
+      ],
+      "animated": [
+        260,
+        176,
+        162,
+        216,
+        161,
+        195,
+        1176
+      ]
+    }
+  },
+  {
+    "id_girl": 118816,
+    "id_girl_ref": 136,
+    "id_member": 183406,
+    "name": "Fanny & Fione",
+    "class": 2,
+    "figure": 6,
+    "element": "light",
+    "rarity": "legendary",
+    "level": 750,
+    "xp": 573227,
+    "nb_grades": 5,
+    "graded": 5,
+    "graded2": "<g ></g><g ></g><g ></g><g ></g><g ></g>",
+    "Graded": "★★★★★",
+    "shards": 100,
+    "affection": 85740,
+    "awakening_level": 10,
+    "armor": [],
+    "carac1": 4850,
+    "carac2": 10150,
+    "carac3": 3912.5,
+    "caracs": {
+      "carac1": 4850,
+      "carac2": 10150,
+      "carac3": 3912.5
+    },
+    "caracs_sum": 18912.5,
+    "salary": 27846,
+    "salary_per_hour": 3978,
+    "salary_timer": 420,
+    "pay_in": 8778,
+    "pay_time": 25200,
+    "ts_pay": 1777991756,
+    "orgasm": 529550,
+    "element_data": {
+      "type": "light",
+      "weakness": "darkness",
+      "domination": "psychic",
+      "domination_ego_bonus_percent": 10,
+      "domination_damage_bonus_percent": 10,
+      "domination_critical_chance_bonus_percent": 20,
+      "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+      "flavor": "Submissive"
+    },
+    "blessed_attributes": [
+      "ego",
+      "damage",
+      "defense",
+      "chance",
+      "speed",
+      "mana_starting",
+      "mana_generation"
+    ],
+    "blessing_bonuses": {
+      "pvp_v4": {
+        "carac1": [
+          20
+        ],
+        "carac2": [
+          20
+        ],
+        "carac3": [
+          20
+        ]
+      }
+    },
+    "can_be_blessed": false,
+    "can_be_blessed_pvp4": true,
+    "skill_tiers_info": {
+      "1": {
+        "tier": 1,
+        "icon": "cash",
+        "skill_points_used": 6,
+        "icon_path": "/images/pictures/design/girl_skills/cash_icon.png"
+      },
+      "2": {
+        "tier": 2,
+        "icon": "stats_boost",
+        "skill_points_used": 9,
+        "icon_path": "/images/pictures/design/girl_skills/stats_boost_icon.png"
+      },
+      "3": {
+        "tier": 3,
+        "icon": "hair_color",
+        "skill_points_used": 4,
+        "icon_path": "https://hh2.hh-content.com/pictures/design/blessings_icons/hair_colors/hair_color_F00.png"
+      },
+      "4": {
+        "tier": 4,
+        "icon": "special_passives",
+        "skill_points_used": 4,
+        "icon_path": "/images/pictures/design/girl_skills/special_passives_icon.png"
+      },
+      "5": {
+        "tier": 5,
+        "icon": "active_skills",
+        "skill_points_used": 0,
+        "icon_path": "/images/pictures/design/girl_skills/active_skills_icon.png"
+      }
+    },
+    "grade_offset_values": [
+      [
+        310
+      ],
+      [
+        292
+      ],
+      [
+        445
+      ],
+      [
+        226
+      ],
+      [
+        1430
+      ],
+      [
+        1403
+      ]
+    ],
+    "grade_offsets": {
+      "static": [
+        310,
+        292,
+        445,
+        226,
+        1430,
+        1403
+      ],
+      "animated": [
+        310,
+        292,
+        445,
+        226,
+        1430,
+        1403
+      ]
+    }
+  },
+  {
+    "id_girl": 5,
+    "id_girl_ref": 5,
+    "id_member": 183406,
+    "name": "Princess Agate",
+    "class": 3,
+    "figure": 10,
+    "element": "water",
+    "rarity": "common",
+    "level": 750,
+    "xp": 358367,
+    "nb_grades": 5,
+    "graded": 5,
+    "graded2": "<g ></g><g ></g><g ></g><g ></g><g ></g>",
+    "Graded": "★★★★★",
+    "shards": 100,
+    "affection": 15533,
+    "awakening_level": 10,
+    "armor": [],
+    "carac1": 4287.5,
+    "carac2": 4287.5,
+    "carac3": 6850,
+    "caracs": {
+      "carac1": 4287.5,
+      "carac2": 4287.5,
+      "carac3": 6850
+    },
+    "caracs_sum": 15425,
+    "salary": 27846,
+    "salary_per_hour": 3978,
+    "salary_timer": 420,
+    "pay_in": 8778,
+    "pay_time": 25200,
+    "ts_pay": 1777991756,
+    "orgasm": 431900,
+    "element_data": {
+      "type": "water",
+      "weakness": "sun",
+      "domination": "fire",
+      "domination_ego_bonus_percent": 10,
+      "domination_damage_bonus_percent": 10,
+      "domination_critical_chance_bonus_percent": 20,
+      "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+      "flavor": "Sensual"
+    },
+    "blessed_attributes": [],
+    "blessing_bonuses": [],
+    "can_be_blessed": false,
+    "can_be_blessed_pvp4": false,
+    "skill_tiers_info": {
+      "1": {
+        "tier": 1,
+        "icon": "cash",
+        "skill_points_used": 6,
+        "icon_path": "/images/pictures/design/girl_skills/cash_icon.png"
+      },
+      "2": {
+        "tier": 2,
+        "icon": "stats_boost",
+        "skill_points_used": 6,
+        "icon_path": "/images/pictures/design/girl_skills/stats_boost_icon.png"
+      },
+      "3": {
+        "tier": 3,
+        "icon": "figure",
+        "skill_points_used": 3,
+        "icon_path": "https://hh2.hh-content.com/pictures/design/blessings_icons/positions/fav_pose_10.png"
+      },
+      "4": {
+        "tier": 4,
+        "icon": "special_passives",
+        "skill_points_used": 3,
+        "icon_path": "/images/pictures/design/girl_skills/special_passives_icon.png"
+      },
+      "5": {
+        "tier": 5,
+        "icon": "active_skills",
+        "skill_points_used": 1,
+        "icon_path": "/images/pictures/design/girl_skills/active_skills_icon.png"
+      }
+    },
+    "grade_offset_values": [
+      [
+        420
+      ],
+      [
+        428
+      ],
+      [
+        437
+      ],
+      [
+        406
+      ],
+      [
+        417
+      ],
+      [
+        401
+      ]
+    ],
+    "grade_offsets": {
+      "static": [
+        420,
+        428,
+        437,
+        406,
+        417,
+        401
+      ],
+      "animated": [
+        420,
+        428,
+        437,
+        406,
+        417,
+        401
+      ]
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Stage 2 task 2.3: adds the third fixture set, a redacted slice of the
harem covering one mythic 6/6, one legendary 5/5, and one common 5/5
girl from the 2026-05-05 dump. The shared loader from PR #1626 is
reused as-is; no production code touched.

## Changes

- `spec/fixtures/haremGirl/sample-girls.json` -- 3 girls
  - Untamed Levitya (mythic, `id_girl=118565805`, `nb_grades=6`)
  - Fanny & Fione (legendary, `id_girl=118816`, `nb_grades=5`)
  - Princess Agate (common, `id_girl=5`, `nb_grades=5`)
  - All owned with `shards=100` and `level=750`.
- `spec/fixtures/haremGirl/README.md` -- audit trail (source path,
  selection, whitelist, dropped fields, refresh procedure).
- `spec/fixtures/haremGirl/Fixtures.spec.ts` -- 6 smoke tests
  covering entry count, rarity slot coverage, numeric ids and progress
  fields, `caracs`, salary fields, and the absence of dropped
  metadata.

## Plan deviation

The strategy plan said page index 0 (`/home.html`) and the path
`girls_full.game.shared.Hero`. The actual dump has the harem on
page index 19 (`/waifu.html`) under the dotted-key path
`girls_full["game.girls_data_list"]`. The plan's
`girls_full.game.shared.Hero` on page 0 contains 28 hero-side records,
not the harem. Field selection follows the real dump shape; the README
documents the substitution.

## Field whitelist

Kept (parser-relevant):

- Ids / classification: `id_girl`, `id_girl_ref`, `id_member`,
  `name`, `class`, `figure`, `element`, `rarity`
- Progress: `level`, `xp`, `nb_grades`, `graded`, `graded2`,
  `Graded`, `shards`, `affection`, `awakening_level`, `armor`
- Caracs: `carac1`, `carac2`, `carac3`, `caracs`, `caracs_sum`
- Salary: `salary`, `salary_per_hour`, `salary_timer`, `pay_in`,
  `pay_time`, `ts_pay`, `orgasm`
- Element / blessing: `element_data`, `blessed_attributes`,
  `blessing_bonuses`, `can_be_blessed`, `can_be_blessed_pvp4`
- Skills / grade offsets: `skill_tiers_info`,
  `grade_offset_values`, `grade_offsets`

Dropped (asset urls, decoration metadata): `avatar`,
`default_avatar`, `black_avatar`, `ico`, `preview`, `images`,
`position_img`, `scene_paths`, `grade_skins`, `animated_grades`,
`eye_color1/2`, `hair_color1/2`, `style`, `zodiac`,
`anniversary`, `release_date`, `date_added`, `id_world`,
`id_quest_get`, `id_role`, `id_places_of_power`, `fav_graded`,
`upgrade_quests`.

PII: none. `name` is a character name (game asset), not the player.
`id_member` is the same player id already present in the league
fixture. No redaction.

## Verification

- `npm test`: 621 passed (615 + 6), 45 suites, 0 skipped.
- `npm run build`: structural diff only (no src changes);
  `HHAuto.user.js` line-ending drift discarded before commit.

## Out of scope

The `parseGirlsFromGameData` parser deferred from stage 1 task 1.3
stays deferred. Per stage 2 rule (test code only) the parser belongs in
stage 3 alongside the parser tests this fixture is sized to feed.