### PR TITLE
test(fixtures): add event event-detection fixture and smoke tests

### DIFF
--- a/spec/fixtures/event/Fixtures.spec.ts
+++ b/spec/fixtures/event/Fixtures.spec.ts
@@ -1,0 +1,89 @@
+import { loadFixture } from "../../testHelpers/Fixtures";
+
+/**
+ * Smoke tests for the event-detection fixture.
+ *
+ * Confirms that event-detection.json loads and carries the shape
+ * promised by the sibling README. Not a parser test; once an event
+ * detection module starts consuming the fixture (stage 3), these
+ * checks can be merged into the parser test.
+ */
+describe("event fixtures", () => {
+    describe("event-detection", () => {
+        it("loads as a compound object with event_data and mega_event", () => {
+            const fixture = loadFixture("event", "event-detection") as Record<string, unknown>;
+            expect(typeof fixture).toBe("object");
+            expect(fixture).toHaveProperty("event_data");
+            expect(fixture).toHaveProperty("mega_event");
+        });
+
+        it("event_data carries identity, timers, and the participation gate", () => {
+            const f = loadFixture("event", "event-detection") as {
+                event_data: {
+                    event_name: unknown;
+                    type: unknown;
+                    identifier: unknown;
+                    seconds_until_event_end: unknown;
+                    event_duration_seconds: unknown;
+                    can_participate: unknown;
+                    participation_info: unknown;
+                    progression_href: unknown;
+                };
+            };
+            expect(typeof f.event_data.event_name).toBe("string");
+            expect(typeof f.event_data.type).toBe("string");
+            expect(typeof f.event_data.identifier).toBe("string");
+            expect(typeof f.event_data.seconds_until_event_end).toBe("number");
+            expect(typeof f.event_data.event_duration_seconds).toBe("number");
+            expect(typeof f.event_data.can_participate).toBe("boolean");
+            expect(typeof f.event_data.participation_info).toBe("string");
+            expect(typeof f.event_data.progression_href).toBe("string");
+        });
+
+        it("event_data.girls is substituted in (not the circular marker) and uses the whitelist", () => {
+            const f = loadFixture("event", "event-detection") as {
+                event_data: { girls: unknown };
+            };
+            expect(Array.isArray(f.event_data.girls)).toBe(true);
+            const girls = f.event_data.girls as Array<Record<string, unknown>>;
+            expect(girls.length).toBeGreaterThan(0);
+            for (const g of girls) {
+                expect(typeof g.id_girl).toBe("number");
+                expect(typeof g.rarity).toBe("string");
+                expect(typeof g.nb_grades).toBe("number");
+                expect(g).toHaveProperty("source");
+                expect(g).toHaveProperty("source_list");
+            }
+        });
+
+        it("strips asset urls and decoration metadata from the event girl", () => {
+            const f = loadFixture("event", "event-detection") as {
+                event_data: { girls: Array<Record<string, unknown>> };
+            };
+            const dropped = [
+                "avatar",
+                "default_avatar",
+                "black_avatar",
+                "ico",
+                "preview",
+                "images",
+                "scene_paths",
+                "release_date",
+                "date_added",
+            ];
+            for (const g of f.event_data.girls) {
+                for (const k of dropped) {
+                    expect(g).not.toHaveProperty(k);
+                }
+            }
+        });
+
+        it("mega_event carries the active flag and the time-remaining counter", () => {
+            const f = loadFixture("event", "event-detection") as {
+                mega_event: { active: unknown; time_remaining: unknown };
+            };
+            expect(typeof f.mega_event.active).toBe("boolean");
+            expect(typeof f.mega_event.time_remaining).toBe("number");
+        });
+    });
+});

--- a/spec/fixtures/event/README.md
+++ b/spec/fixtures/event/README.md
@@ -1,0 +1,95 @@
+# Event fixtures
+
+## Source
+
+- Dump: `INPUT/hhauto_dump_www_hentaiheroes_com_tour_2026-05-05T12-11-40-985Z.json`
+- Capture date: 2026-05-05T12:09:05Z
+- Page index: 13 (`/event.html`)
+
+## Files
+
+### `event-detection.json`
+
+Compound fixture combining the event header and the mega-event flag,
+both consumed by event detection logic.
+
+#### Top-level structure
+
+```json
+{
+  "event_data": { ... event header from battle.event_data ... },
+  "mega_event": { "active": true, "time_remaining": 2242260 }
+}
+```
+
+#### `event_data`
+
+- Source path: `pages[13].battle.event_data`
+- `pages[13].battle.current_event` is an exact duplicate in the dump;
+  only one of the two is fixtured. Keys:
+  - `event_name`, `type`, `identifier` -- event identity
+  - `seconds_until_event_end`, `event_duration_seconds` -- timers
+  - `can_participate`, `participation_info` -- participation gate
+  - `progression_href` -- link target
+  - `girls` -- substituted in from
+    `pages[13].girls_full["game.event_girls"]` (the inspector
+    serialises that there to break the circular reference at
+    `battle.event_data.girls`).
+  - `event_data` -- empty list in this dump (event-type specific
+    sub-payload, populated for some event types).
+- Capture detail: the dump's event is `Cumback Contests`
+  (`identifier=cumback_contest_188`).
+
+#### `mega_event`
+
+- Source paths:
+  - `pages[13].battle.mega_event_active` -> `mega_event.active`
+  - `pages[13].battle.mega_event_time_remaining` -> `mega_event.time_remaining`
+- Captured snapshot has the mega event active.
+
+#### Girl whitelist
+
+Each entry under `event_data.girls` is reduced to the haremGirl
+whitelist plus event-specific extensions:
+
+- Ids / classification: `id_girl`, `id_girl_ref`, `id_member`, `name`,
+  `class`, `figure`, `element`, `rarity`
+- Progress: `level`, `xp`, `nb_grades`, `graded`, `graded2`, `Graded`,
+  `shards`, `affection`, `awakening_level`, `armor`
+- Caracs: `carac1`, `carac2`, `carac3`, `caracs`, `caracs_sum`
+- Salary: `salary`, `salary_per_hour`, `salary_timer`, `pay_in`,
+  `pay_time`, `ts_pay`, `orgasm`
+- Element / blessing: `element_data`, `blessed_attributes`,
+  `blessing_bonuses`, `can_be_blessed`, `can_be_blessed_pvp4`
+- Skills / grade offsets: `skill_tiers_info`, `grade_offset_values`,
+  `grade_offsets`
+- Event-specific: `source`, `source_list`, `own`, `role_data`
+
+Fields not present on a given girl entry are simply absent (e.g. the
+single event girl in this capture has no `salary_timer` or
+`skill_tiers_info`, both legitimately missing).
+
+Fields dropped (asset URLs, decoration metadata): `avatar`,
+`default_avatar`, `black_avatar`, `ico`, `preview`, `images`,
+`position_img`, `scene_paths`, `grade_skins`, `animated_grades`,
+`eye_color1/2`, `hair_color1/2`, `style`, `zodiac`, `anniversary`,
+`release_date`, `date_added`, `id_world`, `id_quest_get`, `id_role`,
+`id_places_of_power`, `fav_graded`, `upgrade_quests`.
+
+PII: none. `name` is a character name (game asset), not the player.
+`id_member` is the same player id already present in the league /
+champion / haremGirl fixtures. `participation_info` is a server-side
+hint string with no personal data. No redaction.
+
+## How to refresh
+
+If a fresh dump is captured later:
+
+1. Confirm the event is on `/event.html` (page 13 in the 2026-05-05
+   capture).
+2. Re-run the extraction with the same field whitelist. The captured
+   event in this dump is `cumback_contest_188`; a different event type
+   may populate `event_data.event_data` with type-specific data --
+   keep it as captured and document the change here.
+3. Re-run the PII / asset-url scan in the extraction script before
+   committing.

--- a/spec/fixtures/event/event-detection.json
+++ b/spec/fixtures/event/event-detection.json
@@ -1,0 +1,259 @@
+{
+  "event_data": {
+    "event_name": "Cumback Contests",
+    "type": "cumback_contest",
+    "seconds_until_event_end": 168660,
+    "event_duration_seconds": 257400,
+    "identifier": "cumback_contest_188",
+    "can_participate": true,
+    "participation_info": "You are currently unable to participate in the event.\nYou need to be level 20 and start World 2 in order to participate.",
+    "progression_href": "/quest/1828",
+    "girls": [
+      {
+        "id_girl": 917446702,
+        "id_girl_ref": 118,
+        "id_member": 183406,
+        "name": "Rock Venam",
+        "class": 1,
+        "figure": 2,
+        "element": "sun",
+        "rarity": "legendary",
+        "level": 1,
+        "xp": 0,
+        "nb_grades": 3,
+        "graded": 1,
+        "graded2": "<g ></g><g class=\"grey\"></g><g class=\"grey\"></g>",
+        "Graded": "★☆☆",
+        "shards": 100,
+        "affection": 6300,
+        "awakening_level": 0,
+        "armor": [],
+        "carac1": 9.3,
+        "carac2": 3.21,
+        "carac3": 4.39,
+        "caracs": {
+          "carac1": 9.3,
+          "carac2": 3.21,
+          "carac3": 4.39
+        },
+        "caracs_sum": 16.900000000000002,
+        "salary": 1580,
+        "salary_per_hour": 1053.33,
+        "salary_timer": 90,
+        "pay_in": 0,
+        "pay_time": 5400,
+        "ts_pay": 1777969047,
+        "orgasm": 473,
+        "element_data": {
+          "type": "sun",
+          "weakness": "stone",
+          "domination": "water",
+          "domination_ego_bonus_percent": 10,
+          "domination_damage_bonus_percent": 10,
+          "domination_critical_chance_bonus_percent": 20,
+          "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+          "flavor": "Playful"
+        },
+        "blessed_attributes": [
+          "carac1",
+          "carac2",
+          "carac3",
+          "ego",
+          "damage",
+          "defense",
+          "chance",
+          "speed",
+          "mana_starting",
+          "mana_generation"
+        ],
+        "blessing_bonuses": {
+          "pvp_v3": {
+            "carac1": [
+              30
+            ],
+            "carac2": [
+              30
+            ],
+            "carac3": [
+              30
+            ]
+          },
+          "pvp_v4": {
+            "carac1": [
+              30
+            ],
+            "carac2": [
+              30
+            ],
+            "carac3": [
+              30
+            ]
+          }
+        },
+        "can_be_blessed": true,
+        "can_be_blessed_pvp4": true,
+        "grade_offset_values": [
+          [
+            330,
+            333
+          ],
+          [
+            328
+          ],
+          [
+            291
+          ],
+          [
+            1252
+          ]
+        ],
+        "grade_offsets": {
+          "static": [
+            330,
+            328,
+            291,
+            1252
+          ],
+          "animated": [
+            333,
+            328,
+            291,
+            1252
+          ]
+        },
+        "source": {
+          "name": "harem",
+          "group": {
+            "name": "harem",
+            "id": null
+          },
+          "ongoing": true,
+          "sentence": "I'm already attracted to you. Find me in your Harem!",
+          "anchor_source": {
+            "url": "/characters/917446702",
+            "label": "Go to Harem",
+            "disabled": false
+          },
+          "anchor_win_from": [
+            {
+              "url": "/characters/917446702",
+              "label": "Go to Harem",
+              "disabled": false
+            }
+          ],
+          "playable": true
+        },
+        "source_list": {
+          "harem": [
+            {
+              "name": "harem",
+              "group": {
+                "name": "harem",
+                "id": null
+              },
+              "ongoing": true,
+              "sentence": "I'm already attracted to you. Find me in your Harem!",
+              "anchor_source": {
+                "url": "/characters/917446702",
+                "label": "Go to Harem",
+                "disabled": false
+              },
+              "anchor_win_from": [
+                {
+                  "url": "/characters/917446702",
+                  "label": "Go to Harem",
+                  "disabled": false
+                }
+              ],
+              "playable": true
+            }
+          ],
+          "cumback_contest": [
+            {
+              "name": "cumback_contest",
+              "group": {
+                "name": "cumback_contest",
+                "id": 188
+              },
+              "ongoing": true,
+              "sentence": "Get me in <i>Cumback Contests</i>",
+              "anchor_source": {
+                "url": "/activities.html?tab=contests",
+                "label": "Go to Contests",
+                "disabled": false
+              },
+              "anchor_win_from": [
+                {
+                  "url": "/activities.html?tab=contests",
+                  "label": "Go to Contests",
+                  "disabled": false
+                }
+              ],
+              "playable": true
+            }
+          ],
+          "crazy_cumback_contest": [
+            {
+              "name": "crazy_cumback_contest",
+              "group": {
+                "name": "crazy_cumback_contest",
+                "id": 8
+              },
+              "ongoing": false,
+              "sentence": "I was available in <i>Crazy Cumback Contest</i>, I’ll be back later!",
+              "anchor_source": {
+                "url": "/activities.html?tab=contests",
+                "label": "Go to Contests",
+                "disabled": false
+              },
+              "anchor_win_from": [
+                {
+                  "url": "/activities.html?tab=contests",
+                  "label": "Go to Contests",
+                  "disabled": false
+                }
+              ],
+              "playable": true
+            }
+          ],
+          "season_tier": [
+            {
+              "name": "season_tier",
+              "group": {
+                "name": "season_tier",
+                "id": 21001
+              },
+              "ongoing": false,
+              "sentence": "I was available in <i>Festival Flirting</i>, I’ll be back later!",
+              "anchor_source": {
+                "url": "/season.html",
+                "label": "Go to Season",
+                "disabled": false
+              },
+              "anchor_win_from": [
+                {
+                  "url": "/season.html",
+                  "label": "Go to Season",
+                  "disabled": false
+                }
+              ],
+              "playable": true
+            }
+          ]
+        },
+        "own": true,
+        "role_data": {
+          "id": 9,
+          "name": "Pleasurelock",
+          "flavour": "Pleasurelock",
+          "description": "When Crit - adds half of the damage dealt by the opponent in the previous attack to her own damage. "
+        }
+      }
+    ],
+    "event_data": []
+  },
+  "mega_event": {
+    "active": true,
+    "time_remaining": 2242260
+  }
+}


### PR DESCRIPTION
## Summary

Stage 2 task 2.5: adds the event-detection fixture, a compound slice
combining the event header and the mega-event flag from page index
13 (`/event.html`) of the 2026-05-05 dump. The shared loader from
PR #1626 is reused as-is; no production code touched.

## Changes

- `spec/fixtures/event/event-detection.json` -- compound:
  `{ event_data, mega_event }`
  - `event_data`: header from `battle.event_data` (`event_name`,
    `type`, `identifier`, timers, `can_participate`,
    `participation_info`, `progression_href`). The `girls` field
    is substituted in from `girls_full["game.event_girls"]` to break
    the inspector's circular marker. Each girl is reduced to the
    haremGirl whitelist plus event-specific extensions (`source`,
    `source_list`, `own`, `role_data`); avatar urls and
    decoration metadata dropped.
  - `mega_event`: `{ active, time_remaining }` from
    `battle.mega_event_active` / `battle.mega_event_time_remaining`.
    Captured snapshot has the mega event active.
- `spec/fixtures/event/README.md` -- audit trail (sources,
  whitelist, dropped fields, refresh procedure with PII / asset-url
  scan).
- `spec/fixtures/event/Fixtures.spec.ts` -- 5 smoke tests covering
  top-level shape, event_data identity / timers / participation gate
  types, the substituted girls list with the whitelist applied,
  dropped asset urls / decoration metadata, and the mega_event shape.

## Plan note

The strategy plan listed one file (`event-detection.json`) without
further specification. The compound shape combines the two sources of
event detection that real consumers use together (event header and
mega-event flag); both are sourced from the same page.
`battle.event_data` and `battle.current_event` are exact
duplicates in this dump; only one is fixtured.

## Verification

- `npm test`: 633 passed (628 + 5), 47 suites, 0 skipped.
- `npm run build`: structural diff only (no src changes);
  `HHAuto.user.js` line-ending drift discarded before commit.
- PII / asset-URL scan in the extraction script: clean.

## Out of scope

- Stage 2 task 2.7 (Stage 2 closure, chore/test-strategy-stage2-close)
  follows in its own PR after this one merges.
- `parseGirlsFromGameData` deferred from stage 1 task 1.3 stays
  deferred to stage 3 alongside the parser tests these fixtures are
  sized to feed.