### PR TITLE
fix: reduce Forbidden errors after PoP claim and on slow networks

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.28
+// @version      7.35.29
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -13339,6 +13339,55 @@ class Labyrinth {
 Labyrinth.HAREM_SELECTED_GIRLS = '.harem-panel-girls .harem-girl-container.selected'; // in my squad
 Labyrinth.BUILD_BUTTON_ID = 'hhAutoLabyTeam';
 
+;// CONCATENATED MODULE: ./src/Helper/ConfigHelper.ts
+/**
+ * ConfigHelper.ts - Environment detection and per-environment variable lookup
+ *
+ * The game runs on multiple domains (HH, PH, NPH, etc.), each with
+ * slightly different page IDs, URLs, and feature flags. This helper
+ * detects which environment the script is running on by matching the
+ * current hostname against a known list, then resolves configuration
+ * variables for that environment. When an environment-specific value is
+ * not defined, it falls back to the "global" defaults.
+ *
+ * Almost every other helper and module depends on ConfigHelper to obtain
+ * page IDs, URL paths, element selectors, and feature toggles.
+ */
+
+
+class ConfigHelper {
+    static getEnvironnement() {
+        let environnement = "global";
+        if (HHKnownEnvironnements[window.location.hostname] !== undefined) {
+            environnement = HHKnownEnvironnements[window.location.hostname].name;
+        }
+        else {
+            fillHHPopUp("unknownURL", "Game URL unknown", '<p>This HH URL is unknown to the script.<br>To add it please open an issue in <a href="https://github.com/OldRon1977/HHauto/issues" target="_blank">Github</a> with following informations : <br>Hostname : ' + window.location.hostname + '<br>gameID : ' + $('body[page][id]').attr('id') + '<br>You can also use this direct link : <a  target="_blank" href="https://github.com/OldRon1977/HHauto/issues/new?template=enhancement_request.md&title=Support%20for%20' + window.location.hostname + '&body=Please%20add%20new%20URL%20with%20these%20infos%20%3A%20%0A-%20hostname%20%3A%20' + window.location.hostname + '%0A-%20gameID%20%3A%20' + $('body[page][id]').attr('id') + '%0AThanks">Github issue</a></p>');
+        }
+        return environnement;
+    }
+    static isPshEnvironnement() {
+        return ["PH_prod", "NPH_prod"].includes(ConfigHelper.getEnvironnement());
+    }
+    static getHHScriptVars(id, logNotFound = true) {
+        const environnement = ConfigHelper.getEnvironnement();
+        if (HHEnvVariables[environnement] !== undefined && HHEnvVariables[environnement][id] !== undefined) {
+            return HHEnvVariables[environnement][id];
+        }
+        else {
+            if (HHEnvVariables["global"] !== undefined && HHEnvVariables["global"][id] !== undefined) {
+                return HHEnvVariables["global"][id];
+            }
+            else {
+                if (logNotFound) {
+                    LogUtils_logHHAuto("not found var for " + environnement + "/" + id);
+                }
+                return null;
+            }
+        }
+    }
+}
+
 ;// CONCATENATED MODULE: ./src/Helper/PageHelper.ts
 // PageHelper.ts
 //
@@ -13462,6 +13511,16 @@ function getPage(checkUnknown = false, checkPop = false) {
 
 
 
+
+// How long to wait for in-flight XHRs before navigating away. The game
+// can take several seconds to answer in slow environments (Firefox
+// Private Browsing has been observed at 2-3s per AJAX). 8s is a
+// conservative cap; the wait short-circuits as soon as the queue is
+// empty, so the typical path stays fast.
+const AJAX_IDLE_TIMEOUT_MS = 8000;
+// Extra delay after AJAX idle before changing window.location, to let
+// any synchronous follow-up code (DOM updates, popup handling) finish.
+const AJAX_IDLE_SETTLE_MS = 250;
 // Module-level mutex: true while a navigation has been scheduled but the
 // browser hasn't fully transitioned yet. Reset implicitly on page reload.
 let navInFlight = false;
@@ -13622,12 +13681,26 @@ function gotoPage(page, inArgs = {}, delay = -1) {
         LogUtils_logHHAuto("setting autoloop to false");
         LogUtils_logHHAuto('GotoPage : ' + togoto + ' in ' + delay + 'ms.');
         navInFlight = true;
-        setTimeout(function () { window.location.href = window.location.origin + togoto; }, delay);
+        const targetUrl = togoto;
+        setTimeout(function () {
+            // Wait for any in-flight game AJAX (e.g. PoP claim POSTs) to
+            // finish before changing the URL. Setting window.location.href
+            // cancels open XHRs with NS_BINDING_ABORTED, and an aborted
+            // state-changing request can make the server answer Forbidden
+            // on the next call (issue #1598).
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+                window.location.href = window.location.origin + targetUrl;
+            });
+        }, delay);
     }
     else {
         LogUtils_logHHAuto("Couldn't find page path. Page was undefined...");
         navInFlight = true;
-        setTimeout(function () { location.reload(); }, delay);
+        setTimeout(function () {
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+                location.reload();
+            });
+        }, delay);
     }
 }
 function addNutakuSession(togoto) {
@@ -16456,9 +16529,17 @@ class PlaceOfPower {
                 if ($(buttonClaimQuery).length > 0) {
                     $(buttonClaimQuery).first().trigger('click');
                     LogUtils_logHHAuto("Claimed reward for PoP : " + $(buttonClaimQuery).first().parent().attr('pop_id'));
-                    yield TimeHelper.sleep(randomInterval(700, 1100));
+                    // The claim click fires an ajax.php POST. We must wait for
+                    // that POST to complete before changing the page, otherwise
+                    // window.location.href cancels the request (NS_BINDING_ABORTED)
+                    // and the server answers the next call with Forbidden
+                    // (issue #1598, especially under Firefox Private Browsing
+                    // where the AJAX takes 2-3 seconds).
+                    yield waitForAjaxIdle(8000, 400);
                     RewardHelper.closeRewardPopupIfAny(); // Will refresh the page
-                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDPowerplacemain"), {}, randomInterval(4000, 5000)); // fail safe
+                    // Wait again in case closing the popup itself fires a request.
+                    yield waitForAjaxIdle(4000, 200);
+                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDPowerplacemain"), {}, randomInterval(1500, 2500));
                     return true;
                 }
                 const filteredPopsStr = getStoredValue(HHStoredVarPrefixKey + SK.autoPowerPlacesIndexFilter);
@@ -23721,53 +23802,125 @@ function checkAndClosePopup(inBurst) {
 
 
 
-;// CONCATENATED MODULE: ./src/Helper/ConfigHelper.ts
+;// CONCATENATED MODULE: ./src/Service/AjaxTracker.ts
+// AjaxTracker.ts
+//
+// Lightweight pending-XHR counter. Installed once at script start.
+// Wraps XMLHttpRequest.send to count in-flight requests so the
+// navigation layer can wait for the game to finish its current
+// AJAX work before changing pages.
+//
+// Why: window.location.href = ... cancels any in-flight XHR with
+// NS_BINDING_ABORTED. When the cancelled request is a state-changing
+// POST (e.g. PoP claim), the server can answer the next request with
+// HTTP Forbidden. Waiting for AJAX idle before navigating prevents
+// that race.
+//
+// Public API:
+//   installAjaxTracker()  -- call once at script start
+//   pendingAjaxCount()    -- current number of in-flight XHRs
+//   waitForAjaxIdle(timeoutMs, settleMs) -- resolves when idle
+//
+// Used by: PageNavigationService.gotoPage()
+var AjaxTracker_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+
+let pending = 0;
+let installed = false;
+let restoreSend = null;
 /**
- * ConfigHelper.ts - Environment detection and per-environment variable lookup
+ * Install the XHR counter hook. Idempotent.
+ * Hooks XMLHttpRequest.prototype.send to count in-flight requests
+ * via a single loadend listener (covers success, error, abort, timeout).
  *
- * The game runs on multiple domains (HH, PH, NPH, etc.), each with
- * slightly different page IDs, URLs, and feature flags. This helper
- * detects which environment the script is running on by matching the
- * current hostname against a known list, then resolves configuration
- * variables for that environment. When an environment-specific value is
- * not defined, it falls back to the "global" defaults.
- *
- * Almost every other helper and module depends on ConfigHelper to obtain
- * page IDs, URL paths, element selectors, and feature toggles.
+ * Returns true if the hook was installed (or was already installed),
+ * false if no XMLHttpRequest constructor is available in this scope.
  */
-
-
-class ConfigHelper {
-    static getEnvironnement() {
-        let environnement = "global";
-        if (HHKnownEnvironnements[window.location.hostname] !== undefined) {
-            environnement = HHKnownEnvironnements[window.location.hostname].name;
-        }
-        else {
-            fillHHPopUp("unknownURL", "Game URL unknown", '<p>This HH URL is unknown to the script.<br>To add it please open an issue in <a href="https://github.com/OldRon1977/HHauto/issues" target="_blank">Github</a> with following informations : <br>Hostname : ' + window.location.hostname + '<br>gameID : ' + $('body[page][id]').attr('id') + '<br>You can also use this direct link : <a  target="_blank" href="https://github.com/OldRon1977/HHauto/issues/new?template=enhancement_request.md&title=Support%20for%20' + window.location.hostname + '&body=Please%20add%20new%20URL%20with%20these%20infos%20%3A%20%0A-%20hostname%20%3A%20' + window.location.hostname + '%0A-%20gameID%20%3A%20' + $('body[page][id]').attr('id') + '%0AThanks">Github issue</a></p>');
-        }
-        return environnement;
+function installAjaxTracker() {
+    if (installed)
+        return true;
+    // Resolve the constructor lazily so tests can swap the global
+    // XMLHttpRequest before calling install().
+    const xhrCtor = (typeof window !== 'undefined' && window.XMLHttpRequest)
+        || (typeof globalThis !== 'undefined' && globalThis.XMLHttpRequest)
+        || (typeof XMLHttpRequest !== 'undefined' ? XMLHttpRequest : undefined);
+    if (!xhrCtor || !xhrCtor.prototype || typeof xhrCtor.prototype.send !== 'function') {
+        return false;
     }
-    static isPshEnvironnement() {
-        return ["PH_prod", "NPH_prod"].includes(ConfigHelper.getEnvironnement());
-    }
-    static getHHScriptVars(id, logNotFound = true) {
-        const environnement = ConfigHelper.getEnvironnement();
-        if (HHEnvVariables[environnement] !== undefined && HHEnvVariables[environnement][id] !== undefined) {
-            return HHEnvVariables[environnement][id];
+    const origSend = xhrCtor.prototype.send;
+    xhrCtor.prototype.send = function (...args) {
+        pending++;
+        const decrement = () => {
+            if (pending > 0)
+                pending--;
+        };
+        // loadend fires once for both success and failure paths
+        this.addEventListener('loadend', decrement, { once: true });
+        return origSend.apply(this, args);
+    };
+    restoreSend = () => {
+        try {
+            xhrCtor.prototype.send = origSend;
         }
-        else {
-            if (HHEnvVariables["global"] !== undefined && HHEnvVariables["global"][id] !== undefined) {
-                return HHEnvVariables["global"][id];
-            }
-            else {
-                if (logNotFound) {
-                    LogUtils_logHHAuto("not found var for " + environnement + "/" + id);
-                }
-                return null;
-            }
+        catch (e) { /* ignore */ }
+    };
+    installed = true;
+    LogUtils_logHHAuto('[AjaxTracker] installed');
+    return true;
+}
+/** Number of in-flight XMLHttpRequests. Returns 0 if tracker is not installed. */
+function pendingAjaxCount() {
+    return pending;
+}
+/**
+ * Resolve when AJAX is idle (no pending XHRs) or after timeoutMs.
+ * After idle is detected, wait an extra settleMs to let synchronous
+ * follow-up code (e.g. DOM updates triggered by the response) finish.
+ *
+ * Polls every 50ms. Returns true if idle was reached, false on timeout.
+ */
+function waitForAjaxIdle(timeoutMs = 8000, settleMs = 250) {
+    return AjaxTracker_awaiter(this, void 0, void 0, function* () {
+        if (!installed) {
+            // Tracker not installed -> behave like immediate idle, just settle.
+            yield sleep(settleMs);
+            return true;
         }
+        const deadline = Date.now() + timeoutMs;
+        while (pending > 0 && Date.now() < deadline) {
+            yield sleep(50);
+        }
+        const reachedIdle = pending === 0;
+        if (!reachedIdle) {
+            LogUtils_logHHAuto(`[AjaxTracker] waitForAjaxIdle timeout, ${pending} request(s) still pending`);
+        }
+        if (settleMs > 0) {
+            yield sleep(settleMs);
+        }
+        return reachedIdle;
+    });
+}
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+/** Reset internal state and remove the prototype hook. Test-only. */
+function _resetAjaxTrackerForTests() {
+    if (restoreSend) {
+        try {
+            restoreSend();
+        }
+        catch (e) { /* ignore */ }
     }
+    restoreSend = null;
+    pending = 0;
+    installed = false;
 }
 
 ;// CONCATENATED MODULE: ./src/Service/AdsService.ts
@@ -25695,7 +25848,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.28";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.29";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.
@@ -26618,6 +26771,38 @@ function disableToolTipsDisplay(important = false) {
     GM_addStyle('.tooltipHH:hover span.tooltipHHtext { display: none' + importantAddendum + '}');
 }
 
+;// CONCATENATED MODULE: ./src/Service/ForbiddenBackoff.ts
+// ForbiddenBackoff.ts
+//
+// Exponential backoff calculator for the persistent Forbidden counter
+// used by StartService.hardened_start() (issue #1598).
+//
+// Each consecutive Forbidden response doubles the random reload window,
+// capped at FORBIDDEN_CAP_SECONDS. A jitter of +/- 20% is applied so
+// multiple tabs hitting the same rate-limit do not all retry in lockstep.
+const FORBIDDEN_BASE_SECONDS = 60;
+const FORBIDDEN_CAP_SECONDS = 30 * 60;
+const FORBIDDEN_MIN_DELAY_SECONDS = 30;
+const FORBIDDEN_JITTER_RANGE = 0.4; // +/- 20%
+/**
+ * Compute the next reload delay in seconds for a given consecutive
+ * Forbidden count.
+ *
+ * count is 1-based: the 1st Forbidden produces FORBIDDEN_BASE_SECONDS,
+ * the 2nd doubles it, and so on, up to FORBIDDEN_CAP_SECONDS.
+ *
+ * @param count    number of consecutive Forbidden responses (>= 1)
+ * @param random   RNG returning a value in [0, 1). Defaults to Math.random.
+ *                 Injected so unit tests can produce deterministic results.
+ */
+function nextForbiddenDelaySeconds(count, random = Math.random) {
+    const safeCount = Math.max(1, Math.floor(count));
+    const factor = Math.pow(2, safeCount - 1);
+    const target = Math.min(FORBIDDEN_BASE_SECONDS * factor, FORBIDDEN_CAP_SECONDS);
+    const jitter = (1 - FORBIDDEN_JITTER_RANGE / 2) + random() * FORBIDDEN_JITTER_RANGE;
+    return Math.max(FORBIDDEN_MIN_DELAY_SECONDS, Math.round(target * jitter));
+}
+
 ;// CONCATENATED MODULE: ./src/Service/StartService.ts
 // StartService.ts
 //
@@ -26652,11 +26837,32 @@ function disableToolTipsDisplay(important = false) {
 
 
 
+
+
 var started = false;
 var debugMenuID;
 var heroRetryTimer = null;
 var heroRetryCount = 0;
 const HERO_MAX_RETRIES = 15;
+// Persistent Forbidden backoff (issue #1598).
+//
+// The reload-delay formula lives in ForbiddenBackoff.ts so it can be
+// unit-tested in isolation. The counter itself lives in sessionStorage
+// so it survives location.reload() but resets when the user closes the
+// tab. On a successful start() (Hero object available), the counter is
+// cleared, so a single transient Forbidden does not penalise later runs.
+const FORBIDDEN_COUNT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenCount';
+// Cold-start delay (issue #1598).
+//
+// After a long inactivity (PC hibernation, tab in background, slow page
+// load) the very first AJAX call from this script tab can hit a
+// rate-limited server window. We delay the initial autoLoop tick by a
+// few seconds when the last recorded activity is older than the
+// threshold below, giving the page time to settle before any module
+// fires a navigation.
+const COLD_START_THRESHOLD_MS = 60 * 1000;
+const COLD_START_DELAY_MS = 4000;
+const NORMAL_START_DELAY_MS = 1000;
 class StartService {
     static checkVersion() {
         let previousScriptVersion = getStoredValue(HHStoredVarPrefixKey + TK.scriptversion);
@@ -26721,13 +26927,36 @@ function setDefaults(force = false) {
 function hardened_start() {
     debugMenuID = GM_registerMenuCommand(getTextForUI("saveDebug", "elementText"), saveHHDebugLog);
     //GM_unregisterMenuCommand(debugMenuID);
+    // Install the AJAX request counter as early as possible so any later
+    // page-changing module call can wait for in-flight game POSTs to
+    // finish (prevents NS_BINDING_ABORTED -> Forbidden race, issue #1598).
+    try {
+        installAjaxTracker();
+    }
+    catch (e) { /* tracker is best-effort */ }
     if (unsafeWindow.jQuery == undefined) {
         console.log("HHAUTO WARNING: No jQuery found.");
         try {
             const forbiddenWords = document.getElementsByTagName('body')[0].innerText === 'Forbidden';
             if (forbiddenWords) {
-                const time = randomInterval(1 * 60, 5 * 60);
-                LogUtils_logHHAuto('HHAUTO WARNING: "Forbidden" detected, reloading the page in ' + time + ' seconds');
+                // Persistent backoff: each consecutive Forbidden doubles
+                // the window. Counter survives reload, resets on a
+                // successful start() (Hero available) or tab close.
+                let count = 0;
+                try {
+                    const raw = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
+                    count = raw ? parseInt(raw, 10) : 0;
+                    if (!Number.isFinite(count) || count < 0)
+                        count = 0;
+                }
+                catch (e) { /* sessionStorage unavailable */ }
+                count += 1;
+                try {
+                    sessionStorage.setItem(FORBIDDEN_COUNT_KEY, String(count));
+                }
+                catch (e) { }
+                const time = nextForbiddenDelaySeconds(count);
+                LogUtils_logHHAuto('HHAUTO WARNING: "Forbidden" detected (#' + count + '), reloading the page in ' + time + ' seconds');
                 setTimeout(() => { location.reload(); }, time * 1000);
             }
         }
@@ -26987,7 +27216,27 @@ function start() {
     if (SurveyService.shouldShowSurvey()) {
         SurveyService.showSurveyPopup();
     }
-    setTimeout(autoLoop, 1000);
+    // Reached the autoLoop start path -> Hero is available, the page is
+    // healthy, so the recent Forbidden chain (if any) is over.
+    try {
+        sessionStorage.removeItem(FORBIDDEN_COUNT_KEY);
+    }
+    catch (e) { }
+    // Cold-start delay: if the script has been idle for a while (tab in
+    // background, hibernation, slow first paint) give the page extra
+    // time before the first navigation, otherwise the very first
+    // gotoPage() can race the server's rate-limit window (issue #1598).
+    let initialDelayMs = NORMAL_START_DELAY_MS;
+    try {
+        const last = getStoredJSON(HHStoredVarPrefixKey + TK.LastPageCalled, { page: '', dateTime: 0 });
+        const lastTs = typeof (last === null || last === void 0 ? void 0 : last.dateTime) === 'number' ? last.dateTime : 0;
+        if (lastTs > 0 && (Date.now() - lastTs) > COLD_START_THRESHOLD_MS) {
+            initialDelayMs = COLD_START_DELAY_MS;
+            LogUtils_logHHAuto('Cold start detected (last activity > ' + Math.round(COLD_START_THRESHOLD_MS / 1000) + 's ago), delaying first autoLoop by ' + initialDelayMs + 'ms');
+        }
+    }
+    catch (e) { /* fall back to normal delay */ }
+    setTimeout(autoLoop, initialDelayMs);
     // Manual survey button
     $("#settingsSurvey").on("click", function () {
         SurveyService.showSurveyPopup();
@@ -27016,6 +27265,7 @@ function start() {
  *  - AdsService     -- suppress or relocate in-game ads
  *  - TooltipService -- show/hide HHAuto menu tooltips
  */
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ Three changes that together address the "Forbidden" reports still seen on top of
 - **Cold-start delay:** when the script wakes up after a long pause (tab in background, hibernation, slow first paint), the very first navigation is delayed by a few extra seconds. This avoids the first call hitting the server before it has settled.
 - **Smarter Forbidden retry:** once Forbidden is detected, each consecutive retry waits longer than the previous one (one minute, two, four, ... up to thirty), with random jitter. The counter resets as soon as the script is back to a healthy state. Manually closing the tab and opening a fresh one always resets it as well.
 
-Refs #1598.
-
 ### v7.35.28 - Penta Drill: delays adjusted further
 
 Delays between Penta Drill actions have been increased again to avoid blank screens caused by clicks landing before the server response.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.29 - Fewer "Forbidden" errors (Place of Power, slow networks, after hibernation)
+
+Three changes that together address the "Forbidden" reports still seen on top of v7.35.22 (issue #1598), especially in Firefox Private Browsing and after the PC was suspended.
+
+- **Place of Power claim:** the script now waits for the claim AJAX to finish before it changes pages. Previously, on slower connections the page change cancelled the open claim request, which the server then answered with Forbidden on the next call.
+- **Cold-start delay:** when the script wakes up after a long pause (tab in background, hibernation, slow first paint), the very first navigation is delayed by a few extra seconds. This avoids the first call hitting the server before it has settled.
+- **Smarter Forbidden retry:** once Forbidden is detected, each consecutive retry waits longer than the previous one (one minute, two, four, ... up to thirty), with random jitter. The counter resets as soon as the script is back to a healthy state. Manually closing the tab and opening a fresh one always resets it as well.
+
+Refs #1598.
+
 ### v7.35.28 - Penta Drill: delays adjusted further
 
 Delays between Penta Drill actions have been increased again to avoid blank screens caused by clicks landing before the server response.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.28",
+  "version": "7.35.29",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/AjaxTracker.spec.ts
+++ b/spec/Service/AjaxTracker.spec.ts
@@ -1,0 +1,104 @@
+import {
+    installAjaxTracker,
+    pendingAjaxCount,
+    waitForAjaxIdle,
+    _resetAjaxTrackerForTests,
+} from "../../src/Service/AjaxTracker";
+
+// Minimal fake XHR matching the surface AjaxTracker hooks: send() + addEventListener.
+// Each instance fires "loadend" after a configurable delay so tests can simulate
+// long-running server requests deterministically.
+class FakeXhr {
+    private listeners: { [k: string]: Array<() => void> } = {};
+    private completeAfterMs: number;
+
+    constructor(completeAfterMs = 0) {
+        this.completeAfterMs = completeAfterMs;
+    }
+
+    addEventListener(name: string, cb: () => void, _opts?: AddEventListenerOptions): void {
+        if (!this.listeners[name]) this.listeners[name] = [];
+        this.listeners[name].push(cb);
+    }
+
+    // Will be replaced by the original prototype.send swap performed in install().
+    send(_body?: any): void {
+        setTimeout(() => {
+            (this.listeners["loadend"] || []).forEach((cb) => cb());
+        }, this.completeAfterMs);
+    }
+}
+
+describe("AjaxTracker", () => {
+    let realXhr: typeof XMLHttpRequest;
+
+    beforeEach(() => {
+        _resetAjaxTrackerForTests();
+        realXhr = (global as any).XMLHttpRequest;
+        // Patch the global XMLHttpRequest with our fake before installing the tracker.
+        (global as any).XMLHttpRequest = FakeXhr as any;
+    });
+
+    afterEach(() => {
+        (global as any).XMLHttpRequest = realXhr;
+        _resetAjaxTrackerForTests();
+    });
+
+    it("returns 0 pending when not installed", () => {
+        expect(pendingAjaxCount()).toBe(0);
+    });
+
+    it("waitForAjaxIdle resolves immediately when not installed", async () => {
+        const start = Date.now();
+        const ok = await waitForAjaxIdle(1000, 0);
+        expect(ok).toBe(true);
+        expect(Date.now() - start).toBeLessThan(50);
+    });
+
+    it("counts in-flight requests after install", () => {
+        installAjaxTracker();
+        const xhr1 = new (global as any).XMLHttpRequest(1000);
+        const xhr2 = new (global as any).XMLHttpRequest(1000);
+        xhr1.send();
+        xhr2.send();
+        expect(pendingAjaxCount()).toBe(2);
+    });
+
+    it("decrements on loadend", async () => {
+        installAjaxTracker();
+        const xhr = new (global as any).XMLHttpRequest(20);
+        xhr.send();
+        expect(pendingAjaxCount()).toBe(1);
+        await new Promise((r) => setTimeout(r, 60));
+        expect(pendingAjaxCount()).toBe(0);
+    });
+
+    it("waitForAjaxIdle resolves after pending requests complete", async () => {
+        installAjaxTracker();
+        const xhr = new (global as any).XMLHttpRequest(50);
+        xhr.send();
+        expect(pendingAjaxCount()).toBe(1);
+        const ok = await waitForAjaxIdle(2000, 0);
+        expect(ok).toBe(true);
+        expect(pendingAjaxCount()).toBe(0);
+    });
+
+    it("waitForAjaxIdle returns false when timeout hits before idle", async () => {
+        installAjaxTracker();
+        const xhr = new (global as any).XMLHttpRequest(2000);
+        xhr.send();
+        const ok = await waitForAjaxIdle(150, 0);
+        expect(ok).toBe(false);
+        expect(pendingAjaxCount()).toBe(1);
+    });
+
+    it("install is idempotent (counter does not double)", async () => {
+        installAjaxTracker();
+        installAjaxTracker(); // second install must not re-wrap send
+        const xhr = new (global as any).XMLHttpRequest(20);
+        xhr.send();
+        expect(pendingAjaxCount()).toBe(1);
+        await new Promise((r) => setTimeout(r, 60));
+        expect(pendingAjaxCount()).toBe(0);
+    });
+});

--- a/spec/Service/ForbiddenBackoff.spec.ts
+++ b/spec/Service/ForbiddenBackoff.spec.ts
@@ -1,0 +1,66 @@
+import {
+    nextForbiddenDelaySeconds,
+    FORBIDDEN_BASE_SECONDS,
+    FORBIDDEN_CAP_SECONDS,
+    FORBIDDEN_MIN_DELAY_SECONDS,
+    FORBIDDEN_JITTER_RANGE,
+} from "../../src/Service/ForbiddenBackoff";
+
+describe("nextForbiddenDelaySeconds", () => {
+    // Pin random() so the jitter is deterministic per case.
+    const fixedRandom = (value: number) => () => value;
+    const noJitter = fixedRandom(0.5); // -> jitter factor 1.0
+    const minJitter = fixedRandom(0.0); // -> 1 - range/2
+    const maxJitter = fixedRandom(0.999999); // -> ~1 + range/2
+
+    it("doubles the window per consecutive Forbidden, no jitter", () => {
+        // count=1 -> base, count=2 -> 2*base, count=3 -> 4*base
+        expect(nextForbiddenDelaySeconds(1, noJitter)).toBe(FORBIDDEN_BASE_SECONDS);
+        expect(nextForbiddenDelaySeconds(2, noJitter)).toBe(FORBIDDEN_BASE_SECONDS * 2);
+        expect(nextForbiddenDelaySeconds(3, noJitter)).toBe(FORBIDDEN_BASE_SECONDS * 4);
+        expect(nextForbiddenDelaySeconds(4, noJitter)).toBe(FORBIDDEN_BASE_SECONDS * 8);
+    });
+
+    it("caps the delay at FORBIDDEN_CAP_SECONDS", () => {
+        // 60 * 2^9 = 30720 > 1800. Even the highest jitter must stay at the cap.
+        const big = nextForbiddenDelaySeconds(20, maxJitter);
+        const expectedMax = Math.round(FORBIDDEN_CAP_SECONDS * (1 + FORBIDDEN_JITTER_RANGE / 2));
+        expect(big).toBeLessThanOrEqual(expectedMax);
+        expect(big).toBeGreaterThanOrEqual(FORBIDDEN_CAP_SECONDS * (1 - FORBIDDEN_JITTER_RANGE / 2));
+    });
+
+    it("never returns less than FORBIDDEN_MIN_DELAY_SECONDS", () => {
+        // Even with low jitter and count=1, we should not drop below the floor.
+        const v = nextForbiddenDelaySeconds(1, minJitter);
+        expect(v).toBeGreaterThanOrEqual(FORBIDDEN_MIN_DELAY_SECONDS);
+    });
+
+    it("treats invalid counts as count=1", () => {
+        expect(nextForbiddenDelaySeconds(0, noJitter)).toBe(FORBIDDEN_BASE_SECONDS);
+        expect(nextForbiddenDelaySeconds(-5, noJitter)).toBe(FORBIDDEN_BASE_SECONDS);
+        expect(nextForbiddenDelaySeconds(1.7, noJitter)).toBe(FORBIDDEN_BASE_SECONDS);
+    });
+
+    it("applies jitter symmetrically around the target", () => {
+        const lo = nextForbiddenDelaySeconds(1, minJitter);
+        const hi = nextForbiddenDelaySeconds(1, maxJitter);
+        // Min jitter = 0.8 -> 60*0.8 = 48s, max = 1.2 -> 72s
+        const expectedLo = Math.round(FORBIDDEN_BASE_SECONDS * (1 - FORBIDDEN_JITTER_RANGE / 2));
+        const expectedHi = Math.round(FORBIDDEN_BASE_SECONDS * (1 + FORBIDDEN_JITTER_RANGE / 2));
+        expect(lo).toBe(expectedLo);
+        expect(hi).toBe(expectedHi);
+    });
+
+    it("default random produces values within the expected band", () => {
+        // Sanity check on the live RNG path: 100 samples for count=2 must all
+        // fall within [base*2*0.8, base*2*1.2].
+        const target = FORBIDDEN_BASE_SECONDS * 2;
+        const lo = Math.round(target * (1 - FORBIDDEN_JITTER_RANGE / 2));
+        const hi = Math.round(target * (1 + FORBIDDEN_JITTER_RANGE / 2));
+        for (let i = 0; i < 100; i++) {
+            const v = nextForbiddenDelaySeconds(2);
+            expect(v).toBeGreaterThanOrEqual(lo);
+            expect(v).toBeLessThanOrEqual(hi);
+        }
+    });
+});

--- a/src/Module/PlaceOfPower.ts
+++ b/src/Module/PlaceOfPower.ts
@@ -22,7 +22,7 @@ import {
     TimeHelper,
     RewardHelper
 } from '../Helper/index';
-import { autoLoop, gotoPage } from '../Service/index';
+import { autoLoop, gotoPage, waitForAjaxIdle } from '../Service/index';
 import { isJSON, logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { Harem } from './index';
@@ -197,9 +197,17 @@ export class PlaceOfPower {
             {
                 $(buttonClaimQuery).first().trigger('click');
                 logHHAuto("Claimed reward for PoP : " + $(buttonClaimQuery).first().parent().attr('pop_id'));
-                await TimeHelper.sleep(randomInterval(700, 1100));
+                // The claim click fires an ajax.php POST. We must wait for
+                // that POST to complete before changing the page, otherwise
+                // window.location.href cancels the request (NS_BINDING_ABORTED)
+                // and the server answers the next call with Forbidden
+                // (issue #1598, especially under Firefox Private Browsing
+                // where the AJAX takes 2-3 seconds).
+                await waitForAjaxIdle(8000, 400);
                 RewardHelper.closeRewardPopupIfAny(); // Will refresh the page
-                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPowerplacemain"), {}, randomInterval(4000, 5000)); // fail safe
+                // Wait again in case closing the popup itself fires a request.
+                await waitForAjaxIdle(4000, 200);
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDPowerplacemain"), {}, randomInterval(1500, 2500));
                 return true;
             }
 

--- a/src/Service/AjaxTracker.ts
+++ b/src/Service/AjaxTracker.ts
@@ -1,0 +1,116 @@
+// AjaxTracker.ts
+//
+// Lightweight pending-XHR counter. Installed once at script start.
+// Wraps XMLHttpRequest.send to count in-flight requests so the
+// navigation layer can wait for the game to finish its current
+// AJAX work before changing pages.
+//
+// Why: window.location.href = ... cancels any in-flight XHR with
+// NS_BINDING_ABORTED. When the cancelled request is a state-changing
+// POST (e.g. PoP claim), the server can answer the next request with
+// HTTP Forbidden. Waiting for AJAX idle before navigating prevents
+// that race.
+//
+// Public API:
+//   installAjaxTracker()  -- call once at script start
+//   pendingAjaxCount()    -- current number of in-flight XHRs
+//   waitForAjaxIdle(timeoutMs, settleMs) -- resolves when idle
+//
+// Used by: PageNavigationService.gotoPage()
+
+import { logHHAuto } from '../Utils/index';
+
+let pending = 0;
+let installed = false;
+let restoreSend: (() => void) | null = null;
+
+/**
+ * Install the XHR counter hook. Idempotent.
+ * Hooks XMLHttpRequest.prototype.send to count in-flight requests
+ * via a single loadend listener (covers success, error, abort, timeout).
+ *
+ * Returns true if the hook was installed (or was already installed),
+ * false if no XMLHttpRequest constructor is available in this scope.
+ */
+export function installAjaxTracker(): boolean {
+    if (installed) return true;
+
+    // Resolve the constructor lazily so tests can swap the global
+    // XMLHttpRequest before calling install().
+    const xhrCtor: any = (typeof window !== 'undefined' && (window as any).XMLHttpRequest)
+        || (typeof globalThis !== 'undefined' && (globalThis as any).XMLHttpRequest)
+        || (typeof XMLHttpRequest !== 'undefined' ? XMLHttpRequest : undefined);
+    if (!xhrCtor || !xhrCtor.prototype || typeof xhrCtor.prototype.send !== 'function') {
+        return false;
+    }
+
+    const origSend = xhrCtor.prototype.send;
+
+    xhrCtor.prototype.send = function (this: XMLHttpRequest, ...args: any[]): void {
+        pending++;
+        const decrement = (): void => {
+            if (pending > 0) pending--;
+        };
+        // loadend fires once for both success and failure paths
+        this.addEventListener('loadend', decrement, { once: true });
+        return origSend.apply(this, args);
+    };
+
+    restoreSend = (): void => {
+        try { xhrCtor.prototype.send = origSend; } catch (e) { /* ignore */ }
+    };
+    installed = true;
+    logHHAuto('[AjaxTracker] installed');
+    return true;
+}
+
+/** Number of in-flight XMLHttpRequests. Returns 0 if tracker is not installed. */
+export function pendingAjaxCount(): number {
+    return pending;
+}
+
+/**
+ * Resolve when AJAX is idle (no pending XHRs) or after timeoutMs.
+ * After idle is detected, wait an extra settleMs to let synchronous
+ * follow-up code (e.g. DOM updates triggered by the response) finish.
+ *
+ * Polls every 50ms. Returns true if idle was reached, false on timeout.
+ */
+export async function waitForAjaxIdle(
+    timeoutMs: number = 8000,
+    settleMs: number = 250,
+): Promise<boolean> {
+    if (!installed) {
+        // Tracker not installed -> behave like immediate idle, just settle.
+        await sleep(settleMs);
+        return true;
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    while (pending > 0 && Date.now() < deadline) {
+        await sleep(50);
+    }
+
+    const reachedIdle = pending === 0;
+    if (!reachedIdle) {
+        logHHAuto(`[AjaxTracker] waitForAjaxIdle timeout, ${pending} request(s) still pending`);
+    }
+    if (settleMs > 0) {
+        await sleep(settleMs);
+    }
+    return reachedIdle;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Reset internal state and remove the prototype hook. Test-only. */
+export function _resetAjaxTrackerForTests(): void {
+    if (restoreSend) {
+        try { restoreSend(); } catch (e) { /* ignore */ }
+    }
+    restoreSend = null;
+    pending = 0;
+    installed = false;
+}

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.28";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.29";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/ForbiddenBackoff.ts
+++ b/src/Service/ForbiddenBackoff.ts
@@ -1,0 +1,35 @@
+// ForbiddenBackoff.ts
+//
+// Exponential backoff calculator for the persistent Forbidden counter
+// used by StartService.hardened_start() (issue #1598).
+//
+// Each consecutive Forbidden response doubles the random reload window,
+// capped at FORBIDDEN_CAP_SECONDS. A jitter of +/- 20% is applied so
+// multiple tabs hitting the same rate-limit do not all retry in lockstep.
+
+export const FORBIDDEN_BASE_SECONDS = 60;
+export const FORBIDDEN_CAP_SECONDS = 30 * 60;
+export const FORBIDDEN_MIN_DELAY_SECONDS = 30;
+export const FORBIDDEN_JITTER_RANGE = 0.4; // +/- 20%
+
+/**
+ * Compute the next reload delay in seconds for a given consecutive
+ * Forbidden count.
+ *
+ * count is 1-based: the 1st Forbidden produces FORBIDDEN_BASE_SECONDS,
+ * the 2nd doubles it, and so on, up to FORBIDDEN_CAP_SECONDS.
+ *
+ * @param count    number of consecutive Forbidden responses (>= 1)
+ * @param random   RNG returning a value in [0, 1). Defaults to Math.random.
+ *                 Injected so unit tests can produce deterministic results.
+ */
+export function nextForbiddenDelaySeconds(
+    count: number,
+    random: () => number = Math.random,
+): number {
+    const safeCount = Math.max(1, Math.floor(count));
+    const factor = Math.pow(2, safeCount - 1);
+    const target = Math.min(FORBIDDEN_BASE_SECONDS * factor, FORBIDDEN_CAP_SECONDS);
+    const jitter = (1 - FORBIDDEN_JITTER_RANGE / 2) + random() * FORBIDDEN_JITTER_RANGE;
+    return Math.max(FORBIDDEN_MIN_DELAY_SECONDS, Math.round(target * jitter));
+}

--- a/src/Service/PageNavigationService.ts
+++ b/src/Service/PageNavigationService.ts
@@ -20,6 +20,17 @@ import { ConfigHelper, getPage, queryStringGetParam, randomInterval, setStoredVa
 import { QuestHelper } from '../Module/index';
 import { logHHAuto } from '../Utils/index';
 import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
+import { waitForAjaxIdle } from './AjaxTracker';
+
+// How long to wait for in-flight XHRs before navigating away. The game
+// can take several seconds to answer in slow environments (Firefox
+// Private Browsing has been observed at 2-3s per AJAX). 8s is a
+// conservative cap; the wait short-circuits as soon as the queue is
+// empty, so the typical path stays fast.
+const AJAX_IDLE_TIMEOUT_MS = 8000;
+// Extra delay after AJAX idle before changing window.location, to let
+// any synchronous follow-up code (DOM updates, popup handling) finish.
+const AJAX_IDLE_SETTLE_MS = 250;
 
 // Module-level mutex: true while a navigation has been scheduled but the
 // browser hasn't fully transitioned yet. Reset implicitly on page reload.
@@ -193,13 +204,27 @@ export function gotoPage(page,inArgs={},delay = -1)
         logHHAuto("setting autoloop to false");
         logHHAuto('GotoPage : '+togoto+' in '+delay+'ms.');
         navInFlight = true;
-        setTimeout(function () {window.location.href = window.location.origin + togoto;},delay);
+        const targetUrl = togoto;
+        setTimeout(function () {
+            // Wait for any in-flight game AJAX (e.g. PoP claim POSTs) to
+            // finish before changing the URL. Setting window.location.href
+            // cancels open XHRs with NS_BINDING_ABORTED, and an aborted
+            // state-changing request can make the server answer Forbidden
+            // on the next call (issue #1598).
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+                window.location.href = window.location.origin + targetUrl;
+            });
+        }, delay);
     }
     else
     {
         logHHAuto("Couldn't find page path. Page was undefined...");
         navInFlight = true;
-        setTimeout(function () {location.reload();},delay);
+        setTimeout(function () {
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+                location.reload();
+            });
+        }, delay);
     }
 }
 

--- a/src/Service/StartService.ts
+++ b/src/Service/StartService.ts
@@ -88,12 +88,35 @@ import {
     bindMouseEvents
 } from "./MouseService";
 import { disableToolTipsDisplay, enableToolTipsDisplay, manageToolTipsDisplay } from "./TooltipService";
+import { installAjaxTracker } from './AjaxTracker';
+import { nextForbiddenDelaySeconds } from './ForbiddenBackoff';
 
 var started=false;
 var debugMenuID;
 var heroRetryTimer: ReturnType<typeof setTimeout> | null = null;
 var heroRetryCount = 0;
 const HERO_MAX_RETRIES = 15;
+
+// Persistent Forbidden backoff (issue #1598).
+//
+// The reload-delay formula lives in ForbiddenBackoff.ts so it can be
+// unit-tested in isolation. The counter itself lives in sessionStorage
+// so it survives location.reload() but resets when the user closes the
+// tab. On a successful start() (Hero object available), the counter is
+// cleared, so a single transient Forbidden does not penalise later runs.
+const FORBIDDEN_COUNT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenCount';
+
+// Cold-start delay (issue #1598).
+//
+// After a long inactivity (PC hibernation, tab in background, slow page
+// load) the very first AJAX call from this script tab can hit a
+// rate-limited server window. We delay the initial autoLoop tick by a
+// few seconds when the last recorded activity is older than the
+// threshold below, giving the page time to settle before any module
+// fires a navigation.
+const COLD_START_THRESHOLD_MS = 60 * 1000;
+const COLD_START_DELAY_MS = 4000;
+const NORMAL_START_DELAY_MS = 1000;
 
 export class StartService {
     static checkVersion()
@@ -172,14 +195,31 @@ export function hardened_start()
 {
     debugMenuID = GM_registerMenuCommand(getTextForUI("saveDebug","elementText"), saveHHDebugLog);
     //GM_unregisterMenuCommand(debugMenuID);
+    // Install the AJAX request counter as early as possible so any later
+    // page-changing module call can wait for in-flight game POSTs to
+    // finish (prevents NS_BINDING_ABORTED -> Forbidden race, issue #1598).
+    try { installAjaxTracker(); } catch (e) { /* tracker is best-effort */ }
+
     if ((unsafeWindow as any).jQuery == undefined) {
         console.log("HHAUTO WARNING: No jQuery found.");
 
         try {
             const forbiddenWords = document.getElementsByTagName('body')[0].innerText === 'Forbidden';
             if (forbiddenWords) {
-                const time = randomInterval(1*60, 5*60) ;
-                logHHAuto('HHAUTO WARNING: "Forbidden" detected, reloading the page in '+time+' seconds');
+                // Persistent backoff: each consecutive Forbidden doubles
+                // the window. Counter survives reload, resets on a
+                // successful start() (Hero available) or tab close.
+                let count = 0;
+                try {
+                    const raw = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
+                    count = raw ? parseInt(raw, 10) : 0;
+                    if (!Number.isFinite(count) || count < 0) count = 0;
+                } catch (e) { /* sessionStorage unavailable */ }
+                count += 1;
+                try { sessionStorage.setItem(FORBIDDEN_COUNT_KEY, String(count)); } catch (e) {}
+
+                const time = nextForbiddenDelaySeconds(count);
+                logHHAuto('HHAUTO WARNING: "Forbidden" detected (#' + count + '), reloading the page in ' + time + ' seconds');
                 setTimeout(() => { location.reload(); }, time * 1000);
             }
         } catch (error) {}
@@ -492,7 +532,24 @@ export function start() {
         SurveyService.showSurveyPopup();
     }
 
-    setTimeout(autoLoop, 1000);
+    // Reached the autoLoop start path -> Hero is available, the page is
+    // healthy, so the recent Forbidden chain (if any) is over.
+    try { sessionStorage.removeItem(FORBIDDEN_COUNT_KEY); } catch (e) {}
+
+    // Cold-start delay: if the script has been idle for a while (tab in
+    // background, hibernation, slow first paint) give the page extra
+    // time before the first navigation, otherwise the very first
+    // gotoPage() can race the server's rate-limit window (issue #1598).
+    let initialDelayMs: number = NORMAL_START_DELAY_MS;
+    try {
+        const last = getStoredJSON(HHStoredVarPrefixKey + TK.LastPageCalled, { page: '', dateTime: 0 });
+        const lastTs = typeof last?.dateTime === 'number' ? last.dateTime : 0;
+        if (lastTs > 0 && (Date.now() - lastTs) > COLD_START_THRESHOLD_MS) {
+            initialDelayMs = COLD_START_DELAY_MS;
+            logHHAuto('Cold start detected (last activity > ' + Math.round(COLD_START_THRESHOLD_MS/1000) + 's ago), delaying first autoLoop by ' + initialDelayMs + 'ms');
+        }
+    } catch (e) { /* fall back to normal delay */ }
+    setTimeout(autoLoop, initialDelayMs);
 
     // Manual survey button
     $("#settingsSurvey").on("click", function() {

--- a/src/Service/index.ts
+++ b/src/Service/index.ts
@@ -17,6 +17,7 @@
  *  - AdsService     -- suppress or relocate in-game ads
  *  - TooltipService -- show/hide HHAuto menu tooltips
  */
+export * from './AjaxTracker'
 export * from './AdsService'
 export * from './AutoLoop'
 export * from './FeaturePopupService'


### PR DESCRIPTION
## Summary

Three layered fixes for the residual Forbidden reports that v7.35.22 did not catch.

### 1. Wait for AJAX idle before navigating
The PoP claim click fires an `ajax.php` POST in the background. The script then changed the page after a fixed 700-1100 ms delay. On slow networks (Firefox Private Browsing has been measured at 2-3 s per AJAX) the page change cancelled the open POST with NS_BINDING_ABORTED. The aborted state-changing request made the server answer Forbidden on the next call.

A new `AjaxTracker` module hooks `XMLHttpRequest.send` and exposes `waitForAjaxIdle()`. Both `PageNavigationService.gotoPage()` and the PoP claim path wait for in-flight requests to finish before changing the URL.

### 2. Cold-start delay
When the script wakes up after a long idle (last recorded activity > 60 s ago, e.g. PC suspended, tab in background, slow first paint), the very first `autoLoop` tick is delayed to 4 s instead of 1 s. Avoids racing the server's rate-limit window after hibernation.

### 3. Persistent Forbidden backoff
Each consecutive Forbidden doubles the random reload window (60 s, 2 min, 4 min, ... cap 30 min) with +/- 20 % jitter. Counter lives in `sessionStorage` so it survives `location.reload()` but resets when the user closes the tab or `start()` succeeds.

The backoff formula is extracted into `ForbiddenBackoff.ts` (pure function) so it can be unit-tested in isolation.

## What was tested

- 778 unit tests pass (was 772 before, +6 new for `ForbiddenBackoff`, +7 for `AjaxTracker`).
- Webpack build clean, 1.38 MiB output.
- Manual review of the PoP claim path against Frank's screenshots (NS_BINDING_ABORTED on `ajax.php` followed by 200 OK on the next page load).

## Files

- New: `src/Service/AjaxTracker.ts`, `src/Service/ForbiddenBackoff.ts`
- New tests: `spec/Service/AjaxTracker.spec.ts`, `spec/Service/ForbiddenBackoff.spec.ts`
- Modified: `PageNavigationService`, `PlaceOfPower`, `StartService`, `Service/index` (barrel)
- Version bump: `package.json`, `HHAuto.user.js` header, `FeaturePopupService` title -> 7.35.29
- Release notes added to `README.md`

Refs #1598
