### PR TITLE
fix: escalate Forbidden backoff and defer navigation on AJAX timeout

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.29
+// @version      7.35.30
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -13513,21 +13513,31 @@ function getPage(checkUnknown = false, checkPop = false) {
 
 
 // How long to wait for in-flight XHRs before navigating away. The game
-// can take several seconds to answer in slow environments (Firefox
-// Private Browsing has been observed at 2-3s per AJAX). 8s is a
-// conservative cap; the wait short-circuits as soon as the queue is
-// empty, so the typical path stays fast.
-const AJAX_IDLE_TIMEOUT_MS = 8000;
+// can take well over 8 seconds to answer in slow environments (Firefox
+// Private Browsing has been observed sending the same response 10-12s
+// after the request). 15s is a conservative cap; the wait
+// short-circuits as soon as the queue is empty, so the typical path
+// stays fast.
+const AJAX_IDLE_TIMEOUT_MS = 15000;
 // Extra delay after AJAX idle before changing window.location, to let
 // any synchronous follow-up code (DOM updates, popup handling) finish.
 const AJAX_IDLE_SETTLE_MS = 250;
 // Module-level mutex: true while a navigation has been scheduled but the
 // browser hasn't fully transitioned yet. Reset implicitly on page reload.
 let navInFlight = false;
+// Throttle the "navigation already in flight" log line so a slow AJAX
+// wait does not flood the log with one entry per AutoLoop tick (issue
+// #1598 follow-up). Only emit once per NAV_BLOCKED_LOG_INTERVAL_MS.
+const NAV_BLOCKED_LOG_INTERVAL_MS = 5000;
+let lastNavBlockedLogAt = 0;
 // Returns true if on correct page.
 function gotoPage(page, inArgs = {}, delay = -1) {
     if (navInFlight) {
-        LogUtils_logHHAuto('gotoPage: navigation already in flight, ignoring ' + page);
+        const now = Date.now();
+        if (now - lastNavBlockedLogAt > NAV_BLOCKED_LOG_INTERVAL_MS) {
+            lastNavBlockedLogAt = now;
+            LogUtils_logHHAuto('gotoPage: navigation already in flight, ignoring ' + page);
+        }
         return false;
     }
     var cp = getPage();
@@ -13687,8 +13697,17 @@ function gotoPage(page, inArgs = {}, delay = -1) {
             // finish before changing the URL. Setting window.location.href
             // cancels open XHRs with NS_BINDING_ABORTED, and an aborted
             // state-changing request can make the server answer Forbidden
-            // on the next call (issue #1598).
-            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+            // on the next call (issue #1598). If the wait times out (the
+            // server is genuinely slow), abort the navigation and let
+            // AutoLoop retry on the next tick instead of cancelling the
+            // open request.
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function (idle) {
+                if (!idle) {
+                    LogUtils_logHHAuto('gotoPage: AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, deferring navigation to ' + targetUrl);
+                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
+                    navInFlight = false;
+                    return;
+                }
                 window.location.href = window.location.origin + targetUrl;
             });
         }, delay);
@@ -13697,7 +13716,13 @@ function gotoPage(page, inArgs = {}, delay = -1) {
         LogUtils_logHHAuto("Couldn't find page path. Page was undefined...");
         navInFlight = true;
         setTimeout(function () {
-            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function (idle) {
+                if (!idle) {
+                    LogUtils_logHHAuto('gotoPage: AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, deferring reload');
+                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
+                    navInFlight = false;
+                    return;
+                }
                 location.reload();
             });
         }, delay);
@@ -25848,7 +25873,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.29";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.30";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.
@@ -26802,6 +26827,35 @@ function nextForbiddenDelaySeconds(count, random = Math.random) {
     const jitter = (1 - FORBIDDEN_JITTER_RANGE / 2) + random() * FORBIDDEN_JITTER_RANGE;
     return Math.max(FORBIDDEN_MIN_DELAY_SECONDS, Math.round(target * jitter));
 }
+/**
+ * Window during which consecutive Forbidden responses are treated as the
+ * same streak (and therefore keep escalating the backoff). If the gap
+ * between two Forbiddens is larger than this window, the counter resets
+ * to 1 because the script clearly recovered for a while in between.
+ */
+const FORBIDDEN_STREAK_WINDOW_MS = 5 * 60 * 1000;
+/**
+ * Decide the next streak count given the previous count and the time
+ * since the previous Forbidden.
+ *
+ * - If there was no previous Forbidden, the new count is 1.
+ * - If the previous Forbidden is older than FORBIDDEN_STREAK_WINDOW_MS,
+ *   the streak counts as broken and the new count is 1.
+ * - Otherwise, the new count is the previous count + 1.
+ *
+ * Pure function so it can be unit-tested without sessionStorage.
+ *
+ * @param prevCount      previous stored count (>= 0)
+ * @param prevTimestamp  ms epoch of previous Forbidden, or 0 if none
+ * @param now            current ms epoch
+ */
+function nextStreakCount(prevCount, prevTimestamp, now) {
+    if (!prevTimestamp || prevCount < 1)
+        return 1;
+    if (now - prevTimestamp > FORBIDDEN_STREAK_WINDOW_MS)
+        return 1;
+    return prevCount + 1;
+}
 
 ;// CONCATENATED MODULE: ./src/Service/StartService.ts
 // StartService.ts
@@ -26852,6 +26906,7 @@ const HERO_MAX_RETRIES = 15;
 // tab. On a successful start() (Hero object available), the counter is
 // cleared, so a single transient Forbidden does not penalise later runs.
 const FORBIDDEN_COUNT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenCount';
+const FORBIDDEN_LAST_AT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenLastAt';
 // Cold-start delay (issue #1598).
 //
 // After a long inactivity (PC hibernation, tab in background, slow page
@@ -26940,19 +26995,28 @@ function hardened_start() {
             const forbiddenWords = document.getElementsByTagName('body')[0].innerText === 'Forbidden';
             if (forbiddenWords) {
                 // Persistent backoff: each consecutive Forbidden doubles
-                // the window. Counter survives reload, resets on a
-                // successful start() (Hero available) or tab close.
-                let count = 0;
+                // the window. The counter only resets when no Forbidden
+                // has been seen for FORBIDDEN_STREAK_WINDOW_MS, so
+                // brief recoveries (e.g. one PoP claim succeeding
+                // between two Forbiddens) do not reset the streak.
+                let prevCount = 0;
+                let prevAt = 0;
                 try {
-                    const raw = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
-                    count = raw ? parseInt(raw, 10) : 0;
-                    if (!Number.isFinite(count) || count < 0)
-                        count = 0;
+                    const rawCount = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
+                    prevCount = rawCount ? parseInt(rawCount, 10) : 0;
+                    if (!Number.isFinite(prevCount) || prevCount < 0)
+                        prevCount = 0;
+                    const rawAt = sessionStorage.getItem(FORBIDDEN_LAST_AT_KEY);
+                    prevAt = rawAt ? parseInt(rawAt, 10) : 0;
+                    if (!Number.isFinite(prevAt) || prevAt < 0)
+                        prevAt = 0;
                 }
                 catch (e) { /* sessionStorage unavailable */ }
-                count += 1;
+                const now = Date.now();
+                const count = nextStreakCount(prevCount, prevAt, now);
                 try {
                     sessionStorage.setItem(FORBIDDEN_COUNT_KEY, String(count));
+                    sessionStorage.setItem(FORBIDDEN_LAST_AT_KEY, String(now));
                 }
                 catch (e) { }
                 const time = nextForbiddenDelaySeconds(count);
@@ -27216,12 +27280,6 @@ function start() {
     if (SurveyService.shouldShowSurvey()) {
         SurveyService.showSurveyPopup();
     }
-    // Reached the autoLoop start path -> Hero is available, the page is
-    // healthy, so the recent Forbidden chain (if any) is over.
-    try {
-        sessionStorage.removeItem(FORBIDDEN_COUNT_KEY);
-    }
-    catch (e) { }
     // Cold-start delay: if the script has been idle for a while (tab in
     // background, hibernation, slow first paint) give the page extra
     // time before the first navigation, otherwise the very first

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.30 - "Forbidden" backoff actually escalates now (Private Browsing follow-up)
+
+Follow-up to v7.35.29 based on logs from Firefox Private Browsing where the same Forbidden kept reappearing every minute.
+
+- **Backoff escalates correctly.** Previously the retry counter reset whenever the script briefly recovered between two Forbiddens, so every reload waited only ~60 seconds. The counter now treats Forbiddens within five minutes as the same streak, so the wait actually doubles to two, four, eight, sixteen minutes (cap thirty) until the streak ends.
+- **Don't navigate away while AJAX is still busy.** If the in-flight AJAX wait times out, the script no longer changes the page. It releases the navigation lock and tries again on the next loop tick. Cancelling an in-flight game request was the original cause of the Forbidden response in the first place.
+- **AJAX wait raised to 15 seconds.** The previous 8s cap was too tight for very slow connections (Firefox Private Browsing has been observed at 10-12s per response).
+- **Less log noise.** The "navigation already in flight, ignoring" line is now throttled to at most once every five seconds.
+
 ### v7.35.29 - Fewer "Forbidden" errors (Place of Power, slow networks, after hibernation)
 
 Three changes that together address the "Forbidden" reports still seen on top of v7.35.22 (issue #1598), especially in Firefox Private Browsing and after the PC was suspended.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.29",
+  "version": "7.35.30",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/ForbiddenBackoff.spec.ts
+++ b/spec/Service/ForbiddenBackoff.spec.ts
@@ -1,9 +1,11 @@
 import {
     nextForbiddenDelaySeconds,
+    nextStreakCount,
     FORBIDDEN_BASE_SECONDS,
     FORBIDDEN_CAP_SECONDS,
     FORBIDDEN_MIN_DELAY_SECONDS,
     FORBIDDEN_JITTER_RANGE,
+    FORBIDDEN_STREAK_WINDOW_MS,
 } from "../../src/Service/ForbiddenBackoff";
 
 describe("nextForbiddenDelaySeconds", () => {
@@ -62,5 +64,35 @@ describe("nextForbiddenDelaySeconds", () => {
             expect(v).toBeGreaterThanOrEqual(lo);
             expect(v).toBeLessThanOrEqual(hi);
         }
+    });
+});
+
+describe("nextStreakCount", () => {
+    it("returns 1 when there is no previous Forbidden", () => {
+        expect(nextStreakCount(0, 0, 1_000_000)).toBe(1);
+    });
+
+    it("returns 1 when the previous count is invalid", () => {
+        expect(nextStreakCount(-3, 1_000_000, 1_000_000)).toBe(1);
+    });
+
+    it("increments the count when previous Forbidden is recent", () => {
+        const now = 10_000_000;
+        const recent = now - 30_000; // 30s ago, well inside the window
+        expect(nextStreakCount(1, recent, now)).toBe(2);
+        expect(nextStreakCount(4, recent, now)).toBe(5);
+    });
+
+    it("resets to 1 when previous Forbidden is older than the streak window", () => {
+        const now = 10_000_000;
+        const old = now - FORBIDDEN_STREAK_WINDOW_MS - 1;
+        expect(nextStreakCount(7, old, now)).toBe(1);
+    });
+
+    it("treats the streak as alive at exactly the window boundary", () => {
+        const now = 10_000_000;
+        const atBoundary = now - FORBIDDEN_STREAK_WINDOW_MS;
+        // <= window means streak continues
+        expect(nextStreakCount(2, atBoundary, now)).toBe(3);
     });
 });

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.29";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.30";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/ForbiddenBackoff.ts
+++ b/src/Service/ForbiddenBackoff.ts
@@ -33,3 +33,36 @@ export function nextForbiddenDelaySeconds(
     const jitter = (1 - FORBIDDEN_JITTER_RANGE / 2) + random() * FORBIDDEN_JITTER_RANGE;
     return Math.max(FORBIDDEN_MIN_DELAY_SECONDS, Math.round(target * jitter));
 }
+
+/**
+ * Window during which consecutive Forbidden responses are treated as the
+ * same streak (and therefore keep escalating the backoff). If the gap
+ * between two Forbiddens is larger than this window, the counter resets
+ * to 1 because the script clearly recovered for a while in between.
+ */
+export const FORBIDDEN_STREAK_WINDOW_MS = 5 * 60 * 1000;
+
+/**
+ * Decide the next streak count given the previous count and the time
+ * since the previous Forbidden.
+ *
+ * - If there was no previous Forbidden, the new count is 1.
+ * - If the previous Forbidden is older than FORBIDDEN_STREAK_WINDOW_MS,
+ *   the streak counts as broken and the new count is 1.
+ * - Otherwise, the new count is the previous count + 1.
+ *
+ * Pure function so it can be unit-tested without sessionStorage.
+ *
+ * @param prevCount      previous stored count (>= 0)
+ * @param prevTimestamp  ms epoch of previous Forbidden, or 0 if none
+ * @param now            current ms epoch
+ */
+export function nextStreakCount(
+    prevCount: number,
+    prevTimestamp: number,
+    now: number,
+): number {
+    if (!prevTimestamp || prevCount < 1) return 1;
+    if (now - prevTimestamp > FORBIDDEN_STREAK_WINDOW_MS) return 1;
+    return prevCount + 1;
+}

--- a/src/Service/PageNavigationService.ts
+++ b/src/Service/PageNavigationService.ts
@@ -23,11 +23,12 @@ import { HHStoredVarPrefixKey, SK, TK } from '../config/index';
 import { waitForAjaxIdle } from './AjaxTracker';
 
 // How long to wait for in-flight XHRs before navigating away. The game
-// can take several seconds to answer in slow environments (Firefox
-// Private Browsing has been observed at 2-3s per AJAX). 8s is a
-// conservative cap; the wait short-circuits as soon as the queue is
-// empty, so the typical path stays fast.
-const AJAX_IDLE_TIMEOUT_MS = 8000;
+// can take well over 8 seconds to answer in slow environments (Firefox
+// Private Browsing has been observed sending the same response 10-12s
+// after the request). 15s is a conservative cap; the wait
+// short-circuits as soon as the queue is empty, so the typical path
+// stays fast.
+const AJAX_IDLE_TIMEOUT_MS = 15000;
 // Extra delay after AJAX idle before changing window.location, to let
 // any synchronous follow-up code (DOM updates, popup handling) finish.
 const AJAX_IDLE_SETTLE_MS = 250;
@@ -36,11 +37,21 @@ const AJAX_IDLE_SETTLE_MS = 250;
 // browser hasn't fully transitioned yet. Reset implicitly on page reload.
 let navInFlight = false;
 
+// Throttle the "navigation already in flight" log line so a slow AJAX
+// wait does not flood the log with one entry per AutoLoop tick (issue
+// #1598 follow-up). Only emit once per NAV_BLOCKED_LOG_INTERVAL_MS.
+const NAV_BLOCKED_LOG_INTERVAL_MS = 5000;
+let lastNavBlockedLogAt = 0;
+
 // Returns true if on correct page.
 export function gotoPage(page,inArgs={},delay = -1)
 {
     if (navInFlight) {
-        logHHAuto('gotoPage: navigation already in flight, ignoring '+page);
+        const now = Date.now();
+        if (now - lastNavBlockedLogAt > NAV_BLOCKED_LOG_INTERVAL_MS) {
+            lastNavBlockedLogAt = now;
+            logHHAuto('gotoPage: navigation already in flight, ignoring '+page);
+        }
         return false;
     }
     var cp=getPage();
@@ -210,8 +221,17 @@ export function gotoPage(page,inArgs={},delay = -1)
             // finish before changing the URL. Setting window.location.href
             // cancels open XHRs with NS_BINDING_ABORTED, and an aborted
             // state-changing request can make the server answer Forbidden
-            // on the next call (issue #1598).
-            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+            // on the next call (issue #1598). If the wait times out (the
+            // server is genuinely slow), abort the navigation and let
+            // AutoLoop retry on the next tick instead of cancelling the
+            // open request.
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function (idle) {
+                if (!idle) {
+                    logHHAuto('gotoPage: AJAX still busy after '+AJAX_IDLE_TIMEOUT_MS+'ms, deferring navigation to '+targetUrl);
+                    setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "true");
+                    navInFlight = false;
+                    return;
+                }
                 window.location.href = window.location.origin + targetUrl;
             });
         }, delay);
@@ -221,7 +241,13 @@ export function gotoPage(page,inArgs={},delay = -1)
         logHHAuto("Couldn't find page path. Page was undefined...");
         navInFlight = true;
         setTimeout(function () {
-            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function () {
+            waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then(function (idle) {
+                if (!idle) {
+                    logHHAuto('gotoPage: AJAX still busy after '+AJAX_IDLE_TIMEOUT_MS+'ms, deferring reload');
+                    setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "true");
+                    navInFlight = false;
+                    return;
+                }
                 location.reload();
             });
         }, delay);

--- a/src/Service/StartService.ts
+++ b/src/Service/StartService.ts
@@ -89,7 +89,7 @@ import {
 } from "./MouseService";
 import { disableToolTipsDisplay, enableToolTipsDisplay, manageToolTipsDisplay } from "./TooltipService";
 import { installAjaxTracker } from './AjaxTracker';
-import { nextForbiddenDelaySeconds } from './ForbiddenBackoff';
+import { nextForbiddenDelaySeconds, nextStreakCount } from './ForbiddenBackoff';
 
 var started=false;
 var debugMenuID;
@@ -105,6 +105,7 @@ const HERO_MAX_RETRIES = 15;
 // tab. On a successful start() (Hero object available), the counter is
 // cleared, so a single transient Forbidden does not penalise later runs.
 const FORBIDDEN_COUNT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenCount';
+const FORBIDDEN_LAST_AT_KEY = HHStoredVarPrefixKey + 'Temp_forbiddenLastAt';
 
 // Cold-start delay (issue #1598).
 //
@@ -207,16 +208,27 @@ export function hardened_start()
             const forbiddenWords = document.getElementsByTagName('body')[0].innerText === 'Forbidden';
             if (forbiddenWords) {
                 // Persistent backoff: each consecutive Forbidden doubles
-                // the window. Counter survives reload, resets on a
-                // successful start() (Hero available) or tab close.
-                let count = 0;
+                // the window. The counter only resets when no Forbidden
+                // has been seen for FORBIDDEN_STREAK_WINDOW_MS, so
+                // brief recoveries (e.g. one PoP claim succeeding
+                // between two Forbiddens) do not reset the streak.
+                let prevCount = 0;
+                let prevAt = 0;
                 try {
-                    const raw = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
-                    count = raw ? parseInt(raw, 10) : 0;
-                    if (!Number.isFinite(count) || count < 0) count = 0;
+                    const rawCount = sessionStorage.getItem(FORBIDDEN_COUNT_KEY);
+                    prevCount = rawCount ? parseInt(rawCount, 10) : 0;
+                    if (!Number.isFinite(prevCount) || prevCount < 0) prevCount = 0;
+                    const rawAt = sessionStorage.getItem(FORBIDDEN_LAST_AT_KEY);
+                    prevAt = rawAt ? parseInt(rawAt, 10) : 0;
+                    if (!Number.isFinite(prevAt) || prevAt < 0) prevAt = 0;
                 } catch (e) { /* sessionStorage unavailable */ }
-                count += 1;
-                try { sessionStorage.setItem(FORBIDDEN_COUNT_KEY, String(count)); } catch (e) {}
+
+                const now = Date.now();
+                const count = nextStreakCount(prevCount, prevAt, now);
+                try {
+                    sessionStorage.setItem(FORBIDDEN_COUNT_KEY, String(count));
+                    sessionStorage.setItem(FORBIDDEN_LAST_AT_KEY, String(now));
+                } catch (e) {}
 
                 const time = nextForbiddenDelaySeconds(count);
                 logHHAuto('HHAUTO WARNING: "Forbidden" detected (#' + count + '), reloading the page in ' + time + ' seconds');
@@ -531,10 +543,6 @@ export function start() {
     if (SurveyService.shouldShowSurvey()) {
         SurveyService.showSurveyPopup();
     }
-
-    // Reached the autoLoop start path -> Hero is available, the page is
-    // healthy, so the recent Forbidden chain (if any) is over.
-    try { sessionStorage.removeItem(FORBIDDEN_COUNT_KEY); } catch (e) {}
 
     // Cold-start delay: if the script has been idle for a while (tab in
     // background, hibernation, slow first paint) give the page extra


### PR DESCRIPTION
## Summary

Follow-up to #1671 / v7.35.29. Logs Frank attached in https://github.com/OldRon1977/HHauto/issues/1598 (`HH_DebugLog_1778454618072.log`, v7.35.29) showed two new issues that weren't caught by the original fix:

1. The Forbidden retry counter was always logging `(#1)`, so the backoff never escalated. Reload waited ~60s every time, even after six consecutive Forbiddens in seven minutes.
2. The 8s AJAX wait was sometimes too short (Private Browsing was sending claim responses 10-12s after the request).

### 1. `nextStreakCount` helper + reset window
The previous reset logic cleared the counter on every successful `start()`. That fired between every two Forbiddens because the script always managed to claim *one* PoP before the next Forbidden hit. Counter never got past `#1`.

New `nextStreakCount(prevCount, prevTs, now)` pure helper. Counter only resets if the gap between two Forbiddens is larger than `FORBIDDEN_STREAK_WINDOW_MS` (5 min). Otherwise it keeps incrementing. Both the count and `lastForbiddenAt` timestamp now live in `sessionStorage`. The unconditional reset in `start()` is gone.

### 2. Defer navigation when AJAX times out
Old behaviour: `waitForAjaxIdle()` resolved with `false` on timeout, but `gotoPage` ignored the return value and navigated anyway. That was the original Forbidden cause (NS_BINDING_ABORTED on the in-flight POST).

New behaviour: when `waitForAjaxIdle` times out, `gotoPage` releases the navigation mutex, re-enables `autoLoop`, and returns. The next AutoLoop tick will retry the navigation. By then the AJAX is usually done.

### 3. AJAX wait raised 8s → 15s
The 8s cap was set conservatively before we had real measurements. Frank's logs show responses up to 10s. 15s gives headroom without hurting the typical fast path (the wait short-circuits as soon as the queue clears).

### 4. Throttle "navigation already in flight" log
Same `gotoPage` blocked entry was being emitted on every AutoLoop tick during a long AJAX wait (8 entries in 8 seconds in Frank's log). Now throttled to one entry per 5 s.

## What was tested

- 783 unit tests pass (was 778 before, +5 new for `nextStreakCount`).
- Webpack build clean.
- Manual review of the gotoPage flow and the streak-window logic against Frank's log.

## Files

- Modified: `ForbiddenBackoff.ts` (new `nextStreakCount` + `FORBIDDEN_STREAK_WINDOW_MS`), `StartService.ts` (uses helper, drops reset on start), `PageNavigationService.ts` (timeout 15s, defer-on-timeout, log throttle)
- Tests: `spec/Service/ForbiddenBackoff.spec.ts` extended
- Version bump: `package.json`, `HHAuto.user.js` header, `FeaturePopupService` title -> 7.35.30
- Release notes added to `README.md`

Refs #1598
