### PR TITLE
chore(inspector): bump to v4.6.1 with auto-update URLs

### DIFF
--- a/bonus-scripts/HHAuto_debug_inspector.user.js
+++ b/bonus-scripts/HHAuto_debug_inspector.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HHAuto Debug - Full Data Inspector
 // @namespace    HHAuto_Debug
-// @version      4.6.0
+// @version      4.6.1
 // @description  Full game data dumper. Works in both iframe and top-window mode. Auto-tour with persistent state across page reloads. Manual phase for protected pages. Passive XHR observer captures Game-AJAX responses per step (read-only).
 // @match        http*://*.haremheroes.com/*
 // @match        http*://*.hentaiheroes.com/*
@@ -17,12 +17,14 @@
 // @grant        GM_xmlhttpRequest
 // @run-at       document-idle
 // @noframes
+// @updateURL    https://github.com/OldRon1977/HHauto/raw/main/bonus-scripts/HHAuto_debug_inspector.user.js
+// @downloadURL  https://github.com/OldRon1977/HHauto/raw/main/bonus-scripts/HHAuto_debug_inspector.user.js
 // ==/UserScript==
 
 (function() {
     'use strict';
 
-    const VERSION = '4.6.0';
+    const VERSION = '4.6.1';
     const LOG_PREFIX = '[Inspector v' + VERSION + ']';
 
     // ==================== CONFIGURATION ====================


### PR DESCRIPTION
Adds `@updateURL` and `@downloadURL` to the inspector userscript
header so Tampermonkey can fetch new versions automatically:

`
https://github.com/OldRon1977/HHauto/raw/main/bonus-scripts/HHAuto_debug_inspector.user.js
`

Same convention as `HHAuto.user.js`. Bumps `@version` and the
in-script `VERSION` constant from `4.6.0` to `4.6.1`.

No functional change.

## Verification

- `node -c bonus-scripts/HHAuto_debug_inspector.user.js` -- syntax OK.
- `npm test`: 717 passed / 53 suites.
- `npm run build`: succeeds.