### PR TITLE
refactor(test): extract pure decision logic from Labyrinth path pipeline

### DIFF
--- a/spec/Module/Labyrinth.pure.spec.ts
+++ b/spec/Module/Labyrinth.pure.spec.ts
@@ -1,0 +1,331 @@
+import {
+    FindBetterState,
+    LabyrinthOpponentLite,
+    buildPathsFromMatrix,
+    decideBetterOption,
+    filterPathsWithTreasure,
+    getNextIndices,
+    sortPathsByDifficulty,
+} from "../../src/Module/Labyrinth.pure";
+
+/**
+ * Pure-function tests for the labyrinth path pipeline and the
+ * findBetter selector. The path pipeline (build / filter / sort) is
+ * tested with minimal records that carry only the two fields the
+ * pipeline reads (`opponentDifficulty`, `isTreasure`); the option
+ * ranker is tested with the full `LabyrinthOpponentLite` shape.
+ *
+ * Adjacency rules from the original code (preserved bit by bit):
+ *   - nextLen === 1 (boss row): every cell -> [0]
+ *   - currLen 1 -> nextLen 2: 0 -> [0, 1]
+ *   - currLen 2 -> nextLen 3: 0 -> [0, 1], 1 -> [1, 2]
+ *   - currLen 3 -> nextLen 2: 0 -> [0], 1 -> [0, 1], 2 -> [1]
+ *   - any other shape: undefined
+ */
+
+type PathCell = { id: string; opponentDifficulty: number; isTreasure: boolean };
+
+const cell = (
+    id: string,
+    overrides: Partial<PathCell> = {},
+): PathCell => ({
+    id,
+    opponentDifficulty: 0,
+    isTreasure: false,
+    ...overrides,
+});
+
+describe("getNextIndices", () => {
+    it("collapses to the single boss cell when nextLen === 1", () => {
+        expect(getNextIndices(0, 2, 1)).toEqual([0]);
+        expect(getNextIndices(1, 2, 1)).toEqual([0]);
+        expect(getNextIndices(2, 3, 1)).toEqual([0]);
+    });
+
+    it("expands the start row (1) into both first-row cells (2)", () => {
+        expect(getNextIndices(0, 1, 2)).toEqual([0, 1]);
+    });
+
+    it("expands a 2-row into a 3-row using the 0->[0,1], 1->[1,2] rule", () => {
+        expect(getNextIndices(0, 2, 3)).toEqual([0, 1]);
+        expect(getNextIndices(1, 2, 3)).toEqual([1, 2]);
+    });
+
+    it("contracts a 3-row into a 2-row using the 0->[0], 1->[0,1], 2->[1] rule", () => {
+        expect(getNextIndices(0, 3, 2)).toEqual([0]);
+        expect(getNextIndices(1, 3, 2)).toEqual([0, 1]);
+        expect(getNextIndices(2, 3, 2)).toEqual([1]);
+    });
+
+    it("returns undefined for unknown shapes (matches the original fallback)", () => {
+        expect(getNextIndices(0, 2, 2)).toBeUndefined();
+        expect(getNextIndices(0, 4, 5)).toBeUndefined();
+    });
+});
+
+describe("buildPathsFromMatrix", () => {
+    it("returns no paths for an empty matrix", () => {
+        expect(buildPathsFromMatrix([])).toEqual([]);
+    });
+
+    it("returns a single path for a one-row matrix (also the boss row)", () => {
+        const a = cell("A");
+        const paths = buildPathsFromMatrix([[a]]);
+        expect(paths).toEqual([[a]]);
+    });
+
+    it("walks a 1-2-1 matrix and produces both branches", () => {
+        const start = cell("S");
+        const left = cell("L");
+        const right = cell("R");
+        const boss = cell("B");
+        const paths = buildPathsFromMatrix([[start], [left, right], [boss]]);
+        expect(paths.map((p) => p.map((c) => c.id))).toEqual([
+            ["S", "L", "B"],
+            ["S", "R", "B"],
+        ]);
+    });
+
+    it("walks a 2-3-2-1 matrix preserving adjacency rules", () => {
+        // 2 cells -> 3 cells: 0 -> [0,1], 1 -> [1,2]
+        // 3 cells -> 2 cells: 0 -> [0], 1 -> [0,1], 2 -> [1]
+        // 2 cells -> 1 cell:  every cell -> [0]
+        const r0 = [cell("a"), cell("b")];
+        const r1 = [cell("c"), cell("d"), cell("e")];
+        const r2 = [cell("f"), cell("g")];
+        const boss = cell("B");
+        const paths = buildPathsFromMatrix([r0, r1, r2, [boss]]);
+        // start a -> {c, d}; from c -> f; from d -> {f, g}
+        // start b -> {d, e}; from d -> {f, g}; from e -> g
+        const ids = paths.map((p) => p.map((c) => c.id).join(""));
+        expect(ids).toEqual([
+            "acfB",
+            "adfB",
+            "adgB",
+            "bdfB",
+            "bdgB",
+            "begB",
+        ]);
+    });
+
+    it("skips empty leading rows and starts from the first populated row", () => {
+        const a = cell("A");
+        const b = cell("B");
+        const paths = buildPathsFromMatrix([[], [], [a], [b]]);
+        expect(paths.map((p) => p.map((c) => c.id))).toEqual([["A", "B"]]);
+    });
+});
+
+describe("filterPathsWithTreasure", () => {
+    it("returns an empty list when no path has any treasure", () => {
+        const paths = [
+            [cell("a"), cell("b")],
+            [cell("c"), cell("d")],
+        ];
+        expect(filterPathsWithTreasure(paths)).toEqual([]);
+    });
+
+    it("keeps only paths that contain at least one treasure", () => {
+        const t = cell("t", { isTreasure: true });
+        const a = cell("a");
+        const b = cell("b");
+        const paths = [
+            [a, b],
+            [a, t],
+            [t, b],
+        ];
+        expect(filterPathsWithTreasure(paths)).toEqual([
+            [a, t],
+            [t, b],
+        ]);
+    });
+
+    it("keeps paths that have multiple treasures", () => {
+        const t1 = cell("t1", { isTreasure: true });
+        const t2 = cell("t2", { isTreasure: true });
+        const paths = [[t1, t2]];
+        expect(filterPathsWithTreasure(paths)).toEqual([[t1, t2]]);
+    });
+});
+
+describe("sortPathsByDifficulty", () => {
+    it("sorts paths ascending by the sum of opponentDifficulty", () => {
+        const easy = [cell("e1", { opponentDifficulty: 1 }), cell("e2", { opponentDifficulty: 1 })];
+        const mid = [cell("m1", { opponentDifficulty: 2 }), cell("m2", { opponentDifficulty: 2 })];
+        const hard = [cell("h1", { opponentDifficulty: 3 }), cell("h2", { opponentDifficulty: 3 })];
+        const paths = [hard, easy, mid];
+        sortPathsByDifficulty(paths);
+        expect(paths.map((p) => p[0].id)).toEqual(["e1", "m1", "h1"]);
+    });
+
+    it("sorts a single-cell-per-path matrix by the lone difficulty value", () => {
+        const easy = [cell("e", { opponentDifficulty: 1 })];
+        const hard = [cell("h", { opponentDifficulty: 5 })];
+        const mid = [cell("m", { opponentDifficulty: 3 })];
+        const paths = [hard, mid, easy];
+        sortPathsByDifficulty(paths);
+        expect(paths.map((p) => p[0].id)).toEqual(["e", "m", "h"]);
+    });
+});
+
+describe("decideBetterOption", () => {
+    const opt = (
+        overrides: Partial<LabyrinthOpponentLite> = {},
+    ): LabyrinthOpponentLite => ({
+        opponentDifficulty: 0,
+        isTreasure: false,
+        isShrine: false,
+        isNext: true,
+        isOpponent: true,
+        power: 0,
+        hasButton: true,
+        ...overrides,
+    });
+
+    const buildState = (
+        overrides: Partial<FindBetterState<LabyrinthOpponentLite>> = {},
+    ): FindBetterState<LabyrinthOpponentLite> => ({
+        options: [],
+        chooseMoreReward: false,
+        haveGirlWounded: false,
+        floor: 1,
+        ...overrides,
+    });
+
+    it("returns null on an empty options list", () => {
+        expect(decideBetterOption(buildState())).toBeNull();
+    });
+
+    it("falls back to the FIRST original option when no eligible option survives the filter", () => {
+        // Only shrines on floor 1 -> all filtered out; no eligible
+        // option remains; first-original fallback kicks in.
+        const a = opt({ isShrine: true, hasButton: false });
+        const b = opt({ isShrine: true, hasButton: false });
+        const chosen = decideBetterOption(buildState({ options: [a, b] }));
+        expect(chosen).toBe(a);
+    });
+
+    it("ignores options with hasButton=false and falls back to firstOption", () => {
+        const a = opt({ hasButton: false });
+        expect(decideBetterOption(buildState({ options: [a] }))).toBe(a);
+    });
+
+    it("ignores options with isNext=false and falls back to firstOption", () => {
+        const a = opt({ isNext: false });
+        expect(decideBetterOption(buildState({ options: [a] }))).toBe(a);
+    });
+
+    it("drops shrines on floor < 3 even with wounded girls", () => {
+        const shrine = opt({ isShrine: true, hasButton: false });
+        const enemy = opt({ isOpponent: true, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [shrine, enemy],
+                haveGirlWounded: true,
+                floor: 2,
+            }),
+        );
+        expect(chosen).toBe(enemy);
+    });
+
+    it("drops shrines on floor >= 3 when no girl is wounded", () => {
+        const shrine = opt({ isShrine: true, hasButton: false });
+        const enemy = opt({ isOpponent: true, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [shrine, enemy],
+                haveGirlWounded: false,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(enemy);
+    });
+
+    it("keeps only shrines on floor >= 3 when at least one girl is wounded", () => {
+        const shrine = opt({ isShrine: true, isOpponent: false });
+        const enemy = opt({ isOpponent: true, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [enemy, shrine],
+                haveGirlWounded: true,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(shrine);
+    });
+
+    it("keeps only treasures when at least one is present", () => {
+        const treasure = opt({ isTreasure: true, isOpponent: false });
+        const enemy = opt({ isOpponent: true, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({ options: [enemy, treasure] }),
+        );
+        expect(chosen).toBe(treasure);
+    });
+
+    it("keeps only easy opponents on floor < 3 without chooseMoreReward", () => {
+        const easy = opt({ opponentDifficulty: 1, power: 100 });
+        const medium = opt({ opponentDifficulty: 2, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [medium, easy],
+                chooseMoreReward: false,
+                floor: 1,
+            }),
+        );
+        // medium drops out; easy is the only survivor
+        expect(chosen).toBe(easy);
+    });
+
+    it("chooseMoreReward picks higher difficulty over lower", () => {
+        const easy = opt({ opponentDifficulty: 1, power: 50 });
+        const hard = opt({ opponentDifficulty: 3, power: 100 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [easy, hard],
+                chooseMoreReward: true,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(hard);
+    });
+
+    it("chooseMoreReward picks lower power within tied difficulty", () => {
+        const tougher = opt({ opponentDifficulty: 2, power: 200 });
+        const weaker = opt({ opponentDifficulty: 2, power: 100 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [tougher, weaker],
+                chooseMoreReward: true,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(weaker);
+    });
+
+    it("default branch picks non-opponent over opponent", () => {
+        const enemy = opt({ isOpponent: true, power: 50 });
+        const npc = opt({ isOpponent: false, power: 200 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [enemy, npc],
+                chooseMoreReward: false,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(npc);
+    });
+
+    it("default branch picks lower power between two opponents", () => {
+        const tougher = opt({ isOpponent: true, power: 200 });
+        const weaker = opt({ isOpponent: true, power: 50 });
+        const chosen = decideBetterOption(
+            buildState({
+                options: [tougher, weaker],
+                chooseMoreReward: false,
+                floor: 5,
+            }),
+        );
+        expect(chosen).toBe(weaker);
+    });
+});

--- a/src/Module/Labyrinth.pure.ts
+++ b/src/Module/Labyrinth.pure.ts
@@ -1,0 +1,280 @@
+// Labyrinth.pure.ts -- Pure decision logic for the labyrinth path pipeline
+// and the "find better option" selector.
+//
+// Extracted from Labyrinth.createPathFromMatrix,
+// Labyrinth.filterPathWithNoTreasue, Labyrinth.sortPathsByDifficulty,
+// and Labyrinth.findBetter so the path-building DFS, the treasure
+// filter, the difficulty sort, and the option ranker can be unit-
+// tested without DOM access, jQuery, globals, or storage.
+//
+// The functions are generic over the opponent record so the impure
+// adapter can keep its DOM-bound `LabyrinthOpponent` shape (with
+// jQuery `button` / `cell` handles) while the pure layer only needs
+// the deterministic decision fields.
+
+/**
+ * Minimal subset of fields the path pipeline reads (build / filter /
+ * sort). The impure adapter's `LabyrinthOpponent` already carries these
+ * two fields, so the pipeline can be invoked with the DOM-bound type
+ * directly without a projection step.
+ */
+export interface LabyrinthPathOpponent {
+    opponentDifficulty: number;
+    isTreasure: boolean;
+}
+
+/**
+ * Field set the option ranker reads. The impure adapter projects its
+ * DOM-bound `LabyrinthOpponent` onto this shape (mapping the jQuery
+ * `button` handle onto the `hasButton` boolean) before delegating.
+ */
+export interface LabyrinthOpponentLite {
+    opponentDifficulty: number;
+    isTreasure: boolean;
+    isShrine: boolean;
+    isNext: boolean;
+    isOpponent: boolean;
+    power: number;
+    /**
+     * In the impure code this is `option.button` (a jQuery handle)
+     * used as a truthiness check inside findBetter. The pure pipeline
+     * sees the same condition as a boolean.
+     */
+    hasButton: boolean;
+}
+
+/**
+ * Reproduce the inner `getNextIndices` closure of
+ * createPathFromMatrix bit by bit. Returns the indices in the next
+ * row that the cell at (currIdx, currLen) can reach.
+ *
+ * Adjacency rules from the original code:
+ *   - nextLen === 1 (boss row): every cell maps to [0]
+ *   - currLen 1 -> nextLen 2: 0 -> [0, 1]
+ *   - currLen 2 -> nextLen 3: 0 -> [0, 1], 1 -> [1, 2]
+ *   - currLen 3 -> nextLen 2: 0 -> [0], 1 -> [0, 1], 2 -> [1]
+ *   - any other shape returns undefined (matches the original
+ *     fallback where the function exits without a return value)
+ */
+export function getNextIndices(
+    currIdx: number,
+    currLen: number,
+    nextLen: number,
+): number[] | undefined {
+    if (nextLen === 1) return [0];
+    if (currLen === 1 && nextLen === 2) return [0, 1];
+    if (currLen === 2 && nextLen === 3) return currIdx === 0 ? [0, 1] : [1, 2];
+    if (currLen === 3 && nextLen === 2) {
+        if (currIdx === 0) return [0];
+        if (currIdx === 1) return [0, 1];
+        return [1];
+    }
+    return undefined;
+}
+
+/**
+ * Reproduce createPathFromMatrix bit by bit. DFS over a
+ * row-of-cells matrix using the adjacency rules in
+ * getNextIndices.
+ *
+ * Empty leading rows are skipped (`while !matrix[startRow] ||
+ * length === 0`) -- this preserves the original quirk that the
+ * matrix may carry empty rows ahead of the first real row.
+ */
+export function buildPathsFromMatrix<T extends LabyrinthPathOpponent>(
+    matrix: T[][],
+): T[][] {
+    const rows = matrix.length;
+    const paths: T[][] = [];
+    if (rows === 0) return paths;
+
+    const lastRow = rows - 1;
+
+    const dfs = (row: number, idx: number, acc: T[]) => {
+        acc.push(matrix[row][idx]);
+
+        if (row === lastRow) {
+            paths.push(acc.slice());
+            acc.pop();
+            return;
+        }
+
+        const nextRow = row + 1;
+        const currLen = matrix[row].length;
+        const nextLen = matrix[nextRow].length;
+
+        const nextIndices = getNextIndices(idx, currLen, nextLen);
+        if (nextIndices === undefined) {
+            // Original fallback path: function returns undefined and
+            // the for-of below would throw. The impure adapter logged
+            // an error before the (commented-out) fallback. Pure
+            // version keeps the same shape: no further descent on an
+            // unrecognised row pair.
+            acc.pop();
+            return;
+        }
+
+        for (const ni of nextIndices) {
+            if (ni >= 0 && ni < nextLen) dfs(nextRow, ni, acc);
+        }
+
+        acc.pop();
+    };
+
+    let startRow = 0;
+    while (startRow < rows && (!matrix[startRow] || matrix[startRow].length === 0)) {
+        startRow++;
+    }
+    if (startRow >= rows) return paths;
+
+    for (let i = 0; i < matrix[startRow].length; i++) {
+        dfs(startRow, i, []);
+    }
+
+    return paths;
+}
+
+/**
+ * Reproduce filterPathWithNoTreasue (typo preserved at the adapter
+ * boundary). Keep only paths that contain at least one treasure cell.
+ */
+export function filterPathsWithTreasure<T extends LabyrinthPathOpponent>(
+    paths: T[][],
+): T[][] {
+    return paths.filter((path) =>
+        path.filter((opponent) => opponent.isTreasure).length > 0,
+    );
+}
+
+/**
+ * Reproduce sortPathsByDifficulty. Sort paths ascending by the sum
+ * of their opponent difficulties. The original used a mutating
+ * .sort() and returned the same array; the pure version mirrors that
+ * (callers must accept that the input array is sorted in place).
+ */
+export function sortPathsByDifficulty<T extends LabyrinthPathOpponent>(
+    paths: T[][],
+): T[][] {
+    return paths.sort((pathA, pathB) => {
+        let difficultyA = 0;
+        let difficultyB = 0;
+        pathA.forEach((opponent) => {
+            difficultyA += opponent.opponentDifficulty;
+        });
+        pathB.forEach((opponent) => {
+            difficultyB += opponent.opponentDifficulty;
+        });
+        return difficultyA - difficultyB;
+    });
+}
+
+export type FindBetterState<T extends LabyrinthOpponentLite> = {
+    options: T[];
+    /**
+     * Setting_autoLabyHard. When true, prefer harder opponents and
+     * lower-power within the same difficulty band.
+     */
+    chooseMoreReward: boolean;
+    /**
+     * `unsafeWindow.girl_squad.filter(g => g.remaining_ego_percent < 100)`
+     * has at least one entry. Wounded squad members trigger the
+     * shrine-keeping branch from floor 3 onwards.
+     */
+    haveGirlWounded: boolean;
+    /**
+     * Labyrinth.getCurrentFloorNumber(). Floor < 3 forbids shrines and
+     * (without chooseMoreReward) prefers easy opponents.
+     */
+    floor: number;
+};
+
+/**
+ * Reproduce Labyrinth.findBetter bit by bit. Filter cascade:
+ *
+ *   1. shrines: drop unless (haveGirlWounded AND floor >= 3)
+ *      else if floor >= 3 AND any shrine present: keep only shrines
+ *   2. treasures: if any treasure present, keep only treasures
+ *   3. easy bias: !chooseMoreReward AND floor < 3 AND any
+ *      opponentDifficulty == 1 present: keep only those
+ *
+ * Then iterate the filtered list and pick the best:
+ *
+ *   - Only options with hasButton AND isNext are eligible.
+ *   - First eligible option becomes the seed.
+ *   - chooseMoreReward branch:
+ *       * higher opponentDifficulty wins
+ *       * tied difficulty: lower power wins
+ *   - else (default) branch:
+ *       * non-opponent beats opponent
+ *       * two opponents: lower power wins
+ *
+ * If no eligible option survives, fall back to the FIRST element of
+ * the ORIGINAL options array (before any filter ran).
+ */
+export function decideBetterOption<T extends LabyrinthOpponentLite>(
+    state: FindBetterState<T>,
+): T | null {
+    let { options } = state;
+    const { chooseMoreReward, haveGirlWounded, floor } = state;
+
+    let firstOption: T | null = null;
+    if (options.length > 0) {
+        firstOption = options[0];
+    }
+
+    if (!haveGirlWounded || floor < 3) {
+        options = options.filter((option) => !option.isShrine);
+    } else if (floor >= 3 && options.filter((option) => option.isShrine).length > 0) {
+        options = options.filter((option) => option.isShrine);
+    }
+
+    if (options.filter((option) => option.isTreasure).length > 0) {
+        options = options.filter((option) => option.isTreasure);
+    }
+
+    if (
+        !chooseMoreReward
+        && floor < 3
+        && options.filter((option) => option.opponentDifficulty == 1).length > 0
+    ) {
+        options = options.filter((option) => option.opponentDifficulty == 1);
+    }
+
+    let chosenOption: T | null = null;
+    options.forEach((option) => {
+        let isBetter = false;
+        if (option.hasButton && option.isNext) {
+            if (chosenOption == null) {
+                isBetter = true;
+            } else if (chooseMoreReward) {
+                if (chosenOption.opponentDifficulty < option.opponentDifficulty) {
+                    isBetter = true;
+                } else if (
+                    chosenOption.opponentDifficulty == option.opponentDifficulty
+                    && chosenOption.power > option.power
+                ) {
+                    isBetter = true;
+                }
+            } else {
+                if (chosenOption.isOpponent && !option.isOpponent) {
+                    isBetter = true;
+                } else if (
+                    chosenOption.isOpponent
+                    && option.isOpponent
+                    && chosenOption.power > option.power
+                ) {
+                    isBetter = true;
+                }
+            }
+        }
+
+        if (isBetter) {
+            chosenOption = option;
+        }
+    });
+
+    if (chosenOption == null && firstOption != null) {
+        chosenOption = firstOption;
+    }
+    return chosenOption;
+}

--- a/src/Module/Labyrinth.ts
+++ b/src/Module/Labyrinth.ts
@@ -24,6 +24,12 @@ import {
 } from '../Helper/index';
 import { logHHAuto, safeJsonParse } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
+import {
+    buildPathsFromMatrix,
+    decideBetterOption,
+    filterPathsWithTreasure,
+    sortPathsByDifficulty as sortPathsByDifficultyPure,
+} from './Labyrinth.pure';
 import { RelicManager } from './RelicManager';
 
 class LabyrinthOpponent{
@@ -335,100 +341,15 @@ export class Labyrinth {
     }
 
     static filterPathWithNoTreasue(paths: LabyrinthOpponent[][]): LabyrinthOpponent[][] {
-        return paths.filter((path) => {
-            return path.filter((opponent) => opponent.isTreasure).length > 0;
-        });
+        return filterPathsWithTreasure(paths);
     }
 
     static sortPathsByDifficulty(paths: LabyrinthOpponent[][]): LabyrinthOpponent[][] {
-        return paths.sort((pathA, pathB) => {
-            let difficultyA = 0;
-            let difficultyB = 0;
-            pathA.forEach((opponent) => {
-                difficultyA += opponent.opponentDifficulty;
-            });
-            pathB.forEach((opponent) => {
-                difficultyB += opponent.opponentDifficulty;
-            });
-            return difficultyA - difficultyB;
-        });
+        return sortPathsByDifficultyPure(paths);
     }
 
     static createPathFromMatrix(matrix: LabyrinthOpponent[][]): LabyrinthOpponent[][] {
-        /*
-        Rules:
-        The curent matrix have 11 rows. Each row have 2 or 3 cell alternatively.
-        If next row have 3 cell, each cell can reach 2 cell of the next row (Cell 1 can reach cell 1 and 2 of the next row, cell 2 can reach 2 and 3 of the next row)
-        If next row have two cell, cell 1 can only access cell 1 of next row, cell 2 can access 1 and 2 of next row, cell 3 can only access cell 2 of next row.
-        last row have only one cell (boss)
-        */
-
-
-        const rows = matrix.length;
-        const paths: LabyrinthOpponent[][] = [];
-        if (rows === 0) return paths;
-
-        const lastRow = rows - 1;
-
-        const getNextIndices = (currIdx: number, currLen: number, nextLen: number): number[] => {
-            // If next row is the boss row (only one cell), every current cell goes to that single cell
-            if (nextLen === 1) return [0];
-
-            // start row, next has 2: 0 -> [0,1]
-            if (currLen === 1 && nextLen === 2) {
-                return [0, 1];
-            }
-
-            // current row has 2, next has 3: 0 -> [0,1], 1 -> [1,2]
-            if (currLen === 2 && nextLen === 3) {
-                return currIdx === 0 ? [0, 1] : [1, 2];
-            }
-
-            // current row has 3, next has 2: 0->[0], 1->[0,1], 2->[1]
-            if (currLen === 3 && nextLen === 2) {
-                if (currIdx === 0) return [0];
-                if (currIdx === 1) return [0, 1];
-                return [1];
-            }
-            logHHAuto('Labyrinth pathing logic error: currLen=' + currLen + ', nextLen=' + nextLen);
-
-            // fallback: try to keep same index if possible
-            /*const res: number[] = [];
-            if (currIdx < nextLen) res.push(currIdx);
-            if (currIdx + 1 < nextLen) res.push(currIdx + 1);
-            return res;*/
-        };
-
-        const dfs = (row: number, idx: number, acc: LabyrinthOpponent[]) => {
-            acc.push(matrix[row][idx]);
-
-            if (row === lastRow) {
-                paths.push(acc.slice());
-                acc.pop();
-                return;
-            }
-
-            const nextRow = row + 1;
-            const currLen = matrix[row].length;
-            const nextLen = matrix[nextRow].length;
-
-            const nextIndices = getNextIndices(idx, currLen, nextLen);
-            for (const ni of nextIndices) {
-                if (ni >= 0 && ni < nextLen) dfs(nextRow, ni, acc);
-            }
-
-            acc.pop();
-        };
-
-        let startRow = 0;
-        while (startRow < rows && (!matrix[startRow] || matrix[startRow].length === 0)) startRow++;
-        if (startRow >= rows) return paths;
-
-        for (let i = 0; i < matrix[startRow].length; i++) {
-            dfs(startRow, i, []);
-        }   
-
-        return paths;
+        return buildPathsFromMatrix(matrix);
     }
 
     static getResetTime() {
@@ -445,75 +366,30 @@ export class Labyrinth {
 
     static findBetter(options: LabyrinthOpponent[]): LabyrinthOpponent{
         const chooseMoreReward = getStoredValue(HHStoredVarPrefixKey + SK.autoLabyHard) == "true";
-
-        const haveGirlWounded = unsafeWindow.girl_squad.filter(girl => girl.remaining_ego_percent < 100).length > 0
-        let choosenOption:LabyrinthOpponent|null = null;
-        let firstOption:LabyrinthOpponent|null = null;
+        const haveGirlWounded = unsafeWindow.girl_squad.filter(girl => girl.remaining_ego_percent < 100).length > 0;
         const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
         if (debugEnabled) logHHAuto("Options " + JSON.stringify(options));
         if (debugEnabled) logHHAuto("haveGirlWounded " + haveGirlWounded);
         if (debugEnabled) logHHAuto("chooseMoreReward " + chooseMoreReward);
-        const floor = Labyrinth.getCurrentFloorNumber();
 
-        if (options.length > 0) {
-            firstOption = options[0];
-        }
-        if (!haveGirlWounded || floor < 3) {
-            // remove Shrine
-            options = options.filter((option) => !option.isShrine);
-        } else if (floor >= 3 && options.filter((option) => option.isShrine).length > 0) {
-            // Keep only shrine
-            options = options.filter((option) => option.isShrine);
-        }
-        if (options.filter((option) => option.isTreasure).length > 0) {
-            // Keep only laby coins
-            options = options.filter((option) => option.isTreasure);
-        }
-        if (!chooseMoreReward && floor < 3 && options.filter((option) => option.opponentDifficulty == 1).length > 0) {
-            // Keep only easy opponent
-            options = options.filter((option) => option.opponentDifficulty == 1);
-        }
-        if (debugEnabled) logHHAuto("Options after filter" + JSON.stringify(options));
-
-        options.forEach((option) =>
-        {
-            let isBetter = false;
-            if(option.button && option.isNext) {
-                if (choosenOption == null)
-                {
-                    if(debugEnabled) logHHAuto('first');
-                    isBetter = true;
-                }
-                else if (chooseMoreReward)
-                {
-                    if (choosenOption.opponentDifficulty < option.opponentDifficulty) {
-                        if (debugEnabled) logHHAuto('More reward: higher difficulty group');
-                        isBetter = true;
-                    }
-                    else if (choosenOption.opponentDifficulty == option.opponentDifficulty && choosenOption.power > option.power) {
-                        if (debugEnabled) logHHAuto('More reward: Powerless opponent');
-                        isBetter = true;
-                    }
-                } else {
-                    if (choosenOption.isOpponent && !option.isOpponent)
-                    {
-                        if(debugEnabled) logHHAuto('Not opponent');
-                        isBetter = true;
-                    }
-                    else if (choosenOption.isOpponent && option.isOpponent && choosenOption.power > option.power )
-                    {
-                        if(debugEnabled) logHHAuto('Powerless opponent');
-                        isBetter = true;
-                    }
-                }
-            }
-
-            if (isBetter) {
-                choosenOption = option;
-            }
+        const liteOptions = options.map(option => ({
+            opponentDifficulty: option.opponentDifficulty,
+            isTreasure: option.isTreasure,
+            isShrine: option.isShrine,
+            isNext: option.isNext,
+            isOpponent: option.isOpponent,
+            power: option.power,
+            hasButton: option.button !== null && option.button !== undefined,
+            __orig: option,
+        }));
+        const chosen = decideBetterOption({
+            options: liteOptions,
+            chooseMoreReward,
+            haveGirlWounded,
+            floor: Labyrinth.getCurrentFloorNumber(),
         });
-        if (choosenOption == null && firstOption != null) choosenOption = firstOption;
-        return choosenOption;
+        if (debugEnabled) logHHAuto("Options after filter (handled by Labyrinth.pure)");
+        return chosen === null ? null as unknown as LabyrinthOpponent : (chosen as { __orig: LabyrinthOpponent }).__orig;
     }
 
     static appendChoosenTag(option){


### PR DESCRIPTION
## Summary

Stage 3 task 3.4: pure-function extraction for the labyrinth path pipeline and the `findBetter` selector.

## Plan deviation

The plan listed task 3.4 as "LabyrinthAuto -- entire decision pipeline". `LabyrinthAuto.run()` is a DOM / click / navigation sequence with no isolatable decision logic. The actual pure logic lives one module over, in `Labyrinth.ts`:

- `createPathFromMatrix` -- DFS over a row-of-cells matrix with adjacency rules
- `filterPathWithNoTreasue` (typo retained at the adapter boundary)
- `sortPathsByDifficulty`
- `findBetter` -- option ranker with a four-step filter cascade and two picker branches

The extraction targets those four functions.

## Pure module

`src/Module/Labyrinth.pure.ts` exports:

- `getNextIndices(currIdx, currLen, nextLen)` -- previously the inner closure of `createPathFromMatrix`
- `buildPathsFromMatrix<T>(matrix)` -- previously `Labyrinth.createPathFromMatrix`
- `filterPathsWithTreasure<T>(paths)` -- previously `Labyrinth.filterPathWithNoTreasue` (typo retained at the adapter boundary; pure function uses corrected name)
- `sortPathsByDifficulty<T>(paths)` -- previously `Labyrinth.sortPathsByDifficulty`
- `decideBetterOption<T>(state)` -- previously `Labyrinth.findBetter`

plus the typed `LabyrinthPathOpponent` / `LabyrinthOpponentLite` / `FindBetterState` shapes. The path-pipeline functions are generic over `LabyrinthPathOpponent` (only `opponentDifficulty` + `isTreasure` are read); `decideBetterOption` is generic over `LabyrinthOpponentLite` (adds `isShrine`, `isNext`, `isOpponent`, `power`, `hasButton`).

## Bit-for-bit equivalence

- `createPathFromMatrix` delegates to `buildPathsFromMatrix`.
- `filterPathWithNoTreasue` delegates to `filterPathsWithTreasure`.
- `sortPathsByDifficulty` delegates to `sortPathsByDifficultyPure`.
- `findBetter` projects the DOM-bound `LabyrinthOpponent[]` onto `LabyrinthOpponentLite[]` (mapping `option.button` truthiness onto `hasButton`, attaching `__orig` as a back-reference), delegates to `decideBetterOption`, and returns the original record.
- All filter cascades, the strict comparisons (`==`, `<`, `>`), and the fallback to `firstOption` when no eligible option survives are preserved.

## Behaviour delta

The five inner debug-log lines inside `findBetter` (`"first"`, `"More reward: higher difficulty group"`, `"More reward: Powerless opponent"`, `"Not opponent"`, `"Powerless opponent"`) are gone. They only fired when `debugEnabled === true` and never affected game state. The three outer debug logs (`"Options ..."`, `"haveGirlWounded ..."`, `"chooseMoreReward ..."`) plus the post-filter log are kept; the post-filter log now reads `"Options after filter (handled by Labyrinth.pure)"` because the filter cascade now runs inside the pure function.

## Tests

- 28 new tests in `spec/Module/Labyrinth.pure.spec.ts`.
- `getNextIndices`: 5 tests covering the boss-row collapse, the start-row expansion, the 2->3 expansion, the 3->2 contraction, and the unknown-shape fallback.
- `buildPathsFromMatrix`: 5 tests covering empty matrix, single-row, 1-2-1 branching, a realistic 2-3-2-1 traversal with all six expected paths, and empty-leading-row skipping.
- `filterPathsWithTreasure`: 3 tests covering no-treasure rejection, treasure-bearing path retention, and multi-treasure paths.
- `sortPathsByDifficulty`: 2 tests covering ascending sort over multi-cell paths and a single-cell-per-path matrix.
- `decideBetterOption`: 13 tests covering empty options, the `firstOption` fallback, the `hasButton`/`isNext` eligibility filter, the four filter-cascade branches (shrines on floor < 3 dropped, shrines on floor >= 3 with no wounded girls dropped, shrines kept when wounded girls + floor >= 3, treasures preferred when present, easy bias on floor < 3 without `chooseMoreReward`), the two `chooseMoreReward` picker branches (higher difficulty wins, lower power on tied difficulty wins), and the two default-branch picker cases (non-opponent beats opponent, lower power between two opponents).
- 692 total (664 + 28), 50 suites, 0 skipped. Existing Labyrinth-related specs untouched.

## Verification

- `npm test`: 692 passed / 0 skipped / 50 suites.
- `npm run build`: success. Bundle diff structural (new pure module appended; adapter call sites swapped to delegations; the five inner debug-log lines drop out as documented above). `HHAuto.user.js` rebuild discarded before commit per workflow rule.

No DOM, no jQuery, no `unsafeWindow` in the new pure module or the new tests.