### PR TITLE
fix: parse the actual stale event in handleEventParsing

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.30
+// @version      7.35.31
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -25195,44 +25195,29 @@ const handleEventParsing = {
         // Events feature must be enabled
         if (ConfigHelper.getHHScriptVars('isEnabledEvents', false) !== true)
             return false;
-        // Skip if no event has reached its next_refresh window. Otherwise the
-        // handler navigates to the event page on every tick even though the
-        // event data is still fresh, which collides with handleLeague (and any
-        // other navigation-triggering handler) and produces a ping-pong loop
-        // between the leagues and the event pages.
-        try {
-            const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
-            const eventList = storedList ? JSON.parse(storedList) : {};
-            const now = Date.now();
-            return Object.keys(eventList).some(id => {
-                const ev = eventList[id];
-                if (!ev || ev.isCompleted)
-                    return false;
-                const nextRefresh = Number(ev.next_refresh);
-                // Trigger if next_refresh is missing/0 (first run) or in the past.
-                return !Number.isFinite(nextRefresh) || nextRefresh <= now;
-            });
-        }
-        catch (_a) {
-            // On unexpected storage shape, fall back to the previous behaviour
-            // (always trigger) so we don't accidentally skip a parse cycle.
-            return true;
-        }
+        // Trigger only if at least one stale event exists. Otherwise the handler
+        // would navigate to the event page on every tick even though the event
+        // data is still fresh, which collided with handleLeague (and any other
+        // navigation-triggering handler) and produced a ping-pong loop between
+        // the leagues and the event pages (issue #1598, #1673).
+        return getStaleEventIDs().length > 0;
     },
     steps: [
         {
             name: 'parseEvents',
             fn: () => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    // Delegate to existing EventModule logic.
-                    // eventIDs are determined at runtime from stored event list.
-                    const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
-                    const eventList = storedList ? JSON.parse(storedList) : {};
-                    const eventIDs = Object.keys(eventList).filter(id => { var _a; return !((_a = eventList[id]) === null || _a === void 0 ? void 0 : _a.isCompleted); });
-                    if (eventIDs.length === 0) {
+                    // Parse the first stale event. precondition + fn must agree on the
+                    // selection: parsing any non-stale event would leave the original
+                    // stale event untouched, so the precondition would keep firing on
+                    // the next tick (issue #1673 -- a stale Path of Attraction entry
+                    // kept the loop alive while a fresh Plus Event was being reparsed
+                    // every tick).
+                    const staleIDs = getStaleEventIDs();
+                    if (staleIDs.length === 0) {
                         return { ok: true }; // nothing to parse
                     }
-                    yield EventModule.parseEventPage(eventIDs[0]);
+                    yield EventModule.parseEventPage(staleIDs[0]);
                     return { ok: true };
                 }
                 catch (err) {
@@ -25244,6 +25229,34 @@ const handleEventParsing = {
     ],
     totalTimeoutMs: 20000,
 };
+/**
+ * Return the IDs of all unfinished events whose `next_refresh` is missing,
+ * non-finite, or already in the past. Exported for direct unit testing in
+ * Pipeline.config.spec.ts.
+ *
+ * On unexpected storage shape this returns a single sentinel ID so that the
+ * caller still triggers a parse cycle (preserves the previous fallback
+ * behaviour where the precondition returned true on parse errors).
+ */
+function getStaleEventIDs(now = Date.now()) {
+    try {
+        const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
+        const eventList = storedList ? JSON.parse(storedList) : {};
+        return Object.keys(eventList).filter(id => {
+            const ev = eventList[id];
+            if (!ev || ev.isCompleted)
+                return false;
+            const nextRefresh = Number(ev.next_refresh);
+            return !Number.isFinite(nextRefresh) || nextRefresh <= now;
+        });
+    }
+    catch (_a) {
+        // Unexpected storage shape: pretend a parse is needed so we don't
+        // accidentally skip a refresh cycle. The actual parseEventPage call
+        // tolerates an empty/garbage tab via its own "global" fallback.
+        return ['__parse_error__'];
+    }
+}
 // ---------------------------------------------------------------------------
 //  Handler: handleLeague
 //  Priority 13 -- matches original AutoLoop ordering.
@@ -25873,7 +25886,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.30";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.31";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.31 - Event/league ping-pong loop with stale events
+
+The script could bounce between the leagues page and the current event page every few seconds without making progress when an unfinished event still sat in the list with an expired refresh timestamp.
+
+- **The right event gets refreshed.** The "is a refresh due" check and the actual parse step looked at different events, so a stale entry could keep firing the trigger forever while the script kept reparsing a different, still-fresh event. The parse step now picks the actually stale event, so the timestamp gets written and the trigger stops firing.
+- **No more event/league bounce.** Once the stale entry is refreshed the parser stays quiet on its next tick, so the leagues page and the event page no longer alternate while time and energy are spent on navigation only.
+
 ### v7.35.30 - "Forbidden" backoff actually escalates now (Private Browsing follow-up)
 
 Follow-up to v7.35.29 based on logs from Firefox Private Browsing where the same Forbidden kept reappearing every minute.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.30",
+  "version": "7.35.31",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/Pipeline.config.spec.ts
+++ b/spec/Service/Pipeline.config.spec.ts
@@ -28,14 +28,16 @@ jest.mock('../../src/Helper/index', () => ({
 jest.mock('../../src/config/index', () => ({
   HHStoredVarPrefixKey: 'HHAuto_',
   SK: { master: 'master' },
-  TK: { eventIDs: 'eventIDs' },
+  TK: { eventsList: 'Temp_eventsList' },
 }));
 
 jest.mock('../../src/Utils/index', () => ({
   logHHAuto: jest.fn(),
 }));
 
-import { pipeline, HandlerConfig } from '../../src/Service/Pipeline.config';
+import { pipeline, HandlerConfig, getStaleEventIDs } from '../../src/Service/Pipeline.config';
+import { getStoredValue } from '../../src/Helper/index';
+const getStoredValueMock = getStoredValue as jest.Mock;
 
 describe('Pipeline.config', () => {
   describe('pipeline array', () => {
@@ -185,6 +187,73 @@ describe('Pipeline.config', () => {
       await expect(
         handler.onFailure!('doLeagueBattle', 'test error')
       ).resolves.toBeUndefined();
+    });
+  });
+
+
+  describe('getStaleEventIDs (issue #1673)', () => {
+    afterEach(() => {
+      getStoredValueMock.mockReset();
+    });
+
+    it('returns empty list when storage is empty', () => {
+      getStoredValueMock.mockReturnValue(undefined);
+      expect(getStaleEventIDs(1000)).toEqual([]);
+    });
+
+    it('returns empty list when all events are fresh', () => {
+      const eventList = {
+        event_251: { id: 'event_251', isCompleted: false, next_refresh: 2000 },
+        path_event_76: { id: 'path_event_76', isCompleted: false, next_refresh: 3000 },
+      };
+      getStoredValueMock.mockReturnValue(JSON.stringify(eventList));
+      expect(getStaleEventIDs(1000)).toEqual([]);
+    });
+
+    it('skips completed events even if next_refresh is stale', () => {
+      const eventList = {
+        old_event: { id: 'old_event', isCompleted: true, next_refresh: 100 },
+      };
+      getStoredValueMock.mockReturnValue(JSON.stringify(eventList));
+      expect(getStaleEventIDs(1000)).toEqual([]);
+    });
+
+    it('returns the stale event when fresh event is listed first (Issue #1673)', () => {
+      // Reproduces issue #1673: event_251 (Plus event) was fresh, but a stale
+      // path_event_76 (Path of Attraction) entry kept the precondition firing.
+      // Without this fix, fn would parse event_251 (eventIDs[0]) and leave the
+      // stale PoA entry untouched, looping forever.
+      const eventList = {
+        event_251: { id: 'event_251', isCompleted: false, next_refresh: 5000 },
+        path_event_76: { id: 'path_event_76', isCompleted: false, next_refresh: 100 },
+      };
+      getStoredValueMock.mockReturnValue(JSON.stringify(eventList));
+      expect(getStaleEventIDs(1000)).toEqual(['path_event_76']);
+    });
+
+    it('returns multiple stale events in insertion order', () => {
+      const eventList = {
+        a: { id: 'a', isCompleted: false, next_refresh: 100 },
+        b: { id: 'b', isCompleted: false, next_refresh: 5000 },
+        c: { id: 'c', isCompleted: false, next_refresh: 200 },
+      };
+      getStoredValueMock.mockReturnValue(JSON.stringify(eventList));
+      expect(getStaleEventIDs(1000)).toEqual(['a', 'c']);
+    });
+
+    it('treats missing or non-finite next_refresh as stale', () => {
+      const eventList = {
+        no_refresh: { id: 'no_refresh', isCompleted: false },
+        nan_refresh: { id: 'nan_refresh', isCompleted: false, next_refresh: 'oops' },
+      };
+      getStoredValueMock.mockReturnValue(JSON.stringify(eventList));
+      expect(getStaleEventIDs(1000).sort()).toEqual(['nan_refresh', 'no_refresh']);
+    });
+
+    it('returns sentinel ID on malformed JSON to preserve fallback parse', () => {
+      getStoredValueMock.mockReturnValue('not-json');
+      const result = getStaleEventIDs(1000);
+      expect(result).toEqual(['__parse_error__']);
     });
   });
 });

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.30";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.31";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/Pipeline.config.ts
+++ b/src/Service/Pipeline.config.ts
@@ -78,44 +78,29 @@ const handleEventParsing: HandlerConfig = {
     // Events feature must be enabled
     if (ConfigHelper.getHHScriptVars('isEnabledEvents', false) !== true) return false;
 
-    // Skip if no event has reached its next_refresh window. Otherwise the
-    // handler navigates to the event page on every tick even though the
-    // event data is still fresh, which collides with handleLeague (and any
-    // other navigation-triggering handler) and produces a ping-pong loop
-    // between the leagues and the event pages.
-    try {
-      const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
-      const eventList = storedList ? JSON.parse(storedList) : {};
-      const now = Date.now();
-      return Object.keys(eventList).some(id => {
-        const ev = eventList[id];
-        if (!ev || ev.isCompleted) return false;
-        const nextRefresh = Number(ev.next_refresh);
-        // Trigger if next_refresh is missing/0 (first run) or in the past.
-        return !Number.isFinite(nextRefresh) || nextRefresh <= now;
-      });
-    } catch {
-      // On unexpected storage shape, fall back to the previous behaviour
-      // (always trigger) so we don't accidentally skip a parse cycle.
-      return true;
-    }
+    // Trigger only if at least one stale event exists. Otherwise the handler
+    // would navigate to the event page on every tick even though the event
+    // data is still fresh, which collided with handleLeague (and any other
+    // navigation-triggering handler) and produced a ping-pong loop between
+    // the leagues and the event pages (issue #1598, #1673).
+    return getStaleEventIDs().length > 0;
   },
   steps: [
     {
       name: 'parseEvents',
       fn: async (): Promise<StepResult> => {
         try {
-          // Delegate to existing EventModule logic.
-          // eventIDs are determined at runtime from stored event list.
-          const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
-          const eventList = storedList ? JSON.parse(storedList) : {};
-          const eventIDs = Object.keys(eventList).filter(
-            id => !eventList[id]?.isCompleted
-          );
-          if (eventIDs.length === 0) {
+          // Parse the first stale event. precondition + fn must agree on the
+          // selection: parsing any non-stale event would leave the original
+          // stale event untouched, so the precondition would keep firing on
+          // the next tick (issue #1673 -- a stale Path of Attraction entry
+          // kept the loop alive while a fresh Plus Event was being reparsed
+          // every tick).
+          const staleIDs = getStaleEventIDs();
+          if (staleIDs.length === 0) {
             return { ok: true }; // nothing to parse
           }
-          await EventModule.parseEventPage(eventIDs[0]);
+          await EventModule.parseEventPage(staleIDs[0]);
           return { ok: true };
         } catch (err) {
           return { ok: false, reason: String(err), retryable: true };
@@ -126,6 +111,33 @@ const handleEventParsing: HandlerConfig = {
   ],
   totalTimeoutMs: 20_000,
 };
+
+/**
+ * Return the IDs of all unfinished events whose `next_refresh` is missing,
+ * non-finite, or already in the past. Exported for direct unit testing in
+ * Pipeline.config.spec.ts.
+ *
+ * On unexpected storage shape this returns a single sentinel ID so that the
+ * caller still triggers a parse cycle (preserves the previous fallback
+ * behaviour where the precondition returned true on parse errors).
+ */
+export function getStaleEventIDs(now: number = Date.now()): string[] {
+  try {
+    const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
+    const eventList = storedList ? JSON.parse(storedList) : {};
+    return Object.keys(eventList).filter(id => {
+      const ev = eventList[id];
+      if (!ev || ev.isCompleted) return false;
+      const nextRefresh = Number(ev.next_refresh);
+      return !Number.isFinite(nextRefresh) || nextRefresh <= now;
+    });
+  } catch {
+    // Unexpected storage shape: pretend a parse is needed so we don't
+    // accidentally skip a refresh cycle. The actual parseEventPage call
+    // tolerates an empty/garbage tab via its own "global" fallback.
+    return ['__parse_error__'];
+  }
+}
 
 // ---------------------------------------------------------------------------
 //  Handler: handleLeague


### PR DESCRIPTION
## Summary

The pipeline event handler had two different rules: the precondition
checked whether *any* unfinished event had an expired ``next_refresh``,
but the parse step always reparsed the *first* unfinished event in the
list. When a fresh Plus event came first and a stale Path of Attraction
entry came second, the fresh event was reparsed every tick, the stale
entry was never refreshed, and ``handleLeague`` kept switching to the
leaderboard between parses, producing the event/league ping-pong loop
in the attached log.

## What changed

- New ``getStaleEventIDs()`` helper. Both ``precondition`` and the
  ``parseEvents`` step call it, so they always agree on which event
  needs work.
- The step parses the first stale event, so ``next_refresh`` actually
  gets written and the trigger stops firing.
- Spec covers the original loop scenario plus edge cases (missing or
  non-finite ``next_refresh``, completed events, malformed JSON).
- Bumped version to 7.35.31, added release notes.

## Verification

- ``npx jest`` -> 790/790 pass (28 in Pipeline.config.spec.ts after
  adding 7 new ones).
- ``npm run build`` -> webpack compiled successfully, HHAuto.user.js
  regenerated with v7.35.31 header.
- Manual log walk against the attached debug dump matches the new
  selection.

Refs #1673
