### PR TITLE
docs(test): record stage 4 task 4.2 first slice

### DIFF
--- a/docs-internal/test-strategy.md
+++ b/docs-internal/test-strategy.md
@@ -6,9 +6,9 @@ and add the date plus commit hash in the Status field.
 ## Status
 
 - Current stage: **4 in progress** (reliability layer)
-- Last completed task: 4.1 (AJAX schema tests -- closed after inventory pass)
+- Last completed task: 4.2 first slice (storage-migration helpers `safeJsonParse` / `isJSON` / `getStoredJSON` plus a real settings snapshot smoke pass)
 - Open reminder: issue #1614 (CI coverage reporting; will be picked up in stage 4 task 4.4 alongside the storage-migration tests)
-- Next step: stage 4 task 4.2 (storage migration tests). Mine `INPUT/HH_DebugLog_*.log` for old `Setting_*` / `Temp_*` snapshots, set the storage to the old shape, call the reader, assert no exception escapes (default value falls in if necessary).
+- Next step: stage 4 task 4.2 next slice. Module-level migration tests for the four sites that call `JSON.parse` directly on a stored value (BDSMHelper, EventModule, AutoLoopActions, Shop -- all guarded by `isJSON` today, so the contract is the same no-throw / fall-back-to-default). Pick one site per slice.
 - Carried-forward reminders for stage 4:
   - `parseGirlsFromGameData(rawData) -> Girl[]` (deferred from stage 1 task 1.3): the haremGirl / event fixtures are sized to feed this parser. Stage 3 did not need it; reactivate when a haremGirl-touching parser test lands.
   - Champion-map fixture deferral: page 8 (`/champions-map.html`) carries no champion JSON in the dump (DOM-only). Needs a different testing approach for DOM-derived state before a map fixture can be produced.
@@ -715,6 +715,22 @@ module.
   - Old storage values from earlier versions as fixtures
   - Test: reader does not crash, default value kicks in
   - Source: `INPUT/HH_DebugLog_*.log` contains current storage snapshots
+  - First slice landed: storage-migration helpers (2026-05-08)
+    - `spec/Service/StorageMigration.spec.ts` -- 26 new tests covering
+      `safeJsonParse` / `isJSON` / `getStoredJSON` edge cases plus a
+      smoke pass over a real settings snapshot.
+    - `spec/fixtures/storage-snapshot/setting-snapshot.json` -- 21
+      keys curated from `INPUT/HH_DebugLog_1778140621437.log` covering
+      boolean / integer / semicolon-list / JSON-array / custom-format /
+      sessionStorage payloads.
+    - Plan deviation documented in the spec: `isJSON` is intentionally
+      a liberal regex pre-check; `safeJsonParse` remains the hard
+      no-throw guard. Tightening the regex is out of scope here.
+    - No `src/` change.
+    - Tests: 743 passed (717 + 26), 54 suites.
+    - Coverage: 30.62 statements / 19.75 branches / 26.22 functions /
+      31.12 lines (was 30.55 / 19.67 / 26.15 / 31.06).
+    - Merged via PR #1654, commit 3d1f208.
 - [ ] **4.3** Multi-domain smoke
   - Per domain clone (hentaiheroes, gayharem, comixharem, mangarpg, ...) one
     test for `domain.includes()` and ConfigHelper domain detection
@@ -813,3 +829,4 @@ findNextChamptionTime with 1 test.
 | 2026-05-08 | Stage 3 finished: 5 pure modules (ClubChampion / Pantheon / Labyrinth / Bundles / LivelyScene), 76 new tests across 5 refactor PRs (1636/1638/1641/1643/1645) and 6 doc PRs (1637/1640/1642/1644/1646 plus the 3.3 skip-only doc PR), 711 total; six of seven sub-tasks renegotiated mid-flight when the plan's symbol names did not match the actual code; two sub-tasks shipped as documented skips (3.3 MonthlyCard -- module name is misleading; 3.6 BossBang half -- DOM-only); behaviour deltas documented per task, all read-only and without game-state effects |
 | 2026-05-08 | Task 4.1 first endpoint slice: live-blessings AJAX schema fixtures (3 temporal snapshots) + parser smoke test (`parseTraits` / `parseBlessedValues` / `parseElement` / `parseBlessingPercent` on real payloads via a typed `BlessingParserSurface` view; no `any`); fixture content is the inner `live_blessings_api.live` value (= actual game-API response BlessingService consumes); 6 new tests (717 total, 53 suites); coverage 30.13->30.55 statements / 18.94->19.67 branches / 25.79->26.15 functions / 30.69->31.06 lines; no plan deviation; merged via PR #1648 (commit 3e647be) |
 | 2026-05-08 | Task 4.1 closed: inspector inventory pass via v4.7.0 (PRs #1650/#1651/#1652 -- per-step XHR observer, auto-update URLs, persistent XHR + fetch hooks). Fresh tour bundle (`hhauto_dump_..._2026-05-08T13-35-50-669Z.json`, inspector v4.7.0) shows three observed endpoints across all 32 pages: `get_girls_blessings` (covered by the live-blessings slice), `process_rewards_queue`, `show_specific_girl_grade`. The latter two have no HHAuto consumer; recorded as audit hints. Plan deviation documented (closing 4.1 with one schema test set; remaining `pages[*].battle.*` / `pages[*].girls_full.*` paths are page-globals already covered in stage 2 fixtures, not AJAX responses; remaining 12 src/ AJAX call sites are writes and not testable from the inspector). Next step: stage 4 task 4.2 (storage migration tests) |
+| 2026-05-08 | Task 4.2 first slice: storage-migration helpers spec (`safeJsonParse` / `isJSON` / `getStoredJSON` edge cases) plus a real settings snapshot smoke pass; `spec/fixtures/storage-snapshot/setting-snapshot.json` curated from `INPUT/HH_DebugLog_1778140621437.log` (21 keys covering boolean / integer / semicolon-list / JSON-array / custom-format / sessionStorage payloads). 26 new tests (743 total, 54 suites). Coverage 30.55->30.62 statements / 19.67->19.75 branches / 26.15->26.22 functions / 31.06->31.12 lines. Plan deviation documented (`isJSON` is intentionally a liberal regex pre-check; `safeJsonParse` remains the hard no-throw guard). No `src/` change. Merged via PR #1654 (commit 3d1f208) |


### PR DESCRIPTION
Plan-only update for the storage-migration helpers slice merged in
PR #1654.

## Changes

- Status block: 4.2 first slice landed (storage-migration helpers
  spec). Next step points at module-level migration tests for the
  four direct `JSON.parse` call sites (`BDSMHelper`,
  `EventModule`, `AutoLoopActions`, `Shop`).
- Task 4.2 entry: documents the helpers slice -- spec file, fixture
  file, plan deviation about `isJSON`'s liberal-regex behavior, no
  `src/` change.
- Change log row: 2026-05-08, PR #1654, commit 3d1f208, 717 -> 743
  tests, coverage drift recorded.

## Verification

- `npm test`: 743 passed (no change from PR #1654), 54 suites.
- No `src/` change in this PR.