### PR TITLE
refactor(test): extract pure decision logic from Pantheon

### DIFF
--- a/spec/Module/Pantheon.pure.spec.ts
+++ b/spec/Module/Pantheon.pure.spec.ts
@@ -1,0 +1,216 @@
+import {
+    IsEnabledState,
+    ShouldFightState,
+    decideIsEnabled,
+    decideShouldFight,
+} from "../../src/Module/Pantheon.pure";
+
+/**
+ * Pure-function tests for the pantheon decisions.
+ *
+ * decideIsEnabled covers the gate "module advertised by the game variant
+ * AND hero level meets the minimum". decideShouldFight covers the full
+ * fight-now boolean cascade with energy/threshold/runThreshold,
+ * humanLikeRun, the pantheon timer, paranoia spending, the booster
+ * requirement, and the daily-goal override.
+ *
+ * Threshold contract preserved from the original code:
+ *   - level gate is non-strict (>=)
+ *   - energy gate is strict (>) on both branches
+ *   - runThreshold is consulted as `runThreshold - 1` (off-by-one is
+ *     intentional in the original isTimeToFight)
+ *   - paranoia override only triggers with energy > 0
+ *   - && binds tighter than ||, so the booster branch is parsed as
+ *     (needBoosterToFight AND haveBoosterEquipped) OR !needBoosterToFight
+ *     OR isDailyGoal
+ */
+describe("decideIsEnabled", () => {
+    const buildState = (
+        overrides: Partial<IsEnabledState> = {},
+    ): IsEnabledState => ({
+        enabled: false,
+        heroLevel: 0,
+        minLevel: 16,
+        ...overrides,
+    });
+
+    it("returns false when the module is disabled regardless of level", () => {
+        expect(decideIsEnabled(buildState({ enabled: false, heroLevel: 500 }))).toBe(false);
+    });
+
+    it("returns false when the hero level is below the minimum", () => {
+        expect(decideIsEnabled(buildState({ enabled: true, heroLevel: 5 }))).toBe(false);
+    });
+
+    it("returns true when the hero level equals the minimum (non-strict >=)", () => {
+        expect(decideIsEnabled(buildState({ enabled: true, heroLevel: 16 }))).toBe(true);
+    });
+
+    it("returns true when the hero level is above the minimum", () => {
+        expect(decideIsEnabled(buildState({ enabled: true, heroLevel: 500 }))).toBe(true);
+    });
+});
+
+describe("decideShouldFight", () => {
+    const buildState = (
+        overrides: Partial<ShouldFightState> = {},
+    ): ShouldFightState => ({
+        energy: 0,
+        threshold: 0,
+        runThreshold: 0,
+        humanLikeRun: false,
+        timerExpired: true,
+        paranoiaSpending: 0,
+        needBoosterToFight: false,
+        haveBoosterEquipped: false,
+        isDailyGoal: false,
+        ...overrides,
+    });
+
+    it("returns false on the default state (timer ready but no energy)", () => {
+        expect(decideShouldFight(buildState())).toBe(false);
+    });
+
+    it("returns false when the timer has not expired even if energy is plentiful", () => {
+        expect(
+            decideShouldFight(
+                buildState({ timerExpired: false, energy: 100, threshold: 0 }),
+            ),
+        ).toBe(false);
+    });
+
+    it("returns true when energy exceeds threshold and runThreshold is zero", () => {
+        expect(
+            decideShouldFight(
+                buildState({ energy: 1, threshold: 0, runThreshold: 0 }),
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when energy equals threshold (strict >)", () => {
+        expect(
+            decideShouldFight(
+                buildState({ energy: 5, threshold: 5, runThreshold: 0 }),
+            ),
+        ).toBe(false);
+    });
+
+    it("humanLikeRun lets a single-energy spend bypass a high runThreshold", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 1,
+                    threshold: 0,
+                    runThreshold: 50,
+                    humanLikeRun: true,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("without humanLikeRun, runThreshold-1 acts as the upper energy gate", () => {
+        // energy = runThreshold - 1 still fails the strict > check
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 49,
+                    threshold: 0,
+                    runThreshold: 50,
+                    humanLikeRun: false,
+                }),
+            ),
+        ).toBe(false);
+
+        // energy = runThreshold passes
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 50,
+                    threshold: 0,
+                    runThreshold: 50,
+                    humanLikeRun: false,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("needBoosterToFight without an equipped booster blocks the fight", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 10,
+                    threshold: 0,
+                    needBoosterToFight: true,
+                    haveBoosterEquipped: false,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it("isDailyGoal overrides the missing booster", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 10,
+                    threshold: 0,
+                    needBoosterToFight: true,
+                    haveBoosterEquipped: false,
+                    isDailyGoal: true,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("needBoosterToFight with an equipped booster passes", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 10,
+                    threshold: 0,
+                    needBoosterToFight: true,
+                    haveBoosterEquipped: true,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("paranoia override fires even when timer has not expired", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 1,
+                    threshold: 100,
+                    runThreshold: 100,
+                    timerExpired: false,
+                    paranoiaSpending: 1,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("paranoia override requires energy > 0", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 0,
+                    paranoiaSpending: 5,
+                    timerExpired: false,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it("paranoia override requires paranoiaSpending > 0", () => {
+        expect(
+            decideShouldFight(
+                buildState({
+                    energy: 5,
+                    threshold: 100,
+                    runThreshold: 100,
+                    timerExpired: false,
+                    paranoiaSpending: 0,
+                }),
+            ),
+        ).toBe(false);
+    });
+});

--- a/src/Module/Pantheon.pure.ts
+++ b/src/Module/Pantheon.pure.ts
@@ -1,0 +1,112 @@
+// Pantheon.pure.ts -- Pure decision logic for the pantheon auto module.
+//
+// Extracted from Pantheon.isEnabled and Pantheon.isTimeToFight so the
+// boolean cascades can be unit-tested without globals, storage, jQuery,
+// or DOM access. Input = data, output = decision.
+//
+// The impure adapter Pantheon.isEnabled reads ConfigHelper plus
+// HeroHelper, builds an IsEnabledState, and delegates here. The impure
+// adapter Pantheon.isTimeToFight reads ConfigHelper, storage, the
+// Hero energy global, ParanoiaService, Booster, and DailyGoals; it
+// then builds a ShouldFightState and delegates here.
+
+export type IsEnabledState = {
+    /**
+     * ConfigHelper.getHHScriptVars("isEnabledPantheon", false) -- the
+     * pantheon module is currently advertised by the game variant.
+     */
+    enabled: boolean;
+    heroLevel: number;
+    /**
+     * ConfigHelper.getHHScriptVars("LEVEL_MIN_PANTHEON") -- the level
+     * gate the game enforces. >= comparison is preserved.
+     */
+    minLevel: number;
+};
+
+/**
+ * Reproduce Pantheon.isEnabled bit by bit:
+ *
+ *   isEnabledPantheon AND heroLevel >= LEVEL_MIN_PANTHEON
+ *
+ * The level gate is non-strict (>=), matching the original.
+ */
+export function decideIsEnabled(state: IsEnabledState): boolean {
+    return state.enabled && state.heroLevel >= state.minLevel;
+}
+
+export type ShouldFightState = {
+    energy: number;
+    threshold: number;
+    runThreshold: number;
+    humanLikeRun: boolean;
+    /**
+     * checkTimer('nextPantheonTime') -- boolean for the pantheon
+     * cooldown. true when the timer has expired.
+     */
+    timerExpired: boolean;
+    /**
+     * ParanoiaService.checkParanoiaSpendings('worship'). The pure
+     * function gates it on energy > 0 itself, mirroring the original.
+     */
+    paranoiaSpending: number;
+    /**
+     * Setting_autoPantheonBoostedOnly -- only fight when boosters are
+     * equipped (unless the daily-goal override fires).
+     */
+    needBoosterToFight: boolean;
+    /**
+     * Booster.haveBoosterEquiped() -- a booster is currently equipped.
+     */
+    haveBoosterEquipped: boolean;
+    /**
+     * DailyGoals.isPantheonDailyGoal() -- a pantheon daily goal is
+     * active. Overrides the booster requirement.
+     */
+    isDailyGoal: boolean;
+};
+
+/**
+ * Reproduce Pantheon.isTimeToFight bit by bit. Original line:
+ *
+ *   (checkTimer('nextPantheonTime') && energyAboveThreshold &&
+ *    (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight
+ *     || isDailyGoal)) || paranoiaSpending
+ *
+ * with
+ *
+ *   energyAboveThreshold = humanLikeRun && energy > threshold
+ *                          || energy > max(threshold, runThreshold - 1)
+ *   paranoiaSpending     = energy > 0 && paranoiaCheck > 0
+ *
+ * Operator precedence is preserved: && binds tighter than ||, so the
+ * three OR-ed booster branches keep their natural structure
+ * (booster-required-and-equipped OR booster-not-required OR daily-goal).
+ *
+ * Threshold comparisons are strict (>) on the lower bound and the
+ * runThreshold-1 expression keeps the off-by-one the original code uses.
+ */
+export function decideShouldFight(state: ShouldFightState): boolean {
+    const {
+        energy,
+        threshold,
+        runThreshold,
+        humanLikeRun,
+        timerExpired,
+        paranoiaSpending,
+        needBoosterToFight,
+        haveBoosterEquipped,
+        isDailyGoal,
+    } = state;
+
+    const energyAboveThreshold =
+        (humanLikeRun && energy > threshold)
+        || energy > Math.max(threshold, runThreshold - 1);
+    const paranoiaOverride = energy > 0 && paranoiaSpending > 0;
+    const boosterCheck =
+        (needBoosterToFight && haveBoosterEquipped)
+        || !needBoosterToFight
+        || isDailyGoal;
+
+    return (timerExpired && energyAboveThreshold && boosterCheck) || paranoiaOverride;
+}

--- a/src/Module/Pantheon.ts
+++ b/src/Module/Pantheon.ts
@@ -27,6 +27,10 @@ import { logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { Booster } from "./Booster";
 import { DailyGoals } from './DailyGoals';
+import {
+    decideIsEnabled,
+    decideShouldFight,
+} from './Pantheon.pure';
 
 export class Pantheon {
 
@@ -67,7 +71,11 @@ export class Pantheon {
     }
 
     static isEnabled(){
-        return ConfigHelper.getHHScriptVars("isEnabledPantheon", false) && HeroHelper.getLevel() >= ConfigHelper.getHHScriptVars("LEVEL_MIN_PANTHEON");
+        return decideIsEnabled({
+            enabled: ConfigHelper.getHHScriptVars("isEnabledPantheon", false),
+            heroLevel: HeroHelper.getLevel(),
+            minLevel: ConfigHelper.getHHScriptVars("LEVEL_MIN_PANTHEON"),
+        });
     }
 
     static isTimeToFight(){
@@ -75,18 +83,32 @@ export class Pantheon {
         const runThreshold = Number(getStoredValue(HHStoredVarPrefixKey + SK.autoPantheonRunThreshold)) || 0;
         const humanLikeRun = getStoredValue(HHStoredVarPrefixKey+TK.PantheonHumanLikeRun) === "true";
 
-        const energyAboveThreshold = humanLikeRun && Pantheon.getEnergy() > threshold || Pantheon.getEnergy() > Math.max(threshold, runThreshold-1);
-        const paranoiaSpending = Pantheon.getEnergy() > 0 && ParanoiaService.checkParanoiaSpendings('worship') > 0;
+        const energy = Pantheon.getEnergy();
         const needBoosterToFight = getStoredValue(HHStoredVarPrefixKey+SK.autoPantheonBoostedOnly) === "true";
-        const haveBoosterEquiped = Booster.haveBoosterEquiped();
+        const haveBoosterEquipped = Booster.haveBoosterEquiped();
+        const timerExpired = checkTimer('nextPantheonTime');
 
-        const isDailyGoal = DailyGoals.isPantheonDailyGoal();
+        // Energy gate (mirrors the pure function) -- pre-computed only
+        // for the diagnostic log line below.
+        const energyAboveThreshold =
+            (humanLikeRun && energy > threshold)
+            || energy > Math.max(threshold, runThreshold - 1);
 
-        if(checkTimer('nextPantheonTime') && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
+        if (timerExpired && energyAboveThreshold && needBoosterToFight && !haveBoosterEquipped) {
             logHHAuto('Time for pantheon but no booster equipped');
         }
 
-        return (checkTimer('nextPantheonTime') && energyAboveThreshold && (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight || isDailyGoal)) || paranoiaSpending;
+        return decideShouldFight({
+            energy,
+            threshold,
+            runThreshold,
+            humanLikeRun,
+            timerExpired,
+            paranoiaSpending: ParanoiaService.checkParanoiaSpendings('worship'),
+            needBoosterToFight,
+            haveBoosterEquipped,
+            isDailyGoal: DailyGoals.isPantheonDailyGoal(),
+        });
     }
 
     static run()


### PR DESCRIPTION
## Summary

Stage 3 task 3.2: pure-function extraction for Pantheon.

Two decisions extracted into `src/Module/Pantheon.pure.ts`:

- `decideIsEnabled(state)` -- pantheon module gate (`enabled` flag AND `heroLevel >= minLevel`). Non-strict `>=` preserved.
- `decideShouldFight(state)` -- full fight-now boolean cascade (energy/threshold/runThreshold, humanLikeRun, pantheon timer, paranoia spending, booster requirement, daily-goal override). Mirrors `Pantheon.isTimeToFight` bit by bit.

## Bit-for-bit equivalence

- `Pantheon.isEnabled` builds the input state and delegates.
- `Pantheon.isTimeToFight` builds the input state and delegates. The `energyAboveThreshold` expression is also recomputed locally in the impure adapter for the existing diagnostic log line ("Time for pantheon but no booster equipped"); the pure function recomputes it independently.
- Operator precedence preserved: `&&` binds tighter than `||`, so the booster branch parses as `(needBoosterToFight AND haveBoosterEquipped) OR !needBoosterToFight OR isDailyGoal`.
- Threshold comparisons stay strict (`>`) on the lower bound; the `runThreshold-1` off-by-one is preserved.

## Behaviour delta

`ParanoiaService.checkParanoiaSpendings('worship')` is now called unconditionally; previously it was short-circuited away when `energy === 0`. Read-only call, no side effects. Mirrors the same delta accepted in League stage 1 task 1.1 (PR #1617).

## Tests

- 16 new tests in `spec/Module/Pantheon.pure.spec.ts`.
- `decideIsEnabled`: 4 tests covering disabled flag, level below minimum, equality at the `>=` boundary, and a clearly-above-minimum case.
- `decideShouldFight`: 12 tests covering the default zero-energy state, an active timer blocking the fight, the energy-above-threshold gate at zero `runThreshold`, the strict-`>` boundary on `threshold`, `humanLikeRun` bypassing a high `runThreshold`, `runThreshold-1` acting as the upper energy gate (both sides), `needBoosterToFight` blocking with no booster equipped, `isDailyGoal` overriding the missing booster, the booster-equipped happy path, and three paranoia-override cases (active even with timer not expired, blocked by zero energy, blocked by zero spending).
- 664 total (648 + 16), 49 suites, 0 skipped. Existing `Pantheon.spec.ts` is untouched and still green.

## Verification

- `npm test`: 664 passed / 0 skipped / 49 suites.
- `npm run build`: success. Bundle diff structural (new pure module appended; adapter call sites swapped to delegations). `HHAuto.user.js` rebuild discarded before commit per workflow rule.

No DOM, no jQuery, no `unsafeWindow` in the new pure module or the new tests.