### PR TITLE
refactor(test): extract pure decision logic from LivelyScene event

### DIFF
--- a/spec/Module/Events/LivelyScene.pure.spec.ts
+++ b/spec/Module/Events/LivelyScene.pure.spec.ts
@@ -1,0 +1,194 @@
+import {
+    CollectTriggerState,
+    PuzzlePieceLite,
+    SelectClaimableState,
+    decideCollectTrigger,
+    selectClaimablePieces,
+} from "../../../src/Module/Events/LivelyScene.pure";
+
+/**
+ * Pure-function tests for the Lively Scene event.
+ *
+ * decideCollectTrigger covers the three-branch OR cascade in
+ * LivelyScene.parse (autoCollect / manualCollectAll /
+ * end-of-event sweep). selectClaimablePieces covers the puzzle-piece
+ * filter in LivelyScene.parseClaimableRewards (unlock-and-not-claimed
+ * gate plus the per-piece eligibility cascade).
+ *
+ * Threshold contracts preserved from the original code:
+ *   - end-of-event branch is strict (<): remainingTime exactly equal
+ *     to limitBeforeEnd does NOT trigger autoCollectAll
+ *   - && binds tighter than || in both decisions
+ */
+describe("decideCollectTrigger", () => {
+    const buildState = (
+        overrides: Partial<CollectTriggerState> = {},
+    ): CollectTriggerState => ({
+        autoCollect: false,
+        manualCollectAll: false,
+        autoCollectAll: false,
+        remainingTime: 9999,
+        limitBeforeEnd: 1000,
+        ...overrides,
+    });
+
+    it("returns false when every flag is off", () => {
+        expect(decideCollectTrigger(buildState())).toBe(false);
+    });
+
+    it("returns true when only autoCollect is on", () => {
+        expect(decideCollectTrigger(buildState({ autoCollect: true }))).toBe(true);
+    });
+
+    it("returns true when only manualCollectAll is on", () => {
+        expect(
+            decideCollectTrigger(buildState({ manualCollectAll: true })),
+        ).toBe(true);
+    });
+
+    it("returns true when autoCollectAll is on AND remainingTime is below the limit", () => {
+        expect(
+            decideCollectTrigger(
+                buildState({
+                    autoCollectAll: true,
+                    remainingTime: 500,
+                    limitBeforeEnd: 1000,
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false when remainingTime exactly equals the limit (strict <)", () => {
+        expect(
+            decideCollectTrigger(
+                buildState({
+                    autoCollectAll: true,
+                    remainingTime: 1000,
+                    limitBeforeEnd: 1000,
+                }),
+            ),
+        ).toBe(false);
+    });
+
+    it("returns false when autoCollectAll is on but the event is far from over", () => {
+        expect(
+            decideCollectTrigger(
+                buildState({
+                    autoCollectAll: true,
+                    remainingTime: 9999,
+                    limitBeforeEnd: 1000,
+                }),
+            ),
+        ).toBe(false);
+    });
+});
+
+type TestPiece = PuzzlePieceLite & { id: string };
+
+describe("selectClaimablePieces", () => {
+    const piece = (
+        id: string,
+        overrides: Partial<TestPiece> = {},
+    ): TestPiece => ({
+        id,
+        reward_unlocked: true,
+        reward_claimed: false,
+        rewardType: "money",
+        ...overrides,
+    });
+
+    const buildState = (
+        overrides: Partial<SelectClaimableState> = {},
+    ): SelectClaimableState => ({
+        rewardsToCollect: [],
+        needToCollect: false,
+        needToCollectAll: false,
+        manualCollectAll: false,
+        ...overrides,
+    });
+
+    it("returns an empty list when the input is empty", () => {
+        expect(selectClaimablePieces<TestPiece>([], buildState())).toEqual([]);
+    });
+
+    it("drops every locked piece regardless of the cascade flags", () => {
+        const pieces = [
+            piece("a", { reward_unlocked: false }),
+            piece("b", { reward_unlocked: false }),
+        ];
+        expect(
+            selectClaimablePieces(
+                pieces,
+                buildState({ manualCollectAll: true }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("drops every already-claimed piece regardless of the cascade flags", () => {
+        const pieces = [
+            piece("a", { reward_claimed: true }),
+            piece("b", { reward_claimed: true }),
+        ];
+        expect(
+            selectClaimablePieces(
+                pieces,
+                buildState({ manualCollectAll: true }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("returns nothing when no eligibility flag is set, even with rewardsToCollect populated", () => {
+        const pieces = [piece("a", { rewardType: "money" })];
+        expect(
+            selectClaimablePieces(
+                pieces,
+                buildState({
+                    rewardsToCollect: ["money"],
+                    needToCollect: false,
+                }),
+            ),
+        ).toEqual([]);
+    });
+
+    it("keeps only pieces whose rewardType is on the allowlist when needToCollect is on", () => {
+        const pieces = [
+            piece("money", { rewardType: "money" }),
+            piece("xp", { rewardType: "xp" }),
+            piece("shards", { rewardType: "girl_shards" }),
+        ];
+        const result = selectClaimablePieces(
+            pieces,
+            buildState({
+                rewardsToCollect: ["money", "girl_shards"],
+                needToCollect: true,
+            }),
+        );
+        expect(result.map((p) => p.id)).toEqual(["money", "shards"]);
+    });
+
+    it("manualCollectAll keeps every unlocked-and-unclaimed piece (allowlist ignored)", () => {
+        const pieces = [
+            piece("money", { rewardType: "money" }),
+            piece("xp", { rewardType: "xp" }),
+            piece("locked", { reward_unlocked: false }),
+            piece("done", { reward_claimed: true }),
+        ];
+        const result = selectClaimablePieces(
+            pieces,
+            buildState({ manualCollectAll: true }),
+        );
+        expect(result.map((p) => p.id)).toEqual(["money", "xp"]);
+    });
+
+    it("needToCollectAll behaves like manualCollectAll for the eligibility cascade", () => {
+        const pieces = [
+            piece("money", { rewardType: "money" }),
+            piece("xp", { rewardType: "xp" }),
+        ];
+        const result = selectClaimablePieces(
+            pieces,
+            buildState({ needToCollectAll: true }),
+        );
+        expect(result.map((p) => p.id)).toEqual(["money", "xp"]);
+    });
+});

--- a/src/Module/Events/LivelyScene.pure.ts
+++ b/src/Module/Events/LivelyScene.pure.ts
@@ -1,0 +1,139 @@
+// LivelyScene.pure.ts -- Pure decision logic for the Lively Scene event.
+//
+// Extracted from LivelyScene.parse and LivelyScene.parseClaimableRewards
+// so the collect-trigger cascade and the puzzle-piece filter can be
+// unit-tested without DOM access, jQuery, storage, or game globals.
+//
+// Two decisions live here:
+//
+// 1. decideCollectTrigger -- the three-branch OR cascade in
+//    LivelyScene.parse that decides whether to invoke goAndCollect at
+//    all. Triggered by any of:
+//      - autoCollect setting on (continuous polling)
+//      - manualCollectAll flag on (user-initiated full sweep)
+//      - autoCollectAll setting on AND remainingTime is below the
+//        end-of-event threshold
+//
+// 2. selectClaimablePieces -- the loop in parseClaimableRewards that
+//    walks the puzzle-piece list and keeps only the entries that are
+//    unlocked-but-not-claimed AND match the per-piece eligibility
+//    rule: matching rewardType under needToCollect, OR needToCollectAll
+//    (any rewardType), OR manualCollectAll (any rewardType).
+
+export type CollectTriggerState = {
+    /**
+     * Setting_autoLivelySceneEventCollect -- the per-poll auto-collect
+     * setting.
+     */
+    autoCollect: boolean;
+    /**
+     * Temp_lseManualCollectAll -- user-initiated manual sweep flag,
+     * persisted between adapter calls so a multi-piece sweep can run
+     * to completion.
+     */
+    manualCollectAll: boolean;
+    /**
+     * Setting_autoLivelySceneEventCollectAll -- end-of-event sweep
+     * setting. Only fires when remainingTime is below limitBeforeEnd.
+     */
+    autoCollectAll: boolean;
+    /**
+     * Seconds left on the event timer (parsed from the DOM by the
+     * impure adapter; null is not modelled here -- the adapter passes
+     * a default value when the timer is missing).
+     */
+    remainingTime: number;
+    /**
+     * getLimitTimeBeforeEnd() result. Strict < boundary: remainingTime
+     * exactly equal to limitBeforeEnd does NOT trigger autoCollectAll.
+     */
+    limitBeforeEnd: number;
+};
+
+/**
+ * Reproduce the OR cascade in LivelyScene.parse bit by bit:
+ *
+ *   autoCollect
+ *   || manualCollectAll
+ *   || (remainingTime < limitBeforeEnd && autoCollectAll)
+ *
+ * Operator precedence preserved: && binds tighter than ||, so the
+ * end-of-event branch parses as one parenthesised conjunction.
+ */
+export function decideCollectTrigger(state: CollectTriggerState): boolean {
+    return (
+        state.autoCollect
+        || state.manualCollectAll
+        || (state.remainingTime < state.limitBeforeEnd && state.autoCollectAll)
+    );
+}
+
+/**
+ * Minimum subset of puzzle-piece fields the filter reads. The impure
+ * adapter computes rewardType from the piece's reward.shards /
+ * reward.rewards[0].type using optional chaining and passes the
+ * result here.
+ */
+export interface PuzzlePieceLite {
+    reward_unlocked: boolean;
+    reward_claimed: boolean;
+    rewardType: string;
+}
+
+export type SelectClaimableState = {
+    /**
+     * Setting_autoLivelySceneEventCollectablesList -- list of reward
+     * types the user opted into collecting on the per-poll path.
+     */
+    rewardsToCollect: string[];
+    /**
+     * checkTimer('nextLivelySceneEventCollectTime') AND
+     * Setting_autoLivelySceneEventCollect === "true". The adapter
+     * computes both factors and hands in the conjunction.
+     */
+    needToCollect: boolean;
+    /**
+     * remainingTime < limitBeforeEnd AND
+     * Setting_autoLivelySceneEventCollectAll === "true". The adapter
+     * computes both factors and hands in the conjunction.
+     */
+    needToCollectAll: boolean;
+    /**
+     * Same flag as in CollectTriggerState; the user-initiated full
+     * sweep ignores rewardsToCollect.
+     */
+    manualCollectAll: boolean;
+};
+
+/**
+ * Reproduce the loop in LivelyScene.parseClaimableRewards bit by bit.
+ * Walks the input list and keeps every piece for which:
+ *
+ *   reward_unlocked AND NOT reward_claimed
+ *   AND (
+ *     (rewardsToCollect.includes(rewardType) AND needToCollect)
+ *     OR needToCollectAll
+ *     OR manualCollectAll
+ *   )
+ *
+ * Operator precedence preserved (&& binds tighter than ||): the per-
+ * type allowlist only gates the per-poll branch; the two sweep modes
+ * accept any rewardType.
+ */
+export function selectClaimablePieces<T extends PuzzlePieceLite>(
+    pieces: T[],
+    state: SelectClaimableState,
+): T[] {
+    const claimable: T[] = [];
+    for (const piece of pieces) {
+        if (piece.reward_unlocked && !piece.reward_claimed) {
+            const allowedByType =
+                state.rewardsToCollect.includes(piece.rewardType)
+                && state.needToCollect;
+            if (allowedByType || state.needToCollectAll || state.manualCollectAll) {
+                claimable.push(piece);
+            }
+        }
+    }
+    return claimable;
+}

--- a/src/Module/Events/LivelyScene.ts
+++ b/src/Module/Events/LivelyScene.ts
@@ -26,6 +26,11 @@ import { autoLoop, gotoPage } from "../../Service/index";
 import { isJSON, logHHAuto } from "../../Utils/index";
 import { HHStoredVarPrefixKey, SK, TK } from "../../config/index";
 import { HHEvent, HHEventData, HHEventList, KKPuzzlePieces } from "../../model/index";
+import {
+    PuzzlePieceLite,
+    decideCollectTrigger,
+    selectClaimablePieces,
+} from "./LivelyScene.pure";
 
 export class LivelyScene {
 
@@ -53,34 +58,38 @@ export class LivelyScene {
 
         const manualCollectAll = getStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll) === 'true';
 
-        if (getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true" || manualCollectAll
-            || remainingTime < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll) === "true") {
+        const shouldTrigger = decideCollectTrigger({
+            autoCollect: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true",
+            manualCollectAll,
+            autoCollectAll: getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll) === "true",
+            remainingTime,
+            limitBeforeEnd: getLimitTimeBeforeEnd(),
+        });
+        if (shouldTrigger) {
             LivelyScene.goAndCollect(remainingTime, manualCollectAll);
         }
 
     }
 
     static parseClaimableRewards(remainingTime: number, manualCollectAll = false) {
-        const claimablePieces: KKPuzzlePieces[] = [];
         const puzzlePieces: KKPuzzlePieces[] = getHHVars('current_event.event_data.puzzle_pieces');
         const rewardsToCollect = getStoredJSON(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectablesList, []);
         const needToCollectAll = remainingTime < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll) === "true";
         const needToCollect = (checkTimer('nextLivelySceneEventCollectTime') && getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true");
 
-        // logHHAuto("Checking double penetration event for collectable rewards.");
+        const projected: (PuzzlePieceLite & { __orig: KKPuzzlePieces })[] = puzzlePieces.map((piece) => ({
+            reward_unlocked: piece.reward_unlocked,
+            reward_claimed: piece.reward_claimed,
+            rewardType: piece?.reward?.shards ? 'girl_shards' : piece?.reward?.rewards[0].type,
+            __orig: piece,
+        }));
 
-        for (let currentPiece = 0; currentPiece < puzzlePieces.length; currentPiece++) {
-            const puzzlePiece:KKPuzzlePieces = puzzlePieces[currentPiece];
-            if (puzzlePiece.reward_unlocked && !puzzlePiece.reward_claimed) {
-                let rewardType = puzzlePiece?.reward?.shards ? 'girl_shards' : puzzlePiece?.reward?.rewards[0].type;
-
-                if (rewardsToCollect.includes(rewardType) && needToCollect || needToCollectAll || manualCollectAll) {
-                    // logHHAuto(`Reward to collect ${puzzlePiece?.reward?.rewards[0].value}x${puzzlePiece?.reward?.rewards[0].type}`);
-                    claimablePieces.push(puzzlePiece);
-                }
-            }
-
-        }
+        const claimablePieces = selectClaimablePieces(projected, {
+            rewardsToCollect,
+            needToCollect,
+            needToCollectAll,
+            manualCollectAll,
+        }).map((p) => p.__orig);
 
         logHHAuto('claimablePieces', claimablePieces);
         return claimablePieces;


### PR DESCRIPTION
## Summary

Stage 3 task 3.6 (LivelyScene half): pure-function extraction for the Lively Scene event.

The other half of task 3.6 -- BossBang -- is documented as a skip in the accompanying doc PR (no isolatable pure logic; the module is a DOM-driven team-search loop with `click()` side effects, the rest is DOM / click / navigation).

## Plan deviation

The plan listed task 3.6 as "LivelyScene, BossBang -- isAvailable, timer reset". The literal `isAvailable` for LivelyScene is `isEnabled`, a trivial Config-flag wrapper that does not warrant a pure extraction (matches the strategy's "no trivial getters" rule). The literal "timer reset" in `goAndCollect` is a single `setTimer + setStoredValue` pair with no branching; nothing pure to extract.

What is pure in the module: the two OR cascades inside `parse` and `parseClaimableRewards`. This PR extracts both.

## Pure module

`src/Module/Events/LivelyScene.pure.ts` exports:

- `decideCollectTrigger(state)` -- three-branch OR cascade in `LivelyScene.parse` that decides whether `goAndCollect` is invoked. Triggered by `autoCollect`, `manualCollectAll`, or (`remainingTime < limitBeforeEnd && autoCollectAll`).
- `selectClaimablePieces<T>(pieces, state)` -- filter loop in `parseClaimableRewards` that walks the puzzle-piece list and keeps unlocked-and-unclaimed entries matching the per-piece eligibility cascade (`rewardsToCollect.includes(rewardType) && needToCollect`, OR `needToCollectAll`, OR `manualCollectAll`).

Plus the typed `CollectTriggerState` / `PuzzlePieceLite` / `SelectClaimableState` shapes.

## Bit-for-bit equivalence

- `LivelyScene.parse` builds the input state and delegates the OR cascade to `decideCollectTrigger`. The resulting boolean gates the `goAndCollect` call exactly as before.
- `LivelyScene.parseClaimableRewards` projects each puzzle-piece onto `PuzzlePieceLite` (mapping the optional-chained `reward.shards`/`.rewards[0].type` onto a single `rewardType` string, attaching `__orig` as a back-reference), delegates the loop to `selectClaimablePieces`, and unwraps the matched `__orig` records.
- Operator precedence preserved: `&&` binds tighter than `||` in both decisions; the end-of-event branch stays parenthesised, the per-type allowlist only gates the per-poll branch.
- The strict `<` boundary on `remainingTime` vs `limitBeforeEnd` is preserved.

## Tests

- 13 new tests in `spec/Module/Events/LivelyScene.pure.spec.ts`.
- `decideCollectTrigger`: 6 tests covering all-off, `autoCollect`-only, `manualCollectAll`-only, `autoCollectAll` with low `remainingTime`, the strict-`<` boundary at `remainingTime === limitBeforeEnd`, and `autoCollectAll` with high `remainingTime`.
- `selectClaimablePieces`: 7 tests covering empty input, all-locked rejection, all-claimed rejection, allowlist-without-`needToCollect` rejection, allowlist with `needToCollect` filter (positive and negative), `manualCollectAll` override (allowlist ignored), and `needToCollectAll` override (allowlist ignored).
- 711 total (698 + 13), 52 suites, 0 skipped.

## Verification

- `npm test`: 711 passed / 0 skipped / 52 suites.
- `npm run build`: success. Bundle diff structural (new pure module appended; adapter call sites swapped to delegations). `HHAuto.user.js` rebuild discarded before commit per workflow rule.

No DOM, no jQuery, no `unsafeWindow` in the new pure module or the new tests.