### PR TITLE
docs(test): tick task 3.6 in stage 3 (LivelyScene + BossBang)

### DIFF
--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -5,10 +5,10 @@ and add the date plus commit hash in the Status field.
 
 ## Status
 
-- Current stage: **3 in progress**, tasks 3.1 - 3.5 done; next is task 3.6 (LivelyScene + BossBang)
-- Last completed task: 3.5 (Bundles `getExpiryTime` pure-function extraction + decision tests)
+- Current stage: **3 in progress**, tasks 3.1 - 3.6 done; next is task 3.7 (stage 3 closure)
+- Last completed task: 3.6 (LivelyScene pure-function extraction + decision tests; BossBang skipped after inspection)
 - Open reminder: issue #1614 (CI coverage reporting; tracked, will be picked up in stage 4)
-- Next step: stage 3 task 3.6 (LivelyScene + BossBang -- isAvailable, timer reset). Inspect both modules for decision points; extract pure logic if a stage-1-style extraction fits, else document the substitution.
+- Next step: stage 3 task 3.7 (stage 3 closure). Summarise the six tasks (3.1 - 3.6) and finalise the change log; close stage 3.
 - Carried-forward reminders for stage 3:
   - `parseGirlsFromGameData(rawData) -> Girl[]` (deferred from stage 1 task 1.3): the haremGirl / event fixtures are sized to feed this parser.
   - Champion-map fixture deferral: page 8 (`/champions-map.html`) carries no champion JSON in the dump (DOM-only). Needs a different testing approach for DOM-derived state before a map fixture can be produced.
@@ -554,7 +554,38 @@ module.
     stage 3 task 3.2.
   - Tests: 698 passed (692 + 6), 0 skipped, 51 suites.
   - Merged via PR #1643, commit cc8c80c.
-- [ ] **3.6** LivelyScene, BossBang -- isAvailable, timer reset
+- [x] **3.6** LivelyScene + BossBang -- partial extraction, BossBang skipped (2026-05-08)
+  - Plan deviation (agreed with the user before implementation):
+    plan listed "isAvailable, timer reset" for both modules.
+    Reality:
+    * LivelyScene: `isEnabled` is a trivial Config-flag wrapper
+      (matches the strategy's "no trivial getters" rule). The
+      "timer reset" path in `goAndCollect` is a single
+      `setTimer + setStoredValue` pair with no branching.
+      What is pure: the two OR cascades inside `parse`
+      (`decideCollectTrigger`) and `parseClaimableRewards`
+      (`selectClaimablePieces`).
+    * BossBang: `parse()` is a DOM-driven team-search loop with
+      `click()` side effects in the loop body. `goToFightPage`
+      and `skipFightPage` are DOM / click / navigation. There is
+      no `isAvailable` check; the timer is unconditional from
+      the DOM with no reset branch. No isolatable pure logic.
+      Skipped (same rationale class as 3.3 MonthlyCard).
+  - New module: `src/Module/Events/LivelyScene.pure.ts` exports
+    `decideCollectTrigger` and `selectClaimablePieces`, plus the
+    typed `CollectTriggerState` / `PuzzlePieceLite` /
+    `SelectClaimableState` shapes.
+  - `LivelyScene.parse` builds the input state and delegates the
+    OR cascade. `LivelyScene.parseClaimableRewards` projects each
+    puzzle-piece onto `PuzzlePieceLite` (mapping the
+    optional-chained `reward.shards`/`.rewards[0].type` onto a
+    single `rewardType` string, attaching `__orig` as a
+    back-reference) and delegates the loop.
+  - Bit-for-bit equivalent: operator precedence preserved
+    (`&&` binds tighter than `||`), strict `<` boundary on
+    `remainingTime` vs `limitBeforeEnd` preserved.
+  - Tests: 711 passed (698 + 13), 0 skipped, 52 suites.
+  - Merged via PR #1645, commit 546df93.
 - [ ] **3.7** Stage 3 finished -- branch `feat/test-decision-logic`
 
 ### Stage 4 -- reliability layer (1-2 days)
@@ -660,3 +691,4 @@ findNextChamptionTime with 1 test.
 | 2026-05-08 | Task 3.3 skipped: MonthlyCard has no claim flow / timer / hero-level gate -- its single public method `updateInputPattern()` only builds regex strings for the settings UI, fully covered by the existing `MonthlyCards.spec.ts` (24 tests). No code change, no PR, only doc update; tests stay at 664 / 49 suites. |
 | 2026-05-08 | Task 3.4 done: Labyrinth path pipeline pure-function extraction (`getNextIndices`, `buildPathsFromMatrix`, `filterPathsWithTreasure`, `sortPathsByDifficulty`, `decideBetterOption`) + 28 new pure tests (692 total), bundle diff structural, plan deviation in module choice documented in the task entry (`LabyrinthAuto.run()` has no isolatable pure logic; the actual decision pipeline lives in `Labyrinth.ts`); behaviour delta documented (five inner debug-log lines inside `findBetter` removed, all under `debugEnabled === true` and without game-state effects), merged via PR #1641 (commit c16adc2) |
 | 2026-05-08 | Task 3.5 done: Bundles `getExpiryTime` pure-function extraction (`decideExpiryTime`) + 6 new pure tests (698 total), bundle diff structural, plan deviation in scope documented in the task entry (no visibility/trigger logic in the module; only the 24-hour threshold check is pure); behaviour delta documented (`randomInterval(60, 180)` now called unconditionally, mirroring League stage 1 task 1.1 and Pantheon stage 3 task 3.2), merged via PR #1643 (commit cc8c80c) |
+| 2026-05-08 | Task 3.6 done: LivelyScene pure-function extraction (`decideCollectTrigger`, `selectClaimablePieces`) + 13 new pure tests (711 total), bundle diff structural; BossBang skipped (no isolatable pure logic, same rationale class as 3.3 MonthlyCard); plan deviation in scope documented in the task entry (`isAvailable` / `timer reset` headings did not map onto either module's actual code), merged via PR #1645 (commit 546df93) |


### PR DESCRIPTION
## Summary

Doc update reflecting stage 3 task 3.6.

- Status block flipped to "stage 3 in progress; tasks 3.1 - 3.6 done; next is 3.7 (stage 3 closure)".
- Task 3.6 ticked with the plan-deviation summary covering both modules:
  - **LivelyScene**: `isAvailable` is a trivial Config-flag wrapper, timer reset has no branch; the actual pure logic is the two OR cascades inside `parse` (`decideCollectTrigger`) and `parseClaimableRewards` (`selectClaimablePieces`), both extracted.
  - **BossBang**: `parse()` is a DOM-driven team-search loop with `click()` side effects; `goToFightPage` / `skipFightPage` are DOM / click / navigation; no `isAvailable` check, timer has no reset branch. No isolatable pure logic. Skipped, same rationale class as 3.3 MonthlyCard.
- Change-log row appended for 2026-05-08 referencing PR #1645 / commit `546df93`.

No code changes.