### PR TITLE
refactor(test): extract pure decision logic from Bundles.getExpiryTime

### DIFF
--- a/spec/Module/Bundles.pure.spec.ts
+++ b/spec/Module/Bundles.pure.spec.ts
@@ -1,0 +1,70 @@
+import {
+    ExpiryTimeState,
+    decideExpiryTime,
+} from "../../src/Module/Bundles.pure";
+
+/**
+ * Pure-function tests for the bundle expiry-time decision.
+ *
+ * decideExpiryTime returns the deterministic seconds value the
+ * impure adapter then hands to setTimer. The 24-hour boundary is
+ * strict (the original code reads `if (freeBundleTimer < 24 * 3600)`)
+ * and exactly 24 * 3600 falls through to the fallback branch.
+ */
+describe("decideExpiryTime", () => {
+    const buildState = (
+        overrides: Partial<ExpiryTimeState> = {},
+    ): ExpiryTimeState => ({
+        scrapedSeconds: null,
+        fallbackSeconds: 9999,
+        ...overrides,
+    });
+
+    it("returns the fallback when no DOM timer was scraped", () => {
+        expect(
+            decideExpiryTime(buildState({ scrapedSeconds: null, fallbackSeconds: 1234 })),
+        ).toBe(1234);
+    });
+
+    it("returns the scraped value when below the 24h cap", () => {
+        expect(
+            decideExpiryTime(
+                buildState({ scrapedSeconds: 23 * 3600 + 59 * 60, fallbackSeconds: 1234 }),
+            ),
+        ).toBe(23 * 3600 + 59 * 60);
+    });
+
+    it("falls back at exactly 24h (strict < boundary)", () => {
+        expect(
+            decideExpiryTime(
+                buildState({ scrapedSeconds: 24 * 3600, fallbackSeconds: 1234 }),
+            ),
+        ).toBe(1234);
+    });
+
+    it("falls back when the scraped value is well above the 24h cap", () => {
+        expect(
+            decideExpiryTime(
+                buildState({ scrapedSeconds: 7 * 24 * 3600, fallbackSeconds: 1234 }),
+            ),
+        ).toBe(1234);
+    });
+
+    it("returns zero when the scraped timer is exactly zero", () => {
+        // Edge: a popup timer that has just expired. 0 < 24*3600, so
+        // the scraped value passes through unchanged.
+        expect(
+            decideExpiryTime(
+                buildState({ scrapedSeconds: 0, fallbackSeconds: 1234 }),
+            ),
+        ).toBe(0);
+    });
+
+    it("returns the typical mid-range scraped value untouched", () => {
+        expect(
+            decideExpiryTime(
+                buildState({ scrapedSeconds: 3600, fallbackSeconds: 1234 }),
+            ),
+        ).toBe(3600);
+    });
+});

--- a/src/Module/Bundles.pure.ts
+++ b/src/Module/Bundles.pure.ts
@@ -1,0 +1,44 @@
+// Bundles.pure.ts -- Pure decision logic for the free-bundle collector.
+//
+// Extracted from Bundles.getExpiryTime so the 24-hour threshold check
+// can be unit-tested without DOM access, jQuery, or randomInterval.
+//
+// The impure adapter Bundles.getExpiryTime scrapes the popup timer
+// from the DOM and falls back to maxCollectionDelay + jitter when the
+// timer is missing or claims to be more than a day in the future
+// (which happens with stale or malformed DOM state). This pure
+// function captures only the threshold decision; the fallback value
+// itself is computed by the adapter and passed in.
+
+export type ExpiryTimeState = {
+    /**
+     * The seconds value scraped from the popup timer span. null when
+     * the DOM lookup found no matching element. The original code
+     * keyed on $(...).length > 0 -- that boolean maps to (scraped !==
+     * null) here.
+     */
+    scrapedSeconds: number | null;
+    /**
+     * Pre-computed fallback seconds (maxCollectionDelay + jitter from
+     * the impure adapter). Used both when the timer is missing and
+     * when the scraped value is at-or-above the 24-hour cap.
+     */
+    fallbackSeconds: number;
+};
+
+/**
+ * Reproduce Bundles.getExpiryTime bit by bit:
+ *
+ *   if scrapedSeconds === null            -> fallbackSeconds
+ *   if scrapedSeconds >= 24 * 3600        -> fallbackSeconds
+ *   otherwise                              -> scrapedSeconds
+ *
+ * The 24-hour boundary is strict (<): the original code reads
+ * `if (freeBundleTimer < 24 * 3600) return freeBundleTimer`, so
+ * exactly 24 * 3600 falls through to the fallback branch.
+ */
+export function decideExpiryTime(state: ExpiryTimeState): number {
+    if (state.scrapedSeconds === null) return state.fallbackSeconds;
+    if (state.scrapedSeconds >= 24 * 3600) return state.fallbackSeconds;
+    return state.scrapedSeconds;
+}

--- a/src/Module/Bundles.ts
+++ b/src/Module/Bundles.ts
@@ -20,18 +20,23 @@ import {
 import { autoLoop, gotoPage } from "../Service/index";
 import { logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
+import { decideExpiryTime } from './Bundles.pure';
 
 export class Bundles {
     static getExpiryTime(){
         const timerRequest = `#popup-payment-container .period_deal .shop-timer span[rel=expires]`
 
+        let scrapedSeconds: number | null = null;
         if ($(timerRequest).length > 0) {
-            const freeBundleTimer = Number(convertTimeToInt($(timerRequest).text()));
-            logHHAuto('freeBundleTimer', freeBundleTimer);
-            if (freeBundleTimer < (24 * 3600)) return freeBundleTimer;
+            scrapedSeconds = Number(convertTimeToInt($(timerRequest).text()));
+            logHHAuto('freeBundleTimer', scrapedSeconds);
         }
-        logHHAuto('ERROR: can\'t get bundle expiry time, default to maxCollectionDelay');
-        return ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
+        const fallbackSeconds = ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
+        const decision = decideExpiryTime({ scrapedSeconds, fallbackSeconds });
+        if (scrapedSeconds === null || scrapedSeconds >= 24 * 3600) {
+            logHHAuto('ERROR: can\'t get bundle expiry time, default to maxCollectionDelay');
+        }
+        return decision;
     }
     static goAndCollectFreeBundles()
     {


### PR DESCRIPTION
## Summary

Stage 3 task 3.5: pure-function extraction for `Bundles.getExpiryTime`.

## Plan deviation

The plan listed task 3.5 as "Bundles -- visibility / trigger". Bundles has no visibility check (the trigger is `getSecondsLeft('nextFreeBundlesCollectTime')` external to the module). `Bundles.goAndCollectFreeBundles` is a DOM / click / `setTimeout` pipeline with no isolatable pure logic. The only piece of pure logic in the module is the 24-hour threshold check inside `Bundles.getExpiryTime`; this PR extracts that.

## Pure module

`src/Module/Bundles.pure.ts` exports `decideExpiryTime` and the typed `ExpiryTimeState` shape. The decision is a three-branch cascade:

- `scrapedSeconds === null` → `fallbackSeconds`
- `scrapedSeconds >= 24 * 3600` → `fallbackSeconds` (strict `<`)
- otherwise → `scrapedSeconds`

## Bit-for-bit equivalence

- `Bundles.getExpiryTime` scrapes the DOM, computes the fallback value, and delegates the threshold decision to `decideExpiryTime`.
- The original ERROR log line (`"can't get bundle expiry time, default to maxCollectionDelay"`) is preserved and now fires whenever the fallback branch is taken (both on a missing DOM timer and on a scraped value at or above 24h, matching the original fallthrough behaviour).
- The 24-hour boundary is strict (`<`): exactly `24 * 3600` falls through to the fallback branch, matching the original `if (freeBundleTimer < 24 * 3600)`.

## Behaviour delta

`randomInterval(60, 180)` is now called unconditionally as part of computing `fallbackSeconds`; previously it was only called in the fallback branch. `randomInterval` is read-only and has no game-state effect. Same delta type as League stage 1 task 1.1 (PR #1617) and Pantheon stage 3 task 3.2 (PR #1638).

## Tests

- 6 new tests in `spec/Module/Bundles.pure.spec.ts`.
- `decideExpiryTime`: 6 tests covering the missing-timer fallback, the just-below-24h pass-through (23h59m), the strict-`<` boundary at exactly 24h, a deeply-out-of-range scraped value (7 days), the zero-timer edge, and the typical mid-range pass-through.
- 698 total (692 + 6), 51 suites, 0 skipped.

## Verification

- `npm test`: 698 passed / 0 skipped / 51 suites.
- `npm run build`: success. Bundle diff structural (new pure module appended; adapter call site swapped to delegation). `HHAuto.user.js` rebuild discarded before commit per workflow rule.

No DOM, no jQuery, no `unsafeWindow` in the new pure module or the new tests.