### PR TITLE
refactor(test): extract pure decision logic from ClubChampion

### DIFF
--- a/spec/Module/ClubChampion.pure.spec.ts
+++ b/spec/Module/ClubChampion.pure.spec.ts
@@ -1,0 +1,218 @@
+import {
+    AlignClubChampionTimerState,
+    NextClubChampionTimerState,
+    decideAlignedClubChampionTimer,
+    decideNextClubChampionTime,
+} from "../../src/Module/ClubChampion.pure";
+
+/**
+ * Pure-function tests for the club-champion timer decisions.
+ *
+ * decideNextClubChampionTime returns a deterministic [min, max] window
+ * that the impure adapter in updateClubChampionTimer feeds into
+ * randomInterval. decideAlignedClubChampionTimer returns the (possibly
+ * aligned) seconds value the adapter then hands to setTimer.
+ *
+ * Threshold contracts preserved from the original code:
+ *   secsToNextTimer === -1   -> no-timer window
+ *   secsToNextTimer >  7200  AND autoClubForceStart -> force-start window
+ *   else                                            -> normal window
+ *
+ * Alignment branch:
+ *   autoChamps AND autoChampAlignTimer
+ *     AND proposedTime > 10
+ *     AND champTimeLeft < 1200
+ *     AND proposedTime < 1200
+ *   -> max(proposedTime, champTimeLeft); else proposedTime untouched.
+ *
+ * All threshold comparisons are strict on purpose; the equality cases
+ * below assert that.
+ */
+describe("decideNextClubChampionTime", () => {
+    const buildState = (
+        overrides: Partial<NextClubChampionTimerState> = {},
+    ): NextClubChampionTimerState => ({
+        secsToNextTimer: -1,
+        autoClubForceStart: false,
+        ...overrides,
+    });
+
+    it("returns the no-timer window when no timer was scraped", () => {
+        expect(decideNextClubChampionTime(buildState({ secsToNextTimer: -1 }))).toEqual({
+            minTime: 15 * 60,
+            maxTime: 17 * 60,
+            reason: "no-timer",
+        });
+    });
+
+    it("returns the normal window for short timers regardless of force-start", () => {
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 600, autoClubForceStart: false }),
+            ),
+        ).toEqual({ minTime: 600, maxTime: 780, reason: "normal" });
+
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 600, autoClubForceStart: true }),
+            ),
+        ).toEqual({ minTime: 600, maxTime: 780, reason: "normal" });
+    });
+
+    it("treats secsToNextTimer = 7200 as below the force-start threshold (strict >)", () => {
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 7200, autoClubForceStart: true }),
+            ),
+        ).toEqual({ minTime: 7200, maxTime: 7380, reason: "normal" });
+    });
+
+    it("returns the force-start window for secsToNextTimer = 7201 with autoClubForceStart on", () => {
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 7201, autoClubForceStart: true }),
+            ),
+        ).toEqual({ minTime: 115 * 60, maxTime: 125 * 60, reason: "force-start" });
+    });
+
+    it("ignores autoClubForceStart and falls back to the normal window when force-start is off", () => {
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 8000, autoClubForceStart: false }),
+            ),
+        ).toEqual({ minTime: 8000, maxTime: 8180, reason: "normal" });
+    });
+
+    it("returns the normal window for a zero timer (immediate retry slot)", () => {
+        expect(
+            decideNextClubChampionTime(
+                buildState({ secsToNextTimer: 0, autoClubForceStart: false }),
+            ),
+        ).toEqual({ minTime: 0, maxTime: 180, reason: "normal" });
+    });
+});
+
+describe("decideAlignedClubChampionTimer", () => {
+    const buildState = (
+        overrides: Partial<AlignClubChampionTimerState> = {},
+    ): AlignClubChampionTimerState => ({
+        proposedTime: 0,
+        champTimeLeft: 0,
+        autoChamps: false,
+        autoChampAlignTimer: false,
+        ...overrides,
+    });
+
+    it("passes the proposed time through when both settings are off", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({ proposedTime: 123, champTimeLeft: 456 }),
+            ),
+        ).toBe(123);
+    });
+
+    it("passes through when only autoChamps is on", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 123,
+                    champTimeLeft: 456,
+                    autoChamps: true,
+                    autoChampAlignTimer: false,
+                }),
+            ),
+        ).toBe(123);
+    });
+
+    it("passes through when only autoChampAlignTimer is on", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 123,
+                    champTimeLeft: 456,
+                    autoChamps: false,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(123);
+    });
+
+    it("aligns to champTimeLeft when both settings are on and the window matches", () => {
+        // proposedTime 123 < 1200, champTimeLeft 456 < 1200, proposedTime > 10
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 123,
+                    champTimeLeft: 456,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(456);
+    });
+
+    it("returns proposedTime when it is already greater than champTimeLeft", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 800,
+                    champTimeLeft: 200,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(800);
+    });
+
+    it("does not align when proposedTime equals 10 (strict > on lower bound)", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 10,
+                    champTimeLeft: 456,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(10);
+    });
+
+    it("does not align when proposedTime equals 1200 (strict < on upper bound)", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 1200,
+                    champTimeLeft: 456,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(1200);
+    });
+
+    it("does not align when champTimeLeft equals 1200 (strict < on champ bound)", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 123,
+                    champTimeLeft: 1200,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(123);
+    });
+
+    it("does not align when champTimeLeft is large even with both settings on", () => {
+        expect(
+            decideAlignedClubChampionTimer(
+                buildState({
+                    proposedTime: 123,
+                    champTimeLeft: 3600,
+                    autoChamps: true,
+                    autoChampAlignTimer: true,
+                }),
+            ),
+        ).toBe(123);
+    });
+});

--- a/src/Module/ClubChampion.pure.ts
+++ b/src/Module/ClubChampion.pure.ts
@@ -1,0 +1,128 @@
+// ClubChampion.pure.ts -- Pure decision logic for the club-champion auto module.
+//
+// Extracted from ClubChampion.updateClubChampionTimer and
+// ClubChampion._setTimer so the range selection and timer alignment can be
+// unit-tested without DOM access, jQuery, randomInterval, or the timer
+// helper.
+//
+// Two decisions live here:
+//
+// 1. decideNextClubChampionTime maps the scraped "seconds to next timer"
+//    plus the autoClubForceStart setting onto the [min, max] window the
+//    impure adapter then feeds into randomInterval. The girl-reward
+//    substitution is deliberately NOT modelled here -- it happens at the
+//    DOM-scrape boundary (getNextClubChampionTimer) and feeds a
+//    pre-substituted secsToNextTimer into this function. That keeps the
+//    pure layer uniform: input is one number, output is one window.
+//
+// 2. decideAlignedClubChampionTimer reproduces the small alignment branch
+//    in _setTimer: if both autoChamps and autoChampAlignTimer are on AND
+//    both timers fall into the alignment window, return max(proposed,
+//    champTimeLeft); otherwise return the proposed value untouched.
+//
+// Bit-for-bit equivalence is the explicit goal -- thresholds (>7200, >10,
+// <1200) keep their strict comparisons.
+
+export type NextClubChampionTimerState = {
+    /**
+     * Seconds left on whichever rest timer the DOM scraped, AFTER the
+     * girl-reward substitution. -1 means no timer was found.
+     */
+    secsToNextTimer: number;
+    /**
+     * Setting_autoClubForceStart. When true and the timer exceeds 7200s,
+     * the window narrows to [115min, 125min] so the bot still runs in a
+     * sensible cadence instead of waiting two hours.
+     */
+    autoClubForceStart: boolean;
+};
+
+export type NextClubChampionTimerReason =
+    | 'no-timer'
+    | 'force-start'
+    | 'normal';
+
+export type NextClubChampionTimerDecision = {
+    minTime: number;
+    maxTime: number;
+    reason: NextClubChampionTimerReason;
+};
+
+/**
+ * Map the scraped timer plus force-start flag to a [min, max] window for
+ * randomInterval. Reproduces the three-branch cascade in
+ * updateClubChampionTimer line by line:
+ *
+ *   secsToNextTimer === -1                     -> [15*60, 17*60]   no-timer
+ *   secsToNextTimer >  7200 && force-start     -> [115*60, 125*60] force-start
+ *   else                                       -> [secs, secs+180] normal
+ *
+ * The 7200s threshold is strict (>): a timer of exactly 7200 falls
+ * through to the normal branch.
+ */
+export function decideNextClubChampionTime(
+    state: NextClubChampionTimerState,
+): NextClubChampionTimerDecision {
+    if (state.secsToNextTimer === -1) {
+        return { minTime: 15 * 60, maxTime: 17 * 60, reason: 'no-timer' };
+    }
+    if (state.secsToNextTimer > 7200 && state.autoClubForceStart) {
+        return { minTime: 115 * 60, maxTime: 125 * 60, reason: 'force-start' };
+    }
+    return {
+        minTime: state.secsToNextTimer,
+        maxTime: 180 + state.secsToNextTimer,
+        reason: 'normal',
+    };
+}
+
+export type AlignClubChampionTimerState = {
+    /**
+     * The candidate value the adapter would otherwise hand to setTimer.
+     */
+    proposedTime: number;
+    /**
+     * Seconds remaining on the sibling 'nextChampionTime' timer.
+     */
+    champTimeLeft: number;
+    /**
+     * Setting_autoChamps -- the sibling auto module is enabled.
+     */
+    autoChamps: boolean;
+    /**
+     * Setting_autoChampAlignTimer -- align both timers when both are short.
+     */
+    autoChampAlignTimer: boolean;
+};
+
+/**
+ * Reproduce the alignment branch in _setTimer:
+ *
+ *   if (autoChamps && autoChampAlignTimer
+ *       && proposedTime > 10 && champTimeLeft < 1200 && proposedTime < 1200)
+ *       proposedTime = max(proposedTime, champTimeLeft);
+ *
+ * All three threshold comparisons are strict on purpose:
+ *   proposedTime > 10  -- skip near-immediate retries
+ *   champTimeLeft < 1200, proposedTime < 1200 -- only align when both are
+ *   below 20 minutes
+ *
+ * The intent of the alignment is to bundle club-champion and
+ * single-champion runs onto the same wake-up: when both fire within the
+ * next 20 minutes, the later one wins so the script does not page-cycle
+ * twice in quick succession.
+ */
+export function decideAlignedClubChampionTimer(
+    state: AlignClubChampionTimerState,
+): number {
+    if (
+        state.autoChamps
+        && state.autoChampAlignTimer
+        && state.proposedTime > 10
+        && state.champTimeLeft < 1200
+        && state.proposedTime < 1200
+    ) {
+        return Math.max(state.proposedTime, state.champTimeLeft);
+    }
+    return state.proposedTime;
+}

--- a/src/Module/ClubChampion.ts
+++ b/src/Module/ClubChampion.ts
@@ -25,6 +25,10 @@ import { gotoPage } from "../Service/index";
 import { logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { Champion } from './index';
+import {
+    decideAlignedClubChampionTimer,
+    decideNextClubChampionTime,
+} from './ClubChampion.pure';
 import { QuestHelper } from "./Quest";
 
 export class ClubChampion {
@@ -60,29 +64,21 @@ export class ClubChampion {
         }
         return 0; // -1 is only when no timer on club page
     }
-    
+
     static updateClubChampionTimer()
     {
         var page=getPage();
         if (page==ConfigHelper.getHHScriptVars("pagesIDClub"))
         {
             logHHAuto('on clubs');
-            let secsToNextTimer = ClubChampion.getNextClubChampionTimer();
-            let noTimer = (secsToNextTimer === -1);
-            let nextClubChampionTime: number;
-
-            if (secsToNextTimer === -1)
-            {
-                nextClubChampionTime = randomInterval(15*60, 17*60);
-            }
-            else if (secsToNextTimer > 7200 && getStoredValue(HHStoredVarPrefixKey+SK.autoClubForceStart) === "true")
-            {
-                nextClubChampionTime = randomInterval(115*60, 125*60);
-            }
-            else
-            {
-                nextClubChampionTime = randomInterval(secsToNextTimer, 180 + secsToNextTimer);
-            }
+            const secsToNextTimer = ClubChampion.getNextClubChampionTimer();
+            const noTimer = (secsToNextTimer === -1);
+            const decision = decideNextClubChampionTime({
+                secsToNextTimer,
+                autoClubForceStart:
+                    getStoredValue(HHStoredVarPrefixKey + SK.autoClubForceStart) === "true",
+            });
+            const nextClubChampionTime = randomInterval(decision.minTime, decision.maxTime);
             ClubChampion._setTimer(nextClubChampionTime);
             return noTimer;
         }
@@ -92,7 +88,7 @@ export class ClubChampion {
     /** From club champion page */
     static getRemainingRestTime(): number{
         let remainingRestTime = 0;
-        
+
         let timerElm = $('.champions-bottom__rest .timer span[rel=expires]').text();
         if (timerElm !== undefined && timerElm !== null && timerElm.length > 0) {
             remainingRestTime = Number(convertTimeToInt(timerElm));
@@ -198,11 +194,11 @@ export class ClubChampion {
                 logHHAuto('Click champions tab');
                 $("#club_champions_tab").trigger('click');
             }
-    
+
             let Started = $("div.club-champion-members-challenges .player-row").length === 1;
             let secsToNextTimer = ClubChampion.getNextClubChampionTimer();
             let noTimer = secsToNextTimer === -1;
-    
+
             if ((Started || getStoredValue(HHStoredVarPrefixKey+SK.autoClubForceStart) === "true") && noTimer)
             {
                 let ticketUsed = 0;
@@ -240,18 +236,19 @@ export class ClubChampion {
     }
 
     /**
-     * 
-     * @param {number} nextClubChampionTime 
+     *
+     * @param {number} nextClubChampionTime
      * @private
      */
     static _setTimer(nextClubChampionTime: number): void {
-        if (getStoredValue(HHStoredVarPrefixKey+SK.autoChamps) ==="true" && getStoredValue(HHStoredVarPrefixKey+SK.autoChampAlignTimer) === "true") {
-            const champTimeLeft = getSecondsLeft('nextChampionTime');
-            if(nextClubChampionTime > 10 && champTimeLeft < 1200 && nextClubChampionTime < 1200) { // align settings
-                // 20 min for standard wait time
-                nextClubChampionTime = Math.max(nextClubChampionTime, champTimeLeft);
-            }
-        }
-        setTimer('nextClubChampionTime', nextClubChampionTime);
+        const aligned = decideAlignedClubChampionTimer({
+            proposedTime: nextClubChampionTime,
+            champTimeLeft: getSecondsLeft('nextChampionTime'),
+            autoChamps:
+                getStoredValue(HHStoredVarPrefixKey + SK.autoChamps) === "true",
+            autoChampAlignTimer:
+                getStoredValue(HHStoredVarPrefixKey + SK.autoChampAlignTimer) === "true",
+        });
+        setTimer('nextClubChampionTime', aligned);
     }
 }


### PR DESCRIPTION
## Summary

Stage 3 task 3.1 first half: pure-function extraction for ClubChampion.

Two decisions extracted into `src/Module/ClubChampion.pure.ts`:

- `decideNextClubChampionTime(state)` -- maps the scraped seconds-to-next-timer plus the `autoClubForceStart` setting onto the `[min, max]` window the impure adapter feeds into `randomInterval`.
- `decideAlignedClubChampionTimer(state)` -- reproduces the alignment branch in `_setTimer` (`autoChamps + autoChampAlignTimer + proposed > 10 + champTimeLeft < 1200 + proposed < 1200 -> max(proposed, champTimeLeft)`).

## Plan deviation

The plan listed `isTimeToFight` and `getNextChampionTime`. ClubChampion has no `isTimeToFight` equivalent that fits the pure pattern: the fight decision in `doClubChampionStuff` is interleaved with DOM scraping, ajax clicks, and `gotoPage` navigation, so extracting it would move more code than it tests. `getNextChampionTime` is renamed to `decideNextClubChampionTime` to match the actual concern (range selection) and to avoid the name clash with `Champion.pure.decideNextChampionTime` from stage 1 task 1.2. `decideAlignedClubChampionTimer` is split out of `_setTimer` because it is the only other piece of pure logic in the module.

## Bit-for-bit equivalence

- `updateClubChampionTimer` builds the input state and delegates the range to `decideNextClubChampionTime`. The returned `[min, max]` tuple goes back into `randomInterval`, same as before.
- `_setTimer` builds the input state and delegates the alignment to `decideAlignedClubChampionTimer`. The returned value is handed to `setTimer`, same as before.
- All threshold comparisons (`>7200`, `>10`, `<1200`) keep their strict semantics. Bundle diff is structural only.

## Tests

- 15 new tests in `spec/Module/ClubChampion.pure.spec.ts`.
- `decideNextClubChampionTime`: 6 tests covering no-timer, normal branch with and without force-start, the strict `>` boundary at 7200, the force-start window above 7200, and a zero timer.
- `decideAlignedClubChampionTimer`: 9 tests covering both settings off, each setting on alone, both on with alignment, both on with proposed already greater, the three strict-comparison boundaries (`proposed = 10`, `proposed = 1200`, `champTimeLeft = 1200`), and a long `champTimeLeft` path.
- 648 total (633 + 15), 48 suites, 0 skipped. Existing `ClubChampion.spec.ts` is untouched and still green.

## Verification

- `npm test`: 648 passed / 0 skipped / 48 suites.
- `npm run build`: success. Bundle diff strucural (new pure module appended; adapter call sites swapped to delegations). `HHAuto.user.js` rebuild discarded before commit per workflow rule.

No DOM, no jQuery, no `unsafeWindow` in the new pure module or the new tests.