### PR TITLE
test(domain): multi-domain smoke for all 21 supported hostnames

### DIFF
--- a/spec/Helper/ConfigHelper.spec.ts
+++ b/spec/Helper/ConfigHelper.spec.ts
@@ -84,4 +84,85 @@ describe("ConfigHelper", function() {
         expect(ConfigHelper.getHHScriptVars('boosterId_MB1')).toBe(2619);
     });
   });
+
+  describe("Multi-domain smoke", function() {
+    /**
+     * Stage 4 task 4.3: per supported domain clone, one smoke test
+     * covering ConfigHelper domain detection and the corresponding
+     * gameID lookup. The full set of hostnames is the registry built
+     * from `src/config/game/*Vars.ts:getEnv()` plus the manual entry
+     * for `www.hornyheroes.com` in HHEnvVariables.ts. PSH detection
+     * (`isPshEnvironnement`) is asserted alongside per Plan.
+     *
+     * Plan deviation (documented): the plan listed `domain.includes()`
+     * checks as one of the things to assert. The HHAuto codebase does
+     * not use `domain.includes()` for environment detection -- it uses
+     * exact-match against `HHKnownEnvironnements[hostname]`. The smoke
+     * tests use exact hostnames accordingly.
+     */
+    beforeEach(() => {
+        document.body.innerHTML = `<!DOCTYPE html><p>Hello world</p>`;
+    });
+
+    interface DomainCase {
+        hostname: string;
+        envName: string;
+        gameId: string;
+        psh: boolean;
+    }
+
+    const DOMAIN_CASES: DomainCase[] = [
+        // Hentai Heroes (HentaiHeroesVars.ts)
+        { hostname: "www.hentaiheroes.com",       envName: "HH_prod",   gameId: "hh_hentai",    psh: false },
+        { hostname: "test.hentaiheroes.com",      envName: "HH_test",   gameId: "hh_hentai",    psh: false },
+        { hostname: "nutaku.haremheroes.com",     envName: "NHH_prod",  gameId: "hh_hentai",    psh: false },
+        { hostname: "thrix.hentaiheroes.com",     envName: "THH_prod",  gameId: "hh_hentai",    psh: false },
+        { hostname: "eroges.hentaiheroes.com",    envName: "EHH_prod",  gameId: "hh_hentai",    psh: false },
+        { hostname: "esprit.hentaiheroes.com",    envName: "OGHH_prod", gameId: "hh_hentai",    psh: false },
+        // Comix Harem (ComixHaremVars.ts)
+        { hostname: "www.comixharem.com",         envName: "CH_prod",   gameId: "hh_comix",     psh: false },
+        { hostname: "nutaku.comixharem.com",      envName: "NCH_prod",  gameId: "hh_comix",     psh: false },
+        // Gay Harem (GayHaremVars.ts)
+        { hostname: "www.gayharem.com",           envName: "GH_prod",   gameId: "hh_gay",       psh: false },
+        { hostname: "nutaku.gayharem.com",        envName: "NGH_prod",  gameId: "hh_gay",       psh: false },
+        { hostname: "eroges.gayharem.com",        envName: "EGH_prod",  gameId: "hh_gay",       psh: false },
+        // Pornstar Harem (PornstarHaremVars.ts) -- PSH
+        { hostname: "www.pornstarharem.com",      envName: "PH_prod",   gameId: "hh_star",      psh: true  },
+        { hostname: "nutaku.pornstarharem.com",   envName: "NPH_prod",  gameId: "hh_star",      psh: true  },
+        // Trans Pornstar Harem (TransPornstarHaremVars.ts)
+        { hostname: "www.transpornstarharem.com", envName: "TPH_prod",  gameId: "hh_startrans", psh: false },
+        { hostname: "nutaku.transpornstarharem.com", envName: "NTPH_prod", gameId: "hh_startrans", psh: false },
+        // Gay Pornstar Harem (GayPornstarHaremVars.ts)
+        { hostname: "www.gaypornstarharem.com",   envName: "GPSH_prod",  gameId: "hh_stargay", psh: false },
+        { hostname: "nutaku.gaypornstarharem.com", envName: "NGPSH_prod", gameId: "hh_stargay", psh: false },
+        // Manga RPG (MangaRpgVars.ts)
+        { hostname: "www.mangarpg.com",           envName: "MRPG_prod",  gameId: "hh_mangarpg", psh: false },
+        { hostname: "nutaku.mangarpg.com",        envName: "NMRPG_prod", gameId: "hh_mangarpg", psh: false },
+        // Amour Agent (AmourAgentVars.ts)
+        { hostname: "www.amouragent.com",         envName: "AA_prod",    gameId: "hh_amour",   psh: false },
+        // Sexy Heroes (manual entry in HHEnvVariables.ts)
+        { hostname: "www.hornyheroes.com",        envName: "SH_prod",    gameId: "hh_sexy",    psh: false },
+    ];
+
+    it.each(DOMAIN_CASES)(
+        "$hostname -> env=$envName, gameID=$gameId, psh=$psh",
+        ({ hostname, envName, gameId, psh }) => {
+            MockHelper.mockDomain(hostname);
+            expect(ConfigHelper.getEnvironnement()).toBe(envName);
+            expect(ConfigHelper.getHHScriptVars("gameID")).toBe(gameId);
+            expect(ConfigHelper.isPshEnvironnement()).toBe(psh);
+        }
+    );
+
+    it("DOMAIN_CASES covers all hostnames in HHKnownEnvironnements", () => {
+        // Sanity: if a new hostname is added to a getEnv() block, this
+        // assertion fails until the smoke table is extended.
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const { HHKnownEnvironnements } = require("../../src/config/HHEnvVariables");
+        const registryHosts = Object.keys(HHKnownEnvironnements);
+        const tableHosts = DOMAIN_CASES.map((c) => c.hostname);
+        const missing = registryHosts.filter((h) => !tableHosts.includes(h));
+        expect(missing).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
Stage 4 task 4.3. Adds a "Multi-domain smoke" describe block to the
existing `spec/Helper/ConfigHelper.spec.ts`, covering every
hostname registered in `HHKnownEnvironnements` via a data-driven
`it.each` table.

## Coverage

| Source | Hostnames |
| --- | --- |
| HentaiHeroesVars.ts | 6 (HH_prod / HH_test / NHH_prod / THH_prod / EHH_prod / OGHH_prod) |
| ComixHaremVars.ts | 2 (CH_prod / NCH_prod) |
| GayHaremVars.ts | 3 (GH_prod / NGH_prod / EGH_prod) |
| GayPornstarHaremVars.ts | 2 (GPSH_prod / NGPSH_prod) |
| MangaRpgVars.ts | 2 (MRPG_prod / NMRPG_prod) |
| PornstarHaremVars.ts | 2 (PH_prod / NPH_prod) |
| TransPornstarHaremVars.ts | 2 (TPH_prod / NTPH_prod) |
| AmourAgentVars.ts | 1 (AA_prod) |
| HHEnvVariables.ts (manual) | 1 (SH_prod) |
| **Total** | **21** |

A 22nd sanity test confirms the table is in sync with
`HHKnownEnvironnements` -- adding a new hostname to a
`src/config/game/*Vars.ts:getEnv()` block fires this guard until
the table is extended.

## Per case

- `ConfigHelper.getEnvironnement()` returns the expected env name
- `ConfigHelper.getHHScriptVars('gameID')` returns the expected
  gameID
- `ConfigHelper.isPshEnvironnement()` matches the PSH whitelist
  (true only for `PH_prod` and `NPH_prod`)

## Plan deviation (documented in the describe block)

The plan called for `domain.includes()` checks. The HHAuto codebase
uses exact-match against `HHKnownEnvironnements[hostname]` -- not
`includes`. The smoke tests use exact hostnames accordingly.

## Verification

- `npm test`: 765 passed (743 + 22), 54 suites.
- `npm run build`: succeeds.
- Coverage unchanged (ConfigHelper was already covered).

## File location

Per user direction: appended to the existing
`spec/Helper/ConfigHelper.spec.ts` instead of creating a new
`spec/config/Domain.spec.ts`.