### PR TITLE
chore(release): v7.35.35

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.34
+// @version      7.35.35
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -26196,7 +26196,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.34";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.35";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.35 - Forbidden race fix in PoP, BossBang, Champion
+
+- **PoP claim path now waits up to 15s for the claim POST** before navigating, matching `gotoPage`. The previous 8s cap was too short for slow connections (Firefox Private Browsing has been observed taking 10-12s).
+- **Wait result is now respected.** When the AJAX wait times out, the navigation is deferred and AutoLoop retries on the next tick instead of cancelling the open POST.
+- **BossBang fight navigation** routed through the same AJAX-idle wait instead of writing `location.href` directly.
+- **Champion auto-team-build and reorder reload** routed through the same AJAX-idle wait instead of `location.reload()`.
+- **Shared timeout constants** so PageNavigation and individual modules cannot drift apart again.
+
 ### v7.35.34 - Trait-match priority and Mode 2 clarity
 
 - **Slot fill prefers Legendary 5* with trait match** over Mythic without trait match in the cluster-first strategy. Empirical: keeping the Tier-3 chain pays off more than forcing Mythic-only fills.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.34",
+  "version": "7.35.35",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -51,7 +51,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.34";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.35";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
Release v7.35.35.

- Version bumped from 7.35.34 to 7.35.35 (`package.json`, banner via `BannerBuilder`, popup title in `FeaturePopupService`).
- README "Latest Updates" entry added on top, summarising the navigation/AJAX changes from #1680.
- Rebuilt `HHAuto.user.js` (banner + popup title now show 7.35.35).

Changes shipped to users in this version come from #1680 (PoP / BossBang / Champion AJAX-idle fix).

Refs #1598