### PR TITLE
ci(coverage): publish coverage summary on PRs (refs #1614)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -28,3 +31,21 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 14
+
+      - name: Comment coverage summary on PR
+        if: github.event_name == 'pull_request'
+        uses: MishaKav/jest-coverage-comment@v1.0.23
+        with:
+          coverage-summary-path: coverage/coverage-summary.json
+          summary-title: "Coverage summary"
+          hide-summary: false
+          create-new-comment: false
+          junitxml-path: ""

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -38,7 +38,7 @@ const config: Config = {
   // A list of reporter names that Jest uses when writing coverage reports.
   // text-summary prints a condensed table at the bottom of the run; html
   // emits coverage/lcov-report/index.html for browser inspection.
-  coverageReporters: ["text", "text-summary", "lcov", "clover", "html"],
+  coverageReporters: ["text", "text-summary", "json-summary", "lcov", "clover", "html"],
 
   // An object that configures minimum threshold enforcement for coverage results
   // coverageThreshold: undefined,


### PR DESCRIPTION
Refs #1614.

Adds CI coverage reporting per the strategy plan task 0.6 / 4.4.
**Reporting only -- no threshold gate** (review consensus, plan
constraint).

## Changes

- `jest.config.ts`: extend `coverageReporters` with
  `json-summary` so the comment action can read
  `coverage/coverage-summary.json`.
- `.github/workflows/ci.yml`:
  - `permissions` block: `contents: read`,
    `pull-requests: write` (required by the comment action;
    minimum scope).
  - **Upload artifact**: `coverage/` directory as workflow
    artifact `coverage-report`, retention 14 days,
    `if: always()` so the artifact is available even on a failed
    test step.
  - **PR comment**: on `pull_request` events, comment a coverage
    summary using `MishaKav/jest-coverage-comment@v1.0.23`
    (pinned, Marketplace latest as of 2026-05-08).
    `create-new-comment: false` so the comment is updated in
    place across pushes.

## Verification

- `npm test`: 765 passed / 54 suites (no test change).
- `coverage/coverage-summary.json` is now produced locally:
  - Statements 30.62 / Branches 19.75 / Functions 26.22 /
    Lines 31.12.
- `npm run build`: succeeds.
- The CI workflow itself runs on this PR -- you should see the
  coverage comment appear once it finishes.

## Reference

Test strategy plan, tasks 0.6 / 4.4
(`docs-internal/test-strategy.md`).