### PR TITLE
Penta Drill: increase delays between actions

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.27
+// @version      7.35.28
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -8190,7 +8190,7 @@ class GenericBattle {
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPentaDrillBattle") && getStoredValue(HHStoredVarPrefixKey + SK.autoPentaDrill) === "true") {
                 LogUtils_logHHAuto("Go back to Penta drill arena after fight.");
-                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"), {}, randomInterval(2000, 4000));
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"), {}, randomInterval(5000, 8000));
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPantheonBattle") && (getStoredValue(HHStoredVarPrefixKey + SK.autoPantheon) === "true" || DailyGoals.isPantheonDailyGoal())) {
                 LogUtils_logHHAuto("Go back to Pantheon arena after Pantheon temple.");
@@ -15590,7 +15590,7 @@ class PentaDrill {
                     LogUtils_logHHAuto("setting autoloop to false");
                     LogUtils_logHHAuto(`Going to crush : ${chosenOpponent.player.nickname} (${chosenID})`);
                     location.href = addNutakuSession(toGoTo);
-                    yield TimeHelper.sleep(randomInterval(4000, 8000));
+                    yield TimeHelper.sleep(randomInterval(5000, 8000));
                     return true;
                 }
             }
@@ -15605,7 +15605,7 @@ class PentaDrill {
                 performButton.trigger('click');
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 LogUtils_logHHAuto("setting autoloop to false");
-                yield TimeHelper.sleep(randomInterval(4000, 6000));
+                yield TimeHelper.sleep(randomInterval(5000, 8000));
                 //setTimer('nextPentaDrillTime',10);
                 return true;
             }
@@ -25695,7 +25695,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.27";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.28";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.28 - Penta Drill: delays adjusted further
+
+Delays between Penta Drill actions have been increased again to avoid blank screens caused by clicks landing before the server response.
+
+---
+
 ### v7.35.27 - Fix: Bypass reserve now applies to +Raid and +Raid Stars
 
 The Bypass reserve toggle was ignored for +Raid and +Raid Stars fights. Both modes always fought as soon as a raid girl was available, regardless of the energy threshold or the toggle state. The toggle now controls the threshold consistently: when OFF, the troll threshold applies to raid fights too; when ON, raid fights start as soon as energy is above zero.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.27",
+  "version": "7.35.28",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/GenericBattle.ts
+++ b/src/Module/GenericBattle.ts
@@ -95,7 +95,7 @@ export class GenericBattle {
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPentaDrillBattle") && getStoredValue(HHStoredVarPrefixKey +SK.autoPentaDrill) === "true")
             {
                 logHHAuto("Go back to Penta drill arena after fight.");
-                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"),{},randomInterval(2000,4000));
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"),{},randomInterval(5000,8000));
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPantheonBattle") && (getStoredValue(HHStoredVarPrefixKey + SK.autoPantheon) === "true" || DailyGoals.isPantheonDailyGoal()))
             {

--- a/src/Module/PentaDrill.ts
+++ b/src/Module/PentaDrill.ts
@@ -159,7 +159,7 @@ export class PentaDrill {
                 logHHAuto("setting autoloop to false");
                 logHHAuto(`Going to crush : ${chosenOpponent.player.nickname} (${chosenID})`);
                 location.href = addNutakuSession(toGoTo) as string;
-                await TimeHelper.sleep(randomInterval(4000, 8000));
+                await TimeHelper.sleep(randomInterval(5000, 8000));
                 return true;
             }
         }
@@ -175,7 +175,7 @@ export class PentaDrill {
             performButton.trigger('click');
             setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "false");
             logHHAuto("setting autoloop to false");
-            await TimeHelper.sleep(randomInterval(4000, 6000));
+            await TimeHelper.sleep(randomInterval(5000, 8000));
             //setTimer('nextPentaDrillTime',10);
             return true;
         }

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.27";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.28";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
Increases all three Penta Drill action delays to 5-8s to avoid blank screens caused by clicks landing before the server response.

Refs #1593

Bumps version to 7.35.28.