### PR TITLE
fix(deps): resync package-lock with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6778,20 +6778,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/dependency-tree/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/deps-regex": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",
@@ -7983,20 +7969,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/filing-cabinet/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/fill-range": {
@@ -12152,20 +12124,6 @@
         "typescript": "^5.4.4 || ^6.0.2"
       }
     },
-    "node_modules/precinct/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -14405,9 +14363,9 @@
       "peer": true
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",


### PR DESCRIPTION
﻿CI on main has been failing since PR #1686 with:

> Invalid: lock file's typescript@5.3.3 does not satisfy typescript@5.9.3

Root cause: `npm ci` is strict; `npm install` is not. The lockfile
listed three nested copies of typescript@5.9.3 (under `dependency-tree`,
`filing-cabinet`, `precinct` -- all part of the madge subtree)
while the top-level entry stayed at 5.3.3.

Fix: `npm install --package-lock-only` deduplicates the lockfile.
typescript is hoisted to 5.9.3 (within the existing `^5.3.3` semver
range from package.json, so no package.json change). The three nested
copies disappear. `+3 / -45` lockfile diff.

Verified locally: `npm ci` -> clean, `npm run typecheck` -> clean,
`npm run build` -> 1.4 MiB bundle, `npm test` -> 56 suites /
807 specs passing.

Build infrastructure only, no version bump.
