### PR TITLE
fix: correct world 24 troll mapping for Daddy

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.45
+// @version      7.35.46
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17920,7 +17920,7 @@ class HentaiHeroes {
     }
 }
 HentaiHeroes.spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4k-IpxTTTELAeaipjR_v1twlqW5vbI'; // zoopokemon
-HentaiHeroes.trollIdMapping = { 21: 19, 24: 20 };
+HentaiHeroes.trollIdMapping = { 21: 19, 24: 22 };
 HentaiHeroes.sideTrollIdMapping = { 22: 20, 23: 21 };
 HentaiHeroes.lastQuestId = 2116; //  TODO update when new quest comes
 
@@ -26995,7 +26995,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.45";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.46";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ list of fields kept, dropped, and pseudonymised.
 
 ## Latest Updates
 
+### v7.35.46 - World 24 Daddy fight typo fix
+
+- **Daddy boss now resolves to the correct troll on world 24.** A typo in the world-to-troll mapping table sent the bot to Arthur (id 20) instead of Daddy (id 22) when fighting on world 24. The mapping is corrected so Auto Troll, the "first/last troll with girl" picker and the troll dropdown resolve world 24 to Daddy again.
+
 ### v7.35.45 - Bot keeps moving while waiting for combativity
 
 - **League, Season, Quest, Champion and friends keep running.** When the troll path was waiting for an energy refill (Plus Event / Plus Mythic / Plus Raid Stars / Plus Raid pending with power=0), the bot froze on the troll loop and skipped every other handler. The wait flag now only suppresses the two pipeline navigations that originally caused the ping-pong loop (event page, leagues page) and leaves classic AutoLoop handlers alone.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.45",
+  "version": "7.35.46",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.45";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.46";
 
 /**
  * HTML content for the feature popup.

--- a/src/config/game/HentaiHeroesVars.ts
+++ b/src/config/game/HentaiHeroesVars.ts
@@ -4,7 +4,7 @@
 
 export class HentaiHeroes {
     static spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4k-IpxTTTELAeaipjR_v1twlqW5vbI'; // zoopokemon
-    static trollIdMapping = { 21: 19, 24: 20 };
+    static trollIdMapping = { 21: 19, 24: 22 };
     static sideTrollIdMapping = { 22: 20, 23: 21 };
     static lastQuestId = 2116; //  TODO update when new quest comes
     static getEnv() {


### PR DESCRIPTION
Fix typo in the Hentai Heroes troll-id mapping table.

World 24 (Daddy) was mapped to troll 20 (Arthur). Auto Troll, the troll-with-girl picker and the troll dropdown therefore resolved world 24 to the wrong opponent. Mapping changed to `{ 21: 19, 24: 22 }`.

Refs #1694