### PR TITLE
test(fixtures): add champion active-champion fixture and smoke tests

### DIFF
--- a/spec/fixtures/champion/Fixtures.spec.ts
+++ b/spec/fixtures/champion/Fixtures.spec.ts
@@ -1,0 +1,117 @@
+import { loadFixture } from "../../testHelpers/Fixtures";
+
+/**
+ * Smoke tests for the champion fixture.
+ *
+ * Confirms that active-champion.json loads and carries the shape
+ * promised by the sibling README. Not a parser test; once a champion
+ * decision module starts consuming the fixture (stage 3), these
+ * checks can be merged into the parser test.
+ */
+describe("champion fixtures", () => {
+    describe("active-champion", () => {
+        it("loads as an object with the expected top-level keys", () => {
+            const fixture = loadFixture("champion", "active-champion") as Record<string, unknown>;
+            expect(typeof fixture).toBe("object");
+            const expectedKeys = [
+                "champion",
+                "timers",
+                "team",
+                "canDraft",
+                "freeDrafts",
+                "priceEnergy",
+                "hero_damage",
+                "reward",
+                "fight",
+            ];
+            for (const k of expectedKeys) {
+                expect(fixture).toHaveProperty(k);
+            }
+        });
+
+        it("has a champion sub-object with numeric ids and tier and a girl whitelist", () => {
+            const f = loadFixture("champion", "active-champion") as {
+                champion: {
+                    id: unknown;
+                    tier: unknown;
+                    level: unknown;
+                    bar: { current: unknown; max: unknown };
+                    girl: { id_girl: unknown; rarity: unknown; nb_grades: unknown };
+                };
+            };
+            expect(typeof f.champion.id).toBe("number");
+            expect(typeof f.champion.tier).toBe("number");
+            expect(typeof f.champion.level).toBe("number");
+            expect(typeof f.champion.bar.current).toBe("number");
+            expect(typeof f.champion.bar.max).toBe("number");
+            expect(typeof f.champion.girl.id_girl).toBe("number");
+            expect(typeof f.champion.girl.rarity).toBe("string");
+            expect(typeof f.champion.girl.nb_grades).toBe("number");
+        });
+
+        it("strips visual asset urls and bubble/scene text from the champion", () => {
+            const f = loadFixture("champion", "active-champion") as { champion: Record<string, unknown> };
+            const dropped = ["image", "portrait", "endSceneImage", "bubbleText", "endSceneText"];
+            for (const k of dropped) {
+                expect(f.champion).not.toHaveProperty(k);
+            }
+        });
+
+        it("carries timers with the three expected fields", () => {
+            const f = loadFixture("champion", "active-champion") as {
+                timers: { championFight: unknown; teamRest: unknown; championRest: unknown };
+            };
+            expect(typeof f.timers.championFight).toBe("number");
+            // teamRest and championRest can legitimately be null (no rest active)
+            expect(["object", "number"]).toContain(typeof f.timers.teamRest);
+            expect(["object", "number"]).toContain(typeof f.timers.championRest);
+        });
+
+        it("has a 10-entry team substituted in (not the circular marker)", () => {
+            const f = loadFixture("champion", "active-champion") as { team: unknown };
+            expect(Array.isArray(f.team)).toBe(true);
+            const team = f.team as Array<{ id_girl: unknown; rarity: unknown; damage: unknown; ico?: unknown }>;
+            expect(team.length).toBe(10);
+            for (const m of team) {
+                expect(["string", "number"]).toContain(typeof m.id_girl);
+                expect(typeof m.rarity).toBe("string");
+                expect(typeof m.damage).toBe("number");
+                expect(m).not.toHaveProperty("ico");
+            }
+        });
+
+        it("redacts every fight participant nickname and drops avatars", () => {
+            const f = loadFixture("champion", "active-champion") as {
+                fight: {
+                    id_fight: unknown;
+                    participants: Array<{ id_member: unknown; nickname: unknown; avatar?: unknown }>;
+                };
+            };
+            expect(typeof f.fight.id_fight).toBe("number");
+            expect(f.fight.participants.length).toBeGreaterThan(0);
+            for (const p of f.fight.participants) {
+                expect(typeof p.id_member).toBe("number");
+                expect(typeof p.nickname).toBe("string");
+                expect(p.nickname as string).toMatch(/^Player_\d+$/);
+                expect(p).not.toHaveProperty("avatar");
+            }
+        });
+
+        it("preserves reward structure with item asset urls stripped", () => {
+            const f = loadFixture("champion", "active-champion") as {
+                reward: {
+                    loot: unknown;
+                    rewards: Array<{ type: unknown; value: { item?: Record<string, unknown> } }>;
+                };
+            };
+            expect(typeof f.reward.loot).toBe("boolean");
+            expect(f.reward.rewards.length).toBeGreaterThan(0);
+            for (const r of f.reward.rewards) {
+                expect(typeof r.type).toBe("string");
+                if (r.value && r.value.item) {
+                    expect(r.value.item).not.toHaveProperty("ico");
+                }
+            }
+        });
+    });
+});

--- a/spec/fixtures/champion/README.md
+++ b/spec/fixtures/champion/README.md
@@ -1,0 +1,80 @@
+# Champion fixtures
+
+## Source
+
+- Dump: `INPUT/hhauto_dump_www_hentaiheroes_com_tour_2026-05-05T12-11-40-985Z.json`
+- Capture date: 2026-05-05T12:08:27Z
+- Page index: 7 (`/club-champion.html`)
+
+## Plan deviation
+
+The strategy plan listed page index 8 (`/champions-map.html`) and two
+files (`champion-map.json`, `active-champion.json`). Reality from the
+dump:
+
+- Page 8 (`/champions-map.html`) carries no champion data. The map is
+  rendered client-side from DOM only; the dump's
+  `dom_data_attributes` payload for that page is the page chrome,
+  not parser-relevant.
+- Page 7 (`/club-champion.html`) carries the active-champion data
+  under `battle.championData`, plus the champion's team under
+  `girls_full["game.championData.team"]` (the inspector serialises
+  the team there to break the circular reference that would otherwise
+  appear at `battle.championData.team`).
+
+Stage 2 ships only `active-champion.json` (one file, page 7).
+A `champion-map.json` is intentionally not produced -- there is
+nothing in the dump to extract for it. The map decision logic
+(`Champion.pure.ts decideNextChampionTime` from stage 1 task 1.2)
+operates on a DOM-derived list and would need an HTML fixture, which
+the strategy plan blocks ("snapshot tests for HTML"). Champion-map
+fixtures are therefore deferred until a different testing approach
+for DOM-derived state is in scope.
+
+## Files
+
+### `active-champion.json`
+
+- Source paths:
+  - `pages[7].battle.championData` (everything except `team`)
+  - `pages[7].girls_full["game.championData.team"]` (substituted in
+    for the circular `team` field)
+- Contents:
+  - `champion` -- id, name, lairName, tier, poses, class, bar
+    `{current,max}`, currentTickets, maxMultipleBattles,
+    battlePriceIncrease, level, plus `girl` reduced to a parser
+    whitelist (id_girl, id_girl_ref, name, class, figure, element,
+    rarity, level, nb_grades, carac1..3).
+  - `timers` -- `championFight`, `teamRest`, `championRest`.
+  - `team` -- 10 entries from the separate dump path; each entry
+    keeps `id_girl`, `class`, `figure`, `rarity`, `damage`.
+  - `canDraft`, `freeDrafts`, `priceEnergy`, `hero_damage` -- as-is.
+  - `reward` -- `loot` flag and the four `rewards` entries; each
+    `value.item` keeps the parser-relevant fields, the `ico` asset
+    url is dropped.
+  - `fight` -- `id_fight`, `start_time`, `active`, plus 19
+    `participants`. Per participant: `id_member`, `level`,
+    `challenge_impression_done`, `challenge_count`. `nickname`
+    is replaced with `Player_<n>`, `avatar` is dropped.
+- Asset urls dropped (champion-level): `image`, `portrait`,
+  `endSceneImage`, `bubbleText`, `endSceneText` (the last two are
+  flavour text that frequently echoes player-facing localisation
+  drift; not parser-relevant).
+- Asset urls dropped (item / team / participant level): `item.ico`,
+  `team[].ico`, `participants[].avatar`.
+- PII redactions: `participants[].nickname` -> `Player_1..19`.
+  `champion.lairName` is preserved (it identifies the in-game club's
+  champion lair, which is semi-public information visible to anyone
+  fighting the champion; redacting it would change the parser shape).
+
+## How to refresh
+
+If a fresh dump is captured later:
+
+1. Confirm the active champion is on page 7 (`/club-champion.html`).
+2. Re-run the extraction with the same field whitelists. If the
+   shape drifts (e.g. new keys added to `championData`), document
+   the choice here.
+3. Re-redact `participants[].nickname` and drop new asset URLs.
+4. Run the PII / asset-url scan in the extraction script before
+   committing.

--- a/spec/fixtures/champion/active-champion.json
+++ b/spec/fixtures/champion/active-champion.json
@@ -1,0 +1,372 @@
+{
+  "champion": {
+    "id": 2,
+    "name": "Chad",
+    "lairName": "Gentlemen Club (GER)'s Boat",
+    "tier": 18,
+    "poses": [
+      4,
+      3,
+      4,
+      3,
+      4
+    ],
+    "class": 1,
+    "bar": {
+      "current": 526164328,
+      "max": 720000000
+    },
+    "currentTickets": 6811,
+    "maxMultipleBattles": 28,
+    "battlePriceIncrease": 6,
+    "level": 300,
+    "girl": {
+      "id_girl": 960719275,
+      "id_girl_ref": 410,
+      "name": "Kumiko",
+      "class": 1,
+      "figure": 3,
+      "element": "nature",
+      "rarity": "legendary",
+      "level": 750,
+      "nb_grades": 5,
+      "carac1": 9937.5,
+      "carac2": 2812.5,
+      "carac3": 5625
+    }
+  },
+  "timers": {
+    "championFight": 2328698,
+    "teamRest": null,
+    "championRest": null
+  },
+  "team": [
+    {
+      "id_girl": "270574600",
+      "class": 1,
+      "figure": 4,
+      "rarity": "mythic",
+      "damage": 57834
+    },
+    {
+      "id_girl": "793414851",
+      "class": 1,
+      "figure": 3,
+      "rarity": "mythic",
+      "damage": 58905
+    },
+    {
+      "id_girl": "712589405",
+      "class": 1,
+      "figure": 4,
+      "rarity": "mythic",
+      "damage": 61851
+    },
+    {
+      "id_girl": "960719275",
+      "class": 1,
+      "figure": 3,
+      "rarity": "legendary",
+      "damage": 50682
+    },
+    {
+      "id_girl": "608480884",
+      "class": 1,
+      "figure": 4,
+      "rarity": "legendary",
+      "damage": 54698
+    },
+    {
+      "id_girl": "169671372",
+      "class": 1,
+      "figure": 4,
+      "rarity": "legendary",
+      "damage": 39972
+    },
+    {
+      "id_girl": "696124016",
+      "class": 2,
+      "figure": 6,
+      "rarity": "rare",
+      "damage": 44
+    },
+    {
+      "id_girl": "288304117",
+      "class": 1,
+      "figure": 4,
+      "rarity": "legendary",
+      "damage": 23676
+    },
+    {
+      "id_girl": "976276200",
+      "class": 1,
+      "figure": 2,
+      "rarity": "legendary",
+      "damage": 31428
+    },
+    {
+      "id_girl": "330911919",
+      "class": 2,
+      "figure": 8,
+      "rarity": "mythic",
+      "damage": 58905
+    }
+  ],
+  "canDraft": true,
+  "freeDrafts": 91,
+  "priceEnergy": 60,
+  "hero_damage": 55108,
+  "reward": {
+    "loot": true,
+    "rewards": [
+      {
+        "type": "item",
+        "value": {
+          "item": {
+            "id_item": 181,
+            "type": "gift",
+            "identifier": "K1",
+            "rarity": "legendary",
+            "price": 291900,
+            "currency": "sc",
+            "value": 700,
+            "carac1": 0,
+            "carac2": 0,
+            "carac3": 0,
+            "endurance": 0,
+            "chance": "0.00",
+            "ego": 0,
+            "damage": 0,
+            "duration": 0,
+            "skin": "hentai,gay,sexy",
+            "name": "Flowers",
+            "display_price": 291900,
+            "default_market_price": 29190
+          },
+          "quantity": 1
+        }
+      },
+      {
+        "type": "item",
+        "value": {
+          "item": {
+            "id_item": 182,
+            "type": "gift",
+            "identifier": "K2",
+            "rarity": "legendary",
+            "price": 396150,
+            "currency": "sc",
+            "value": 950,
+            "carac1": 0,
+            "carac2": 0,
+            "carac3": 0,
+            "endurance": 0,
+            "chance": "0.00",
+            "ego": 0,
+            "damage": 0,
+            "duration": 0,
+            "skin": "hentai,gay,sexy",
+            "name": "Chocolates",
+            "display_price": 396150,
+            "default_market_price": 39615
+          },
+          "quantity": 1
+        }
+      },
+      {
+        "type": "item",
+        "value": {
+          "item": {
+            "id_item": 183,
+            "type": "gift",
+            "identifier": "K3",
+            "rarity": "legendary",
+            "price": 500400,
+            "currency": "sc",
+            "value": 1200,
+            "carac1": 0,
+            "carac2": 0,
+            "carac3": 0,
+            "endurance": 0,
+            "chance": "0.00",
+            "ego": 0,
+            "damage": 0,
+            "duration": 0,
+            "skin": "hentai,gay,sexy",
+            "name": "Bracelet",
+            "display_price": 500400,
+            "default_market_price": 50040
+          },
+          "quantity": 1
+        }
+      },
+      {
+        "type": "item",
+        "value": {
+          "item": {
+            "id_item": 184,
+            "type": "gift",
+            "identifier": "K4",
+            "rarity": "legendary",
+            "price": 625500,
+            "currency": "sc",
+            "value": 1500,
+            "carac1": 0,
+            "carac2": 0,
+            "carac3": 0,
+            "endurance": 0,
+            "chance": "0.00",
+            "ego": 0,
+            "damage": 0,
+            "duration": 0,
+            "skin": "hentai,gay,sexy",
+            "name": "Lingerie",
+            "display_price": 625500,
+            "default_market_price": 62550
+          },
+          "quantity": 1
+        }
+      }
+    ]
+  },
+  "fight": {
+    "id_fight": 1005817,
+    "start_time": 1777672717,
+    "active": true,
+    "participants": [
+      {
+        "id_member": 7944077,
+        "nickname": "Player_1",
+        "level": 530,
+        "challenge_impression_done": 115991364,
+        "challenge_count": 63
+      },
+      {
+        "id_member": 183406,
+        "nickname": "Player_2",
+        "level": 644,
+        "challenge_impression_done": 99948662,
+        "challenge_count": 50
+      },
+      {
+        "id_member": 3781464,
+        "nickname": "Player_3",
+        "level": 675,
+        "challenge_impression_done": 57299975,
+        "challenge_count": 36
+      },
+      {
+        "id_member": 3276247,
+        "nickname": "Player_4",
+        "level": 690,
+        "challenge_impression_done": 32617636,
+        "challenge_count": 16
+      },
+      {
+        "id_member": 84849,
+        "nickname": "Player_5",
+        "level": 753,
+        "challenge_impression_done": 29803263,
+        "challenge_count": 15
+      },
+      {
+        "id_member": 4473853,
+        "nickname": "Player_6",
+        "level": 684,
+        "challenge_impression_done": 29405086,
+        "challenge_count": 17
+      },
+      {
+        "id_member": 6395740,
+        "nickname": "Player_7",
+        "level": 577,
+        "challenge_impression_done": 26373303,
+        "challenge_count": 25
+      },
+      {
+        "id_member": 366883,
+        "nickname": "Player_8",
+        "level": 716,
+        "challenge_impression_done": 20411548,
+        "challenge_count": 24
+      },
+      {
+        "id_member": 3001732,
+        "nickname": "Player_9",
+        "level": 775,
+        "challenge_impression_done": 20234784,
+        "challenge_count": 24
+      },
+      {
+        "id_member": 7248461,
+        "nickname": "Player_10",
+        "level": 589,
+        "challenge_impression_done": 19611751,
+        "challenge_count": 20
+      },
+      {
+        "id_member": 1576342,
+        "nickname": "Player_11",
+        "level": 668,
+        "challenge_impression_done": 18014247,
+        "challenge_count": 31
+      },
+      {
+        "id_member": 299787,
+        "nickname": "Player_12",
+        "level": 729,
+        "challenge_impression_done": 12456035,
+        "challenge_count": 17
+      },
+      {
+        "id_member": 7055324,
+        "nickname": "Player_13",
+        "level": 577,
+        "challenge_impression_done": 10973906,
+        "challenge_count": 6
+      },
+      {
+        "id_member": 3570450,
+        "nickname": "Player_14",
+        "level": 597,
+        "challenge_impression_done": 8064736,
+        "challenge_count": 13
+      },
+      {
+        "id_member": 7197719,
+        "nickname": "Player_15",
+        "level": 552,
+        "challenge_impression_done": 7703734,
+        "challenge_count": 24
+      },
+      {
+        "id_member": 410196,
+        "nickname": "Player_16",
+        "level": 617,
+        "challenge_impression_done": 6596020,
+        "challenge_count": 10
+      },
+      {
+        "id_member": 300281,
+        "nickname": "Player_17",
+        "level": 693,
+        "challenge_impression_done": 5376428,
+        "challenge_count": 14
+      },
+      {
+        "id_member": 777618,
+        "nickname": "Player_18",
+        "level": 556,
+        "challenge_impression_done": 3169494,
+        "challenge_count": 6
+      },
+      {
+        "id_member": 8400061,
+        "nickname": "Player_19",
+        "level": 673,
+        "challenge_impression_done": 2112356,
+        "challenge_count": 4
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Stage 2 task 2.4: adds the active club champion fixture sliced from
page index 7 (`/club-champion.html`) of the 2026-05-05 dump. The
shared loader from PR #1626 is reused as-is; no production code
touched.

## Changes

- `spec/fixtures/champion/active-champion.json` -- `battle.championData`
  in full (champion with girl whitelist, timers, `canDraft`,
  `freeDrafts`, `priceEnergy`, `hero_damage`, reward, fight) plus
  the 10-member team substituted in from
  `girls_full["game.championData.team"]` to break the inspector's
  circular marker. Asset URLs stripped at every level (champion
  `image`/`portrait`/scenes, `item.ico`, `team[].ico`,
  `participants[].avatar`). Participant nicknames redacted to
  `Player_1..19`.
- `spec/fixtures/champion/README.md` -- audit trail.
- `spec/fixtures/champion/Fixtures.spec.ts` -- 7 smoke tests covering
  top-level keys, champion sub-object types, dropped asset URLs and
  bubble/scene text, timers shape (`championRest` / `teamRest`
  legitimately nullable), team length and shape, redacted participant
  nicknames without avatars, and reward structure with `item.ico`
  stripped.

## Plan deviation

The strategy plan listed page index 8 (`/champions-map.html`) and
two files (`champion-map.json`, `active-champion.json`).

- Page 8 carries no champion data. The map is rendered client-side
  from DOM only; the dump's `dom_data_attributes` payload for that
  page is page chrome, not parser-relevant.
- Page 7 carries the active champion (`battle.championData`) plus
  the team side-channel that breaks the circular reference.

`champion-map.json` is intentionally not produced. The
`Champion.pure.ts decideNextChampionTime` function from stage 1
task 1.2 operates on DOM-derived state; an HTML fixture is what it
would consume, and the strategy plan blocks "snapshot tests for HTML".
Map fixtures stay deferred until a different testing approach for
DOM-derived state is in scope. Task 2.4 therefore ships one file, not
two.

## Verification

- `npm test`: 628 passed (621 + 7), 46 suites, 0 skipped.
- `npm run build`: structural diff only (no src changes);
  `HHAuto.user.js` line-ending drift discarded before commit.
- PII / asset-URL scan in the extraction script: clean.

## Out of scope

- Champion-map fixture (see plan deviation above).
- `parseGirlsFromGameData` deferred from stage 1 task 1.3 stays
  deferred to stage 3 alongside the parser tests the haremGirl /
  champion fixtures are sized to feed.