### PR TITLE
test(storage-migration): cover safeJsonParse / isJSON / getStoredJSON

### DIFF
--- a/spec/Service/StorageMigration.spec.ts
+++ b/spec/Service/StorageMigration.spec.ts
@@ -1,0 +1,223 @@
+import { isJSON, safeJsonParse } from "../../src/Utils/index";
+import { getStoredJSON, getStoredValue, setStoredValue } from "../../src/Helper/StorageHelper";
+import { HHStoredVarPrefixKey, SK, TK } from "../../src/config/index";
+import { loadFixture } from "../testHelpers/Fixtures";
+
+/**
+ * Storage migration spec -- stage 4 task 4.2.
+ *
+ * Stage-4 reliability: when an HHAuto release reads a storage value
+ * that was written by an older release (different format, different
+ * type, missing key, broken JSON), the reader must not throw. The
+ * default value falls in if the input cannot be parsed.
+ *
+ * The spec exercises three layers:
+ *   1. `safeJsonParse` -- the central try/catch + default-value helper
+ *   2. `isJSON` -- the regex-based pre-check used as a guard before
+ *      direct `JSON.parse` calls in modules
+ *   3. `getStoredJSON` -- the public reader that delegates to
+ *      `safeJsonParse`
+ *
+ * Plus a smoke pass over a real settings snapshot from
+ * `INPUT/HH_DebugLog_*.log` to confirm that current production
+ * payloads survive the readers without crashing.
+ */
+
+interface SettingSnapshot {
+    [prefixedKey: string]: string;
+}
+
+describe("storage migration -- safeJsonParse", () => {
+    it("returns the default for undefined input", () => {
+        expect(safeJsonParse(undefined, "fallback")).toBe("fallback");
+    });
+
+    it("returns the default for null input", () => {
+        expect(safeJsonParse(null, "fallback")).toBe("fallback");
+    });
+
+    it("returns the default for an empty string", () => {
+        expect(safeJsonParse("", { ok: false })).toEqual({ ok: false });
+    });
+
+    it("returns the default for malformed JSON", () => {
+        expect(safeJsonParse("{not: json}", [])).toEqual([]);
+        expect(safeJsonParse("[1,2,", [])).toEqual([]);
+        expect(safeJsonParse("undefined", null)).toBeNull();
+    });
+
+    it("parses well-formed JSON arrays", () => {
+        expect(safeJsonParse("[]", null)).toEqual([]);
+        expect(safeJsonParse("[1,2,3]", null)).toEqual([1, 2, 3]);
+    });
+
+    it("parses well-formed JSON objects", () => {
+        expect(safeJsonParse('{"a":1,"b":"x"}', null)).toEqual({ a: 1, b: "x" });
+    });
+
+    it("parses JSON primitives", () => {
+        expect(safeJsonParse("true", null)).toBe(true);
+        expect(safeJsonParse("false", null)).toBe(false);
+        expect(safeJsonParse("42", null)).toBe(42);
+        expect(safeJsonParse('"hello"', null)).toBe("hello");
+    });
+
+    it("supports a reviver callback", () => {
+        const result = safeJsonParse<{ x: number }>(
+            '{"x":3}',
+            { x: 0 },
+            (key, value) => (key === "x" ? value * 2 : value),
+        );
+        expect(result.x).toBe(6);
+    });
+
+    it("falls back if the reviver throws", () => {
+        const result = safeJsonParse(
+            '{"x":1}',
+            { fallback: true },
+            () => { throw new Error("boom"); },
+        );
+        expect(result).toEqual({ fallback: true });
+    });
+});
+
+describe("storage migration -- isJSON", () => {
+    it.each([
+        [undefined, false],
+        [null, false],
+        ["", false],
+        ["   ", false],
+    ])("rejects empty/whitespace-ish input %p", (input, expected) => {
+        expect(isJSON(input)).toBe(expected);
+    });
+
+    it("recognises JSON arrays and objects", () => {
+        expect(isJSON("[]")).toBe(true);
+        expect(isJSON("[1,2,3]")).toBe(true);
+        expect(isJSON('{"a":1}')).toBe(true);
+    });
+
+    it("recognises JSON primitives", () => {
+        expect(isJSON("true")).toBe(true);
+        expect(isJSON("false")).toBe(true);
+        expect(isJSON("null")).toBe(true);
+        expect(isJSON("42")).toBe(true);
+        expect(isJSON('"hello"')).toBe(true);
+    });
+
+    it("rejects clearly malformed JSON", () => {
+        // isJSON is the pre-check used in front of `JSON.parse` calls
+        // in modules. It is intentionally regex-based and not as strict
+        // as `JSON.parse` itself -- some malformed payloads slip through
+        // (e.g. `"[1,2,"`). The hard guard against malformed input
+        // remains `safeJsonParse`, which catches the real `JSON.parse`
+        // exception. The cases below are the unambiguous rejects.
+        expect(isJSON("{not: json}")).toBe(false);
+        expect(isJSON("undefined")).toBe(false);
+        expect(isJSON("not-json-at-all")).toBe(false);
+    });
+
+    it("documents the known liberal-regex behavior", () => {
+        // Trailing-comma input slips through the regex pre-check.
+        // Callers must still wrap the parse in safeJsonParse (try/catch).
+        expect(isJSON("[1,2,")).toBe(true);
+        // The matching safeJsonParse call must not blow up:
+        expect(safeJsonParse("[1,2,", null)).toBeNull();
+    });
+});
+
+describe("storage migration -- getStoredJSON", () => {
+    const KEY = HHStoredVarPrefixKey + SK.autoSeasonCollectablesList;
+
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    it("returns the default when the key is missing from storage", () => {
+        expect(getStoredJSON(KEY, ["default-marker"])).toEqual(["default-marker"]);
+    });
+
+    it("returns the default when the key is the empty string", () => {
+        setStoredValue(KEY, "");
+        expect(getStoredJSON(KEY, ["default-marker"])).toEqual(["default-marker"]);
+    });
+
+    it("returns the default when the stored value is malformed JSON", () => {
+        setStoredValue(KEY, "{not: json}");
+        expect(getStoredJSON(KEY, ["default-marker"])).toEqual(["default-marker"]);
+    });
+
+    it("returns the default for an unregistered key (getStoredValue -> undefined)", () => {
+        expect(getStoredJSON("HHAuto_Setting_does_not_exist", { ok: false })).toEqual({ ok: false });
+    });
+
+    it("parses a well-formed JSON-array stored value", () => {
+        setStoredValue(KEY, "[1,2,3]");
+        expect(getStoredJSON<number[]>(KEY, [])).toEqual([1, 2, 3]);
+    });
+
+    it("parses a well-formed JSON-object stored value", () => {
+        // pick a key that accepts an object payload via the storage round-trip
+        const haremSizeKey = HHStoredVarPrefixKey + TK.HaremSize;
+        setStoredValue(haremSizeKey, JSON.stringify({ count: 1716, count_date: 1715000000 }));
+        const result = getStoredJSON<{ count: number; count_date: number }>(haremSizeKey, { count: 0, count_date: 0 });
+        expect(result).toEqual({ count: 1716, count_date: 1715000000 });
+    });
+});
+
+describe("storage migration -- real snapshot smoke", () => {
+    let snapshot: SettingSnapshot;
+
+    beforeAll(() => {
+        snapshot = loadFixture("storage-snapshot", "setting-snapshot") as SettingSnapshot;
+    });
+
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    it("loads with at least one localStorage and one sessionStorage entry", () => {
+        const localKeys = Object.keys(snapshot).filter(k => k.startsWith("localStorage."));
+        const sessionKeys = Object.keys(snapshot).filter(k => k.startsWith("sessionStorage."));
+        expect(localKeys.length).toBeGreaterThan(0);
+        expect(sessionKeys.length).toBeGreaterThan(0);
+    });
+
+    it("hydrates every snapshot entry into the matching storage and reads it back via getStoredValue", () => {
+        for (const [prefixedKey, value] of Object.entries(snapshot)) {
+            const [bucket, ...rest] = prefixedKey.split(".");
+            const key = rest.join(".");
+            if (bucket === "localStorage") {
+                window.localStorage.setItem(key, value);
+            } else if (bucket === "sessionStorage") {
+                window.sessionStorage.setItem(key, value);
+            } else {
+                throw new Error(`Unexpected bucket prefix: ${bucket}`);
+            }
+        }
+        for (const prefixedKey of Object.keys(snapshot)) {
+            const key = prefixedKey.split(".").slice(1).join(".");
+            // Some keys are not registered in HHStoredVars -- getStoredValue then returns undefined.
+            // The contract under test is no-throw; both undefined and the original value are acceptable.
+            expect(() => getStoredValue(key)).not.toThrow();
+        }
+    });
+
+    it("forces every snapshot value through getStoredJSON without throwing", () => {
+        for (const [prefixedKey, value] of Object.entries(snapshot)) {
+            const [bucket, ...rest] = prefixedKey.split(".");
+            const key = rest.join(".");
+            if (bucket === "localStorage") {
+                window.localStorage.setItem(key, value);
+            } else if (bucket === "sessionStorage") {
+                window.sessionStorage.setItem(key, value);
+            }
+            // Default is an empty array; the call must return either the parsed value
+            // (for the JSON-array payloads in the fixture) or the default for the
+            // non-JSON entries -- never throw.
+            expect(() => getStoredJSON(key, [] as unknown[])).not.toThrow();
+        }
+    });
+});

--- a/spec/fixtures/storage-snapshot/README.md
+++ b/spec/fixtures/storage-snapshot/README.md
@@ -1,0 +1,65 @@
+# storage-snapshot fixtures
+
+## Source
+
+- Log: `INPUT/HH_DebugLog_1778140621437.log` (HHAuto v7.35.25 export)
+- Capture context: ``HHAuto`` user-script writes a debug snapshot of all
+  registered ``HHStoredVars`` keys to a JSON file. Format is a flat
+  object with prefix-encoded keys: ``localStorage.<key>`` /
+  ``sessionStorage.<key>``.
+- This fixture stores 21 keys covering distinct value shapes used as
+  inputs for the storage-migration helpers tests.
+
+## File
+
+- `setting-snapshot.json` -- 21 entries selected from the log.
+
+## Selection rationale
+
+One sample per value shape that the storage helpers (`safeJsonParse`,
+`isJSON`, `getStoredJSON`) have to survive without crashing:
+
+- boolean strings (e.g. `"false"`, `"true"`)
+- integer strings (e.g. `"500000000"`, `"20000"`)
+- semicolon-separated lists (e.g. `"B1;B2;B3;B4"`,
+  `"1;2;3;4;5;6;7;8;9;10;..."`)
+- JSON-array strings (e.g. `"[]"`)
+- custom multi-segment strings (e.g.
+  `"140-320/Sleep:28800-30400|Active:250-460|..."`)
+- sessionStorage temp entries (e.g.
+  `"HHAuto_Temp_sandalwoodMaxUsages": "11"`)
+
+## Redactions
+
+None. The HHAuto debug log carries Setting / Temp values only -- no
+hero name, no IDs, no auth tokens. The 21 selected keys were
+spot-checked against the PII inventory: each value is either a
+boolean string, a number string, a delimiter-separated list of fixed
+tokens (booster IDs, filter indices), an empty JSON literal, or a
+configuration string with no personal identifiers.
+
+## Consumers
+
+- `src/Helper/StorageHelper.ts`:
+  - `getStoredValue(key)` -- raw lookup against `HHStoredVars`
+  - `getStoredJSON(key, default, reviver?)` -- delegates to
+    `safeJsonParse`
+- `src/Utils/Utils.ts`:
+  - `isJSON(str)` -- regex-based pre-check
+  - `safeJsonParse(json, default, reviver?)` -- try/catch wrapper
+
+The schema test reads each entry, sets it on the corresponding
+`window.localStorage` / `window.sessionStorage`, then exercises the
+reader for that key plus generic edge cases (missing key, empty
+string, malformed JSON).
+
+## How to refresh
+
+If a fresh debug log is captured later (e.g. after a new HHAuto
+release introduces new keys):
+
+1. Pick the most recent file in `INPUT/HH_DebugLog_*.log`.
+2. Re-pick keys that cover the listed value shapes; if a new shape
+   class appears (e.g. nested JSON object instead of a primitive
+   string), document it here and add a sample.
+3. Verify the snapshot still passes the migration spec.

--- a/spec/fixtures/storage-snapshot/setting-snapshot.json
+++ b/spec/fixtures/storage-snapshot/setting-snapshot.json
@@ -1,0 +1,23 @@
+{
+  "localStorage.HHAuto_Setting_settPerTab": "false",
+  "localStorage.HHAuto_Setting_autoAffW": "false",
+  "localStorage.HHAuto_Setting_autoBuyBoosters": "false",
+  "localStorage.HHAuto_Setting_paranoia": "true",
+  "localStorage.HHAuto_Setting_master": "false",
+  "localStorage.HHAuto_Setting_autoAff": "500000000",
+  "localStorage.HHAuto_Setting_autoExp": "500000000",
+  "localStorage.HHAuto_Setting_autoStats": "500000000",
+  "localStorage.HHAuto_Setting_autoSalaryMinSalary": "20000",
+  "localStorage.HHAuto_Setting_maxBooster": "10",
+  "localStorage.HHAuto_Setting_minShardsX10": "10",
+  "localStorage.HHAuto_Setting_autoBuyBoostersFilter": "B1;B2;B3;B4",
+  "localStorage.HHAuto_Setting_autoChampsFilter": "1;2;3;4;5;6",
+  "localStorage.HHAuto_Setting_autoEquipBoostersSlots": "B1;B2;B3;B4",
+  "localStorage.HHAuto_Setting_autoPowerPlacesIndexFilter": "1;2;3",
+  "localStorage.HHAuto_Setting_eventTrollOrder": "1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20",
+  "localStorage.HHAuto_Setting_autoSeasonCollectablesList": "[]",
+  "localStorage.HHAuto_Setting_autoPentaDrillCollectablesList": "[]",
+  "localStorage.HHAuto_Setting_autoFreeBundlesCollectablesList": "[]",
+  "localStorage.HHAuto_Setting_paranoiaSettings": "140-320/Sleep:28800-30400|Active:250-460|Casual:1500-2700/6:Sleep|8:Casual|10:Active|12:Casual|14:Active|18:Casual|20:Active|22:Casual|24:Sleep",
+  "sessionStorage.HHAuto_Temp_sandalwoodMaxUsages": "11"
+}


### PR DESCRIPTION
Stage 4 task 4.2 first slice. Adds 26 tests covering the three
storage-migration helpers and a real settings snapshot smoke pass.

## Migration story

- `safeJsonParse` is the central try/catch + default-value helper used
  by every JSON-typed read path.
- `isJSON` is the regex-based pre-check used in front of direct
  `JSON.parse` calls in modules. It is intentionally not as strict as
  `JSON.parse` itself -- `safeJsonParse` remains the hard guard.
- `getStoredJSON` delegates to `safeJsonParse`; the contract is
  no-throw with default-value fallback for missing / empty / malformed
  input.

## Files

- `spec/Service/StorageMigration.spec.ts` -- 26 new tests:
  edge cases (undefined, null, empty, malformed, well-formed) for
  each helper, plus a smoke pass over a real settings snapshot.
- `spec/fixtures/storage-snapshot/setting-snapshot.json` -- 21 keys
  curated from `INPUT/HH_DebugLog_1778140621437.log` covering
  boolean / integer / semicolon-list / JSON-array / custom-format /
  sessionStorage payloads.
- `spec/fixtures/storage-snapshot/README.md` -- audit trail.

## Documented behavior

The spec records a known liberal-regex behavior of `isJSON`:
`'[1,2,'` is accepted by the pre-check; the real `JSON.parse`
exception is caught by `safeJsonParse`. This matches the existing
contract; tightening the regex is out of scope for stage 4.

No `src/` change; existing helpers are pure.

## Verification

- `npm test`: 743 passed (717 + 26), 54 suites.
- `npm run build`: succeeds.
- Coverage: 30.62 statements / 19.75 branches / 26.22 functions /
  31.12 lines (was 30.55 / 19.67 / 26.15 / 31.06).