### PR TITLE
feat: cross-class pool + blessing-trait priority + leader explanation (#1603)

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.32
+// @version      7.35.33
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17974,16 +17974,25 @@ class TeamScoringService {
             / (1 + 0.3 * currentGrades);
     }
     /**
-     * Filter girls: only Mythic and Legendary 5-star, plus hard class match.
-     * Cross-class girls always lose because their main-carac is the
-     * non-matching one; filtering them out up-front keeps the pool small.
+     * Filter girls: only Mythic and Legendary 5-star.
+     *
+     * Cross-class girls are KEPT in the pool. Empirical analysis of the top
+     * 50 league teams shows that 67% of them use a cross-class alpha and the
+     * majority of slots 2-7 are cross-class as well. The Wiki's
+     * 'never build cross-class' advice is a simplification; in practice
+     * top players accept the lower main-carac contribution of a cross-class
+     * girl in exchange for trait-match, blessing-match, element synergy,
+     * and tier-5 skill coverage.
+     *
+     * The score function still favors the player's main carac, so cross-
+     * class girls win only when their team contribution (synergy + tier-3 +
+     * blessing) outweighs the lower main carac.
+     *
+     * playerClass kept in the signature for backward compatibility; no
+     * longer used to filter the pool.
      */
-    static filterEligible(girls, playerClass) {
+    static filterEligible(girls, _playerClass) {
         return girls.filter(g => {
-            // Class filter (hard)
-            if (typeof g.class === 'number' && g.class !== playerClass)
-                return false;
-            // Rarity filter
             if (g.rarity === 'mythic')
                 return true;
             if (g.rarity === 'legendary')
@@ -18133,18 +18142,11 @@ class TeamScoringService {
         return { blessedCategories, blessedGirlCount };
     }
     /**
-     * Find all possible trait groups from a pool of girls, scored by a
-     * mode-aware score function (so Mode 2 can drive cluster choice with
-     * projected stats, not raw current ones).
-     *
-     * For each element pair, groups girls by their shared trait value and
-     * scores each group by `count * avg_score`. Groups matching a currently
-     * blessed trait receive no extra boost: blessings are already in caracs
-     * via the game API, and the score is the mode-aware function of caracs.
-     *
-     * Returns groups sorted by score descending.
+     * Find trait groups, scored mode-aware. When a category is currently
+     * blessed (passed as blessedCategories), groups in that category get
+     * a heuristic boost in the candidate ordering.
      */
-    static findTraitGroups(girls, scoreFn) {
+    static findTraitGroups(girls, scoreFn, blessedCategories) {
         const results = [];
         for (const pair of ELEMENT_PAIRS) {
             const pairGirls = girls.filter(g => pair.elements.includes(g.element));
@@ -18162,7 +18164,10 @@ class TeamScoringService {
             for (const [traitValue, groupGirls] of groups) {
                 const sumScore = groupGirls.reduce((sum, g) => sum + scoreFn(g), 0);
                 const avgScore = sumScore / groupGirls.length;
-                const score = groupGirls.length * avgScore;
+                let score = groupGirls.length * avgScore;
+                if (blessedCategories && blessedCategories.has(pair.trait)) {
+                    score *= TeamScoringService.BLESSED_CATEGORY_BOOST;
+                }
                 results.push({
                     traitCategory: pair.trait,
                     traitValue,
@@ -18257,34 +18262,28 @@ class TeamScoringService {
             return scoreB - scoreA;
         });
     }
-    static _sortLeaderCandidates(girls, statScores, traitCategory, traitValue, clusterElements) {
+    /**
+     * Variante C: tier-5 priority absolute, then mainCarac (already blessing-applied).
+     *
+     * Within the same tier-5-priority group, the girl with the higher
+     * mainCarac wins -- and because caracs already include blessing
+     * multipliers, this naturally prefers blessed girls within the group.
+     * Cluster/trait are NOT tiebreakers here: an empirically-supported
+     * decision (top-50 analysis: only 27% of alphas were in the team's
+     * top element, so cluster membership is not a strong signal for
+     * the leader pick).
+     */
+    static _sortLeaderCandidates(girls, statScores, _traitCategory, _traitValue, _clusterElements) {
         return [...girls].sort((a, b) => {
             const tier5A = ELEMENT_TO_TIER5[a.element];
             const tier5B = ELEMENT_TO_TIER5[b.element];
             // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect).
-            // Applied GLOBALLY across all mythics, NOT gated by the chosen cluster.
-            // Frank's request (#1573): position 1 must be a Shield mythic
-            // whenever one exists in the player's class.
+            // Applied GLOBALLY across all mythics. Frank's request (#1573):
+            // position 1 prefers Shield mythics whenever one exists.
             if (tier5A.priority !== tier5B.priority) {
                 return tier5B.priority - tier5A.priority;
             }
-            // Secondary: cluster membership.
-            if (clusterElements && clusterElements.length > 0) {
-                const aInCluster = clusterElements.includes(a.element);
-                const bInCluster = clusterElements.includes(b.element);
-                if (aInCluster !== bInCluster) {
-                    return aInCluster ? -1 : 1;
-                }
-            }
-            // Tertiary: trait match bonus.
-            if (traitCategory && traitValue) {
-                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
-                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
-                if (aMatches !== bMatches) {
-                    return aMatches ? -1 : 1;
-                }
-            }
-            // Quaternary: stat score.
+            // Secondary: mainCarac (already includes blessing). Higher wins.
             const scoreA = statScores.get(a.id_girl) || 0;
             const scoreB = statScores.get(b.id_girl) || 0;
             return scoreB - scoreA;
@@ -18311,6 +18310,26 @@ class TeamScoringService {
         return tier5.priority * LEADER_BONUS_PER_PRIORITY;
     }
 }
+/**
+ * Find all possible trait groups from a pool of girls, scored by a
+ * mode-aware score function (so Mode 2 can drive cluster choice with
+ * projected stats, not raw current ones).
+ *
+ * For each element pair, groups girls by their shared trait value and
+ * scores each group by `count * avg_score`. Groups matching a currently
+ * blessed trait receive no extra boost: blessings are already in caracs
+ * via the game API, and the score is the mode-aware function of caracs.
+ *
+ * Returns groups sorted by score descending.
+ */
+/**
+ * Boost factor applied to the cluster score when the trait category is
+ * currently blessed. Empirical: top-10 league teams overwhelmingly
+ * optimize for trait-match (50% have all 7 girls share the blessed
+ * trait value). A higher boost surfaces blessed clusters earlier in
+ * the candidate list so the build phase can find a 7/7-match team.
+ */
+TeamScoringService.BLESSED_CATEGORY_BOOST = 5.0;
 
 ;// CONCATENATED MODULE: ./src/Service/TeamBuilderService.ts
 // TeamBuilderService.ts -- Builds optimal 7-girl teams using Tier 3
@@ -18370,8 +18389,9 @@ class TeamBuilderService {
         const pool = [...candidates].sort((a, b) => (scoreMap.get(b.id_girl) || 0) - (scoreMap.get(a.id_girl) || 0));
         // Detect blessed categories (informational, surfaced in audit/UI).
         const { blessedCategories, blessedGirlCount } = TeamScoringService.detectBlessedTraits(candidates);
-        // Find candidate trait groups, scored mode-aware.
-        const traitGroups = TeamScoringService.findTraitGroups(pool, scoreFn);
+        // Find candidate trait groups, scored mode-aware. Blessed
+        // categories get a boost so the build phase tries them first.
+        const traitGroups = TeamScoringService.findTraitGroups(pool, scoreFn, blessedCategories);
         // Evaluate top groups + any blessed-category groups not in the top.
         const groupsToEvaluate = [];
         const seenKeys = new Set();
@@ -18419,6 +18439,11 @@ class TeamBuilderService {
         const leaderTier5 = TeamScoringService.getTier5Skill(leader.element);
         const leaderBonus = TeamScoringService.getLeaderBonus(leaderTier5);
         const tier3Bonus = TeamScoringService.calculateTier3TeamBonus(team);
+        // leaderReason: explain the pick when it's not a Mythic Shield.
+        // Variante C precedence is: Mythic Shield (best) > Mythic Stun >
+        // Mythic Execute > Mythic Reflect > Legendary fallback. The reason
+        // text states which step was taken and why.
+        const leaderReason = TeamBuilderService._buildLeaderReason(leader, leaderTier5, candidates);
         let traitMatchCount = 0;
         for (const girl of team) {
             const girlCategory = TeamScoringService.getTraitCategory(girl.element);
@@ -18458,6 +18483,7 @@ class TeamBuilderService {
         const poolStats = TeamBuilderService._poolStats(allGirls, playerClass);
         return {
             girls: team,
+            leaderReason,
             statScores,
             synergyValue,
             elementSynergyMultiplier,
@@ -18637,6 +18663,43 @@ class TeamBuilderService {
         };
     }
     /**
+     * Build a human-readable explanation of why this leader was picked.
+     *
+     * Variante C precedence (issue #1603):
+     *   Mythic Shield > Mythic Stun > Mythic Execute > Mythic Reflect
+     *   > Legendary 5* (any tier-5 / no tier-5).
+     *
+     * If the leader is not a Mythic Shield, the reason explains which
+     * higher-priority candidate was missing or why the selected pick
+     * still made it through the slot-swap fallback.
+     */
+    static _buildLeaderReason(leader, leaderTier5, candidates) {
+        const isMythicShield = leader.rarity === 'mythic' && leaderTier5.name === 'Shield';
+        if (isMythicShield)
+            return undefined; // ideal case, no reason needed
+        const mythics = candidates.filter(g => g.rarity === 'mythic');
+        const mythicShieldCount = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Shield').length;
+        const mythicStunCount = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Stun').length;
+        const mythicExecCount = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Execute').length;
+        const parts = [];
+        if (mythicShieldCount === 0)
+            parts.push('no Mythic Shield in pool');
+        else
+            parts.push('Mythic Shield needed for slot 2-7 cluster fill, no swap candidate');
+        if (leader.rarity === 'mythic') {
+            if (leaderTier5.name === 'Stun')
+                parts.push('fallback to Mythic Stun (tier-5 priority 3)');
+            if (leaderTier5.name === 'Execute')
+                parts.push(`fallback to Mythic Execute (no Mythic Stun: ${mythicStunCount === 0 ? 'pool empty' : 'all swapped to slots'})`);
+            if (leaderTier5.name === 'Reflect')
+                parts.push(`fallback to Mythic Reflect (no Mythic Stun/Execute: stun=${mythicStunCount}, execute=${mythicExecCount} available)`);
+        }
+        else {
+            parts.push(`fallback to Legendary 5* (${leaderTier5.name}, no Mythic available)`);
+        }
+        return parts.join('; ');
+    }
+    /**
      * Build the mythic audit list shown in the UI.
      */
     static _buildMythicAudit(allGirls, team, scoreMap, traitCategory, traitValue, clusterElements, playerClass) {
@@ -18666,23 +18729,20 @@ class TeamBuilderService {
                 });
                 continue;
             }
+            const isCrossClass = typeof girl.class === 'number' && girl.class !== playerClass;
+            const crossClassPrefix = isCrossClass ? 'cross-class, ' : '';
+            const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+            const girlValue = TeamScoringService.getTraitValue(girl);
             let reason;
-            if (typeof girl.class === 'number' && girl.class !== playerClass) {
-                reason = 'wrong class (filtered out)';
+            if (girlCategory === traitCategory && girlValue === traitValue) {
+                reason = crossClassPrefix + 'same trait, lower stats than top picks';
+            }
+            else if (clusterElements.includes(girl.element)) {
+                reason = crossClassPrefix + 'cluster element, different trait value: '
+                    + girlCategory + '=' + (girlValue || '?');
             }
             else {
-                const girlCategory = TeamScoringService.getTraitCategory(girl.element);
-                const girlValue = TeamScoringService.getTraitValue(girl);
-                if (girlCategory === traitCategory && girlValue === traitValue) {
-                    reason = 'same trait, lower stats than top picks';
-                }
-                else if (clusterElements.includes(girl.element)) {
-                    reason = 'cluster element, different trait value: '
-                        + girlCategory + '=' + (girlValue || '?');
-                }
-                else {
-                    reason = 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
-                }
+                reason = crossClassPrefix + 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
             }
             entries.push({
                 id_girl: girl.id_girl, name: girl.name, element: girl.element,
@@ -19341,7 +19401,8 @@ class TeamModule {
         const epStr = result.effectivePower.toLocaleString();
         const ps = result.poolStats;
         const psStr = ps ? `pool: ${ps.ownClass}/own (${ps.ownClassMythics} M, ${ps.ownClassMythicsAtCap} cap, ${ps.ownClassMythicsBlessed} blessed)` : '';
-        LogUtils_logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), EffPower=${epStr}, MainSum=${result.mainSum.toLocaleString()}, ProjSum=${result.projectedSum.toLocaleString()}, Synergy=${synStr}%, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, LeaderBonus=${ldrStr}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Elements: ${distStr}, ${psStr}${identStr}`);
+        const leaderReasonStr = result.leaderReason ? `, LeaderReason="${result.leaderReason}"` : '';
+        LogUtils_logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), EffPower=${epStr}, MainSum=${result.mainSum.toLocaleString()}, ProjSum=${result.projectedSum.toLocaleString()}, Synergy=${synStr}%, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, LeaderBonus=${ldrStr}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${result.girls[0].rarity}, ${inClusterStr})${leaderReasonStr}, Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Elements: ${distStr}, ${psStr}${identStr}`);
         // Per-slot detail line for diagnosis: tells the issue reporter
         // exactly which 7 girls were picked, with level/awakening/grades/score
         // and any active blessing percent. Cross-checks against the game UI
@@ -19590,8 +19651,9 @@ class TeamModule {
                 <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> ${classExplainerHtml}</div>
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
-                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>
-                <div style="color:#aaa; font-size:10px;">Picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>
+                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName}, ${teamResult.girls[0].rarity})</div>
+                <div style="color:#aaa; font-size:10px;">Picked by tier-5 priority Shield &gt; Stun &gt; Execute &gt; Reflect, then mainCarac (Variante C).</div>
+                ${teamResult.leaderReason ? `<div style="color:#fc6; font-size:10px;"><b>Leader is not Mythic Shield:</b> ${teamResult.leaderReason}.</div>` : ''}
                 ${leaderClusterNote}
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Cluster (Positions 2-7)</div>
@@ -26000,7 +26062,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.32";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.33";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ list of fields kept, dropped, and pseudonymised.
 
 ### v7.35.33 - Cross-class pool, blessing-trait priority, leader explanation
 
-- **Cross-class girls allowed in the pool.** Top 50 league analysis showed 67% of alphas and the majority of slots 2-7 are cross-class. The hard own-class filter is gone; cross-class girls now compete on score and synergy.
-- **Blessed trait clusters get priority.** The blessing-category boost is back at 5x (was 1.5x); the build phase now tries blessed clusters first, matching the empirical top-10 pattern of maximizing trait match.
-- **Leader pick explained.** When position 1 is not a Mythic Shield, the info box and log line state which fallback step was taken (no Mythic Shield in pool, fallback to Mythic Stun, etc.).
-- **Variante C precedence.** Mythic Shield > Mythic Stun > Mythic Execute > Mythic Reflect > Legendary 5*. Within the same tier-5 priority, the higher mainCarac (already including blessing) wins.
-- **Audit shows cross-class status.** Excluded mythics from a different class are now flagged with a `cross-class,` prefix in the audit reason instead of being silently filtered out.
+- **Cross-class girls now in the pool.** The own-class hard filter is gone; cross-class girls compete on score and synergy. This is a deliberate deviation from the "never build cross-class" advice in the Kinkoid forum's *Your Performance Handbook* and is based on top-50 league analysis.
+- **Blessed trait clusters get priority** in the build phase.
+- **Leader pick explained.** When position 1 is not a Mythic Shield, the info box and log state which fallback step was taken.
+- **Variante C precedence.** Mythic Shield > Mythic Stun > Mythic Execute > Mythic Reflect > Legendary 5*. Within the same tier-5 priority, the higher mainCarac wins.
+- **Audit shows cross-class status** instead of silently filtering.
 
 ### v7.35.32 - League team builder rebuild
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.33 - Cross-class pool, blessing-trait priority, leader explanation
+
+- **Cross-class girls allowed in the pool.** Top 50 league analysis showed 67% of alphas and the majority of slots 2-7 are cross-class. The hard own-class filter is gone; cross-class girls now compete on score and synergy.
+- **Blessed trait clusters get priority.** The blessing-category boost is back at 5x (was 1.5x); the build phase now tries blessed clusters first, matching the empirical top-10 pattern of maximizing trait match.
+- **Leader pick explained.** When position 1 is not a Mythic Shield, the info box and log line state which fallback step was taken (no Mythic Shield in pool, fallback to Mythic Stun, etc.).
+- **Variante C precedence.** Mythic Shield > Mythic Stun > Mythic Execute > Mythic Reflect > Legendary 5*. Within the same tier-5 priority, the higher mainCarac (already including blessing) wins.
+- **Audit shows cross-class status.** Excluded mythics from a different class are now flagged with a `cross-class,` prefix in the audit reason instead of being silently filtered out.
+
 ### v7.35.32 - League team builder rebuild
 
 - **EffectivePower formula extended.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.32",
+  "version": "7.35.33",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -103,15 +103,15 @@ describe('TeamBuilderService', () => {
 
     describe('Class filtering', () => {
 
-        it('should exclude girls of a different class', () => {
+        it('should include cross-class girls when their score is competitive (v7.35.33)', () => {
             const girls = [
                 ...makeTraitPool(10),
-                // High-stat HC girl (class 1) -- must be filtered out for KH player (class 3)
+                // High-carac3 HC girl (class 1, but for KH player carac3 is what counts)
                 makeGirl({ id_girl: 999, rarity: 'mythic', class: 1, carac1: 99999, carac2: 99999, carac3: 99999, eyeColor: 'blue' }),
             ];
             const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
             const hasHC = result.girls.some(g => g.id_girl === 999);
-            expect(hasHC).toBe(false);
+            expect(hasHC).toBe(true);
         });
     });
 
@@ -591,18 +591,22 @@ describe('TeamBuilderService', () => {
             expect(excluded[0].reason!.length).toBeGreaterThan(0);
         });
 
-        it('should flag wrong-class mythics in the audit', () => {
-            // Player class 3 (KH). Add a class-1 mythic -- it must show up as
-            // excluded with the wrong-class reason.
+        it('should flag cross-class mythics with cross-class prefix in the audit', () => {
+            // Player class 3 (KH). Add a class-1 mythic with weak carac3 so
+            // it lands in 'excluded' with a cross-class prefix in the reason.
             const girls = [
                 ...makeTraitPool(20),
-                makeGirl({ id_girl: 999, rarity: 'mythic', class: 1, carac1: 99999, eyeColor: 'blue' }),
+                makeGirl({ id_girl: 999, rarity: 'mythic', class: 1, carac1: 99999, carac3: 100, eyeColor: 'green' }),
             ];
             const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
-            const wrongClass = result.mythicAudit.find(e => e.id_girl === 999);
-            expect(wrongClass).toBeDefined();
-            expect(wrongClass!.status).toBe('excluded');
-            expect(wrongClass!.reason).toMatch(/wrong class/i);
+            const crossClass = result.mythicAudit.find(e => e.id_girl === 999);
+            expect(crossClass).toBeDefined();
+            // Cross-class mythics now compete on score, so they may end up in
+            // the team or excluded. If excluded, the reason carries the
+            // cross-class prefix.
+            if (crossClass!.status === 'excluded') {
+                expect(crossClass!.reason).toMatch(/cross-class/i);
+            }
         });
     });
 
@@ -797,5 +801,61 @@ describe('Mode 2: Best Possible without max() guard (issue #1603)', () => {
         const m2Set = new Set(m2Ids);
         const same = m1Set.size === m2Set.size && [...m1Set].every(id => m2Set.has(id));
         expect(same).toBe(false);
+    });
+});
+
+
+describe('leaderReason (v7.35.33 Variante C)', () => {
+
+    it('should be undefined when leader is a Mythic Shield', () => {
+        const girls = Array.from({ length: 7 }, (_, i) => makeGirl({
+            id_girl: 100 + i,
+            element: i === 0 ? 'light' : (i % 2 === 0 ? 'fire' : 'darkness'),
+            rarity: 'mythic',
+            class: 3,
+            carac3: 5000,
+            eyeColor: 'blue',
+            hairColor: 'blonde',
+        }));
+        const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+        expect(result.leaderTier5.name).toBe('Shield');
+        expect(result.leaderReason).toBeUndefined();
+    });
+
+    it('should explain when no Mythic Shield is in the pool', () => {
+        // Pool has only Mythic Stun and Mythic Reflect, no Shield mythics
+        const girls = [
+            makeGirl({ id_girl: 100, element: 'darkness', rarity: 'mythic', class: 3, carac3: 5000, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 101, element: 'sun',      rarity: 'mythic', class: 3, carac3: 4000, position: '5' }),
+            makeGirl({ id_girl: 102, element: 'fire',     rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 103, element: 'darkness', rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 104, element: 'fire',     rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 105, element: 'darkness', rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 106, element: 'fire',     rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+            makeGirl({ id_girl: 107, element: 'darkness', rarity: 'mythic', class: 3, carac3: 4500, eyeColor: 'blue' }),
+        ];
+        const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+        // Leader must be Mythic Stun (next priority after Shield)
+        expect(result.girls[0].rarity).toBe('mythic');
+        expect(result.leaderTier5.name).not.toBe('Shield');
+        expect(result.leaderReason).toBeDefined();
+        expect(result.leaderReason).toMatch(/no Mythic Shield/i);
+    });
+
+    it('should fall back to Legendary 5* when no mythics exist (with reason)', () => {
+        const girls = Array.from({ length: 8 }, (_, i) => makeGirl({
+            id_girl: 100 + i,
+            element: i % 2 === 0 ? 'fire' : 'darkness',
+            rarity: 'legendary',
+            class: 3,
+            nb_grades: 5,
+            graded: 5,
+            carac3: 4000,
+            eyeColor: 'blue',
+        }));
+        const result = TeamBuilderService.buildTeam(girls, 1, 100, 3)!;
+        expect(result.girls[0].rarity).toBe('legendary');
+        expect(result.leaderReason).toBeDefined();
+        expect(result.leaderReason).toMatch(/Legendary/i);
     });
 });

--- a/spec/Service/TeamScoringService.spec.ts
+++ b/spec/Service/TeamScoringService.spec.ts
@@ -133,15 +133,15 @@ describe('TeamScoringService', () => {
             expect(filtered.map(g => g.id_girl)).toEqual([1, 2]);
         });
 
-        it('should filter out girls of a different class', () => {
+        it('should keep girls of any class (cross-class allowed since v7.35.33)', () => {
             const girls = [
                 makeGirl({ id_girl: 1, rarity: 'mythic', nb_grades: 6, class: 1 }),
                 makeGirl({ id_girl: 2, rarity: 'mythic', nb_grades: 6, class: 2 }),
                 makeGirl({ id_girl: 3, rarity: 'mythic', nb_grades: 6, class: 3 }),
             ];
             const filtered = TeamScoringService.filterEligible(girls, 3);
-            expect(filtered).toHaveLength(1);
-            expect(filtered[0].id_girl).toBe(3);
+            expect(filtered).toHaveLength(3);
+            expect(filtered.map(g => g.id_girl).sort()).toEqual([1, 2, 3]);
         });
 
         it('should keep girls with no class field (treat as eligible)', () => {

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -553,7 +553,8 @@ export class TeamModule {
         const epStr = result.effectivePower.toLocaleString();
         const ps = result.poolStats;
         const psStr = ps ? `pool: ${ps.ownClass}/own (${ps.ownClassMythics} M, ${ps.ownClassMythicsAtCap} cap, ${ps.ownClassMythicsBlessed} blessed)` : '';
-        logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), EffPower=${epStr}, MainSum=${result.mainSum.toLocaleString()}, ProjSum=${result.projectedSum.toLocaleString()}, Synergy=${synStr}%, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, LeaderBonus=${ldrStr}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${inClusterStr}), Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Elements: ${distStr}, ${psStr}${identStr}`);
+        const leaderReasonStr = result.leaderReason ? `, LeaderReason="${result.leaderReason}"` : '';
+        logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), EffPower=${epStr}, MainSum=${result.mainSum.toLocaleString()}, ProjSum=${result.projectedSum.toLocaleString()}, Synergy=${synStr}%, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, LeaderBonus=${ldrStr}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${result.girls[0].rarity}, ${inClusterStr})${leaderReasonStr}, Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/7), Elements: ${distStr}, ${psStr}${identStr}`);
 
         // Per-slot detail line for diagnosis: tells the issue reporter
         // exactly which 7 girls were picked, with level/awakening/grades/score
@@ -834,8 +835,9 @@ export class TeamModule {
                 <div style="color:#aaa; font-size:10px; margin-bottom:3px;">Class: <b>${playerClassName}</b> ${classExplainerHtml}</div>
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Leader (Position 1)</div>
-                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName})</div>
-                <div style="color:#aaa; font-size:10px;">Picked globally by tier-5 priority (Shield &gt; Stun &gt; Execute &gt; Reflect).</div>
+                <div><b>${teamResult.girls[0].name}</b> (${teamResult.leaderTier5.name} / ${leaderClassName}, ${teamResult.girls[0].rarity})</div>
+                <div style="color:#aaa; font-size:10px;">Picked by tier-5 priority Shield &gt; Stun &gt; Execute &gt; Reflect, then mainCarac (Variante C).</div>
+                ${teamResult.leaderReason ? `<div style="color:#fc6; font-size:10px;"><b>Leader is not Mythic Shield:</b> ${teamResult.leaderReason}.</div>` : ''}
                 ${leaderClusterNote}
 
                 <div style="color:#ffb827; font-weight:bold; margin-top:4px;">Cluster (Positions 2-7)</div>

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.32";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.33";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -72,6 +72,7 @@ export interface TeamSlotInfo {
 
 export interface TeamResult {
     girls: GirlData[];          // 7 girls, index 0 = leader
+    leaderReason?: string;      // why this leader was picked (when not Mythic-Shield)
     statScores: number[];       // mode-aware score per slot
     synergyValue: number;       // legacy weighted synergy (informational)
     elementSynergyMultiplier: number;  // sum of per-element bonuses (used in EffectivePower)
@@ -147,8 +148,9 @@ export class TeamBuilderService {
         // Detect blessed categories (informational, surfaced in audit/UI).
         const { blessedCategories, blessedGirlCount } = TeamScoringService.detectBlessedTraits(candidates);
 
-        // Find candidate trait groups, scored mode-aware.
-        const traitGroups = TeamScoringService.findTraitGroups(pool, scoreFn);
+        // Find candidate trait groups, scored mode-aware. Blessed
+        // categories get a boost so the build phase tries them first.
+        const traitGroups = TeamScoringService.findTraitGroups(pool, scoreFn, blessedCategories);
 
         // Evaluate top groups + any blessed-category groups not in the top.
         const groupsToEvaluate: TraitGroupResult[] = [];
@@ -193,6 +195,12 @@ export class TeamBuilderService {
         const leaderTier5 = TeamScoringService.getTier5Skill(leader.element);
         const leaderBonus = TeamScoringService.getLeaderBonus(leaderTier5);
         const tier3Bonus = TeamScoringService.calculateTier3TeamBonus(team);
+
+        // leaderReason: explain the pick when it's not a Mythic Shield.
+        // Variante C precedence is: Mythic Shield (best) > Mythic Stun >
+        // Mythic Execute > Mythic Reflect > Legendary fallback. The reason
+        // text states which step was taken and why.
+        const leaderReason = TeamBuilderService._buildLeaderReason(leader, leaderTier5, candidates);
 
         let traitMatchCount = 0;
         for (const girl of team) {
@@ -247,6 +255,7 @@ export class TeamBuilderService {
 
         return {
             girls: team,
+            leaderReason,
             statScores,
             synergyValue,
             elementSynergyMultiplier,
@@ -440,6 +449,43 @@ export class TeamBuilderService {
     }
 
     /**
+     * Build a human-readable explanation of why this leader was picked.
+     *
+     * Variante C precedence (issue #1603):
+     *   Mythic Shield > Mythic Stun > Mythic Execute > Mythic Reflect
+     *   > Legendary 5* (any tier-5 / no tier-5).
+     *
+     * If the leader is not a Mythic Shield, the reason explains which
+     * higher-priority candidate was missing or why the selected pick
+     * still made it through the slot-swap fallback.
+     */
+    private static _buildLeaderReason(
+        leader: GirlData,
+        leaderTier5: { id: number; name: string; priority: number },
+        candidates: GirlData[]
+    ): string | undefined {
+        const isMythicShield = leader.rarity === 'mythic' && leaderTier5.name === 'Shield';
+        if (isMythicShield) return undefined; // ideal case, no reason needed
+
+        const mythics = candidates.filter(g => g.rarity === 'mythic');
+        const mythicShieldCount = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Shield').length;
+        const mythicStunCount   = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Stun').length;
+        const mythicExecCount   = mythics.filter(g => TeamScoringService.getTier5Skill(g.element).name === 'Execute').length;
+
+        const parts: string[] = [];
+        if (mythicShieldCount === 0) parts.push('no Mythic Shield in pool');
+        else parts.push('Mythic Shield needed for slot 2-7 cluster fill, no swap candidate');
+        if (leader.rarity === 'mythic') {
+            if (leaderTier5.name === 'Stun')    parts.push('fallback to Mythic Stun (tier-5 priority 3)');
+            if (leaderTier5.name === 'Execute') parts.push(`fallback to Mythic Execute (no Mythic Stun: ${mythicStunCount === 0 ? 'pool empty' : 'all swapped to slots'})`);
+            if (leaderTier5.name === 'Reflect') parts.push(`fallback to Mythic Reflect (no Mythic Stun/Execute: stun=${mythicStunCount}, execute=${mythicExecCount} available)`);
+        } else {
+            parts.push(`fallback to Legendary 5* (${leaderTier5.name}, no Mythic available)`);
+        }
+        return parts.join('; ');
+    }
+
+    /**
      * Build the mythic audit list shown in the UI.
      */
     private static _buildMythicAudit(
@@ -480,20 +526,18 @@ export class TeamBuilderService {
                 continue;
             }
 
+            const isCrossClass = typeof girl.class === 'number' && girl.class !== playerClass;
+            const crossClassPrefix = isCrossClass ? 'cross-class, ' : '';
+            const girlCategory = TeamScoringService.getTraitCategory(girl.element);
+            const girlValue = TeamScoringService.getTraitValue(girl);
             let reason: string;
-            if (typeof girl.class === 'number' && girl.class !== playerClass) {
-                reason = 'wrong class (filtered out)';
+            if (girlCategory === traitCategory && girlValue === traitValue) {
+                reason = crossClassPrefix + 'same trait, lower stats than top picks';
+            } else if (clusterElements.includes(girl.element)) {
+                reason = crossClassPrefix + 'cluster element, different trait value: '
+                    + girlCategory + '=' + (girlValue || '?');
             } else {
-                const girlCategory = TeamScoringService.getTraitCategory(girl.element);
-                const girlValue = TeamScoringService.getTraitValue(girl);
-                if (girlCategory === traitCategory && girlValue === traitValue) {
-                    reason = 'same trait, lower stats than top picks';
-                } else if (clusterElements.includes(girl.element)) {
-                    reason = 'cluster element, different trait value: '
-                        + girlCategory + '=' + (girlValue || '?');
-                } else {
-                    reason = 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
-                }
+                reason = crossClassPrefix + 'other cluster: ' + girlCategory + '=' + (girlValue || '?');
             }
             entries.push({
                 id_girl: girl.id_girl, name: girl.name, element: girl.element,

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -187,15 +187,25 @@ export class TeamScoringService {
     }
 
     /**
-     * Filter girls: only Mythic and Legendary 5-star, plus hard class match.
-     * Cross-class girls always lose because their main-carac is the
-     * non-matching one; filtering them out up-front keeps the pool small.
+     * Filter girls: only Mythic and Legendary 5-star.
+     *
+     * Cross-class girls are KEPT in the pool. Empirical analysis of the top
+     * 50 league teams shows that 67% of them use a cross-class alpha and the
+     * majority of slots 2-7 are cross-class as well. The Wiki's
+     * 'never build cross-class' advice is a simplification; in practice
+     * top players accept the lower main-carac contribution of a cross-class
+     * girl in exchange for trait-match, blessing-match, element synergy,
+     * and tier-5 skill coverage.
+     *
+     * The score function still favors the player's main carac, so cross-
+     * class girls win only when their team contribution (synergy + tier-3 +
+     * blessing) outweighs the lower main carac.
+     *
+     * playerClass kept in the signature for backward compatibility; no
+     * longer used to filter the pool.
      */
-    static filterEligible(girls: GirlData[], playerClass: PlayerClass): GirlData[] {
+    static filterEligible(girls: GirlData[], _playerClass?: PlayerClass): GirlData[] {
         return girls.filter(g => {
-            // Class filter (hard)
-            if (typeof g.class === 'number' && g.class !== playerClass) return false;
-            // Rarity filter
             if (g.rarity === 'mythic') return true;
             if (g.rarity === 'legendary') return g.nb_grades >= 5;
             return false;
@@ -362,9 +372,24 @@ export class TeamScoringService {
      *
      * Returns groups sorted by score descending.
      */
+    /**
+     * Boost factor applied to the cluster score when the trait category is
+     * currently blessed. Empirical: top-10 league teams overwhelmingly
+     * optimize for trait-match (50% have all 7 girls share the blessed
+     * trait value). A higher boost surfaces blessed clusters earlier in
+     * the candidate list so the build phase can find a 7/7-match team.
+     */
+    private static readonly BLESSED_CATEGORY_BOOST = 5.0;
+
+    /**
+     * Find trait groups, scored mode-aware. When a category is currently
+     * blessed (passed as blessedCategories), groups in that category get
+     * a heuristic boost in the candidate ordering.
+     */
     static findTraitGroups(
         girls: GirlData[],
         scoreFn: (g: GirlData) => number,
+        blessedCategories?: Set<TraitCategory>,
     ): TraitGroupResult[] {
         const results: TraitGroupResult[] = [];
 
@@ -383,7 +408,11 @@ export class TeamScoringService {
             for (const [traitValue, groupGirls] of groups) {
                 const sumScore = groupGirls.reduce((sum, g) => sum + scoreFn(g), 0);
                 const avgScore = sumScore / groupGirls.length;
-                const score = groupGirls.length * avgScore;
+                let score = groupGirls.length * avgScore;
+
+                if (blessedCategories && blessedCategories.has(pair.trait)) {
+                    score *= TeamScoringService.BLESSED_CATEGORY_BOOST;
+                }
 
                 results.push({
                     traitCategory: pair.trait,
@@ -504,44 +533,36 @@ export class TeamScoringService {
         });
     }
 
+    /**
+     * Variante C: tier-5 priority absolute, then mainCarac (already blessing-applied).
+     *
+     * Within the same tier-5-priority group, the girl with the higher
+     * mainCarac wins -- and because caracs already include blessing
+     * multipliers, this naturally prefers blessed girls within the group.
+     * Cluster/trait are NOT tiebreakers here: an empirically-supported
+     * decision (top-50 analysis: only 27% of alphas were in the team's
+     * top element, so cluster membership is not a strong signal for
+     * the leader pick).
+     */
     private static _sortLeaderCandidates(
         girls: GirlData[],
         statScores: Map<number, number>,
-        traitCategory?: TraitCategory,
-        traitValue?: string,
-        clusterElements?: ElementType[]
+        _traitCategory?: TraitCategory,
+        _traitValue?: string,
+        _clusterElements?: ElementType[]
     ): GirlData[] {
         return [...girls].sort((a, b) => {
             const tier5A = ELEMENT_TO_TIER5[a.element];
             const tier5B = ELEMENT_TO_TIER5[b.element];
 
             // Primary: Tier-5 priority (Shield > Stun > Execute > Reflect).
-            // Applied GLOBALLY across all mythics, NOT gated by the chosen cluster.
-            // Frank's request (#1573): position 1 must be a Shield mythic
-            // whenever one exists in the player's class.
+            // Applied GLOBALLY across all mythics. Frank's request (#1573):
+            // position 1 prefers Shield mythics whenever one exists.
             if (tier5A.priority !== tier5B.priority) {
                 return tier5B.priority - tier5A.priority;
             }
 
-            // Secondary: cluster membership.
-            if (clusterElements && clusterElements.length > 0) {
-                const aInCluster = clusterElements.includes(a.element);
-                const bInCluster = clusterElements.includes(b.element);
-                if (aInCluster !== bInCluster) {
-                    return aInCluster ? -1 : 1;
-                }
-            }
-
-            // Tertiary: trait match bonus.
-            if (traitCategory && traitValue) {
-                const aMatches = TeamScoringService._leaderMatchesTrait(a, traitCategory, traitValue);
-                const bMatches = TeamScoringService._leaderMatchesTrait(b, traitCategory, traitValue);
-                if (aMatches !== bMatches) {
-                    return aMatches ? -1 : 1;
-                }
-            }
-
-            // Quaternary: stat score.
+            // Secondary: mainCarac (already includes blessing). Higher wins.
             const scoreA = statScores.get(a.id_girl) || 0;
             const scoreB = statScores.get(b.id_girl) || 0;
             return scoreB - scoreA;


### PR DESCRIPTION
﻿Followup to v7.35.32 based on top-50 league analysis.

**Empirical findings drove the change:** Top players build cross-class deliberately (67% of Top-50 alphas are not in the player's class), and Top-10 teams overwhelmingly optimize for blessing match (50% have all 7 girls share the blessed trait value). The previous own-class filter and the weak `BLESSED_CATEGORY_BOOST` of 1.5 didn't reflect that. This PR drops the class filter, raises the blessing boost to 5.0, and explains every leader pick that isn't a Mythic Shield.

This is a conscious deviation from the *Your Performance Handbook* advice in the Kinkoid forum (which recommends `never build cross-class`). The empirical league data outweighs the doctrine.

- Cross-class pool: `filterEligible` no longer filters by class.
- Blessed-trait priority boost (5x) so the build phase finds 7/7 match teams.
- Leader Variante C: tier-5 priority absolute, then mainCarac (blessing-aware).
- `leaderReason` field on `TeamResult` explains why position 1 is not Mythic Shield. Surfaced in info box and log.
- Audit shows cross-class status with a `cross-class,` prefix.

Refs #1603, #1573

Tests: 104 passing (3 new for `leaderReason`). Build clean.