### PR TITLE
chore: clean up ADR-003 markers in Champion and Troll

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.50
+// @version      7.35.51
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -9662,12 +9662,7 @@ var Troll_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _ar
 
 
 
-// >>> ADR-003 / issue #1598 - troll:imports begin
-// CLEANUP-MODE (when stable): remove only the two marker comment lines.
-// REVERT-MODE (if unstable): if no other ADR-003 block remains in this file,
-// remove this import statement entirely.
 
-// <<< ADR-003 / issue #1598 - troll:imports end
 
 
 
@@ -10190,22 +10185,6 @@ class Troll {
                                 || bypassThreshold)
                             && ((eventTrollGirl === null || eventTrollGirl === void 0 ? void 0 : eventTrollGirl.is_mythic) || getStoredValue(HHStoredVarPrefixKey + SK.useX50FightsAllowNormalEvent) === "true")) {
                             LogUtils_logHHAuto("Going to crush 50 times: " + trollz[Number(TTF)] + ' for ' + battleButtonX50Price + ' kobans.');
-                            // >>> ADR-003 / issue #1598 - troll:battleX50 begin
-                            // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                            // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                            // with the pre-fix code:
-                            //     setHHVars('Hero.infos.hc_confirm',true);
-                            //     Booster.resetBattleResponseFlag();
-                            //     battleButtonX50[0].click();
-                            //     setHHVars('Hero.infos.hc_confirm',hcConfirmValue);
-                            //     logHHAuto(`Crushed 50 times: ${trollz[Number(TTF)]} for ${battleButtonX50Price} kobans.`);
-                            //     if (getStoredValue(HHStoredVarPrefixKey+TK.questRequirement) === "battle") {
-                            //         setStoredValue(HHStoredVarPrefixKey+TK.questRequirement, "none");
-                            //     }
-                            //     RewardHelper.ObserveAndGetGirlRewards();
-                            //     await Booster.waitForBattleResponse();
-                            //     return;
-                            // and (if no other ADR-003 block remains in this file) drop the imports above.
                             if (!acquirePostMutex('troll:battleX50')) {
                                 LogUtils_logHHAuto('Troll: another POST in flight, deferring x50 battle');
                                 return;
@@ -10231,7 +10210,6 @@ class Troll {
                                 yield awaitServerSettleAfterPost(x50Duration);
                             else
                                 LogUtils_logHHAuto('Troll: x50 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                            // <<< ADR-003 / issue #1598 - troll:battleX50 end
                             return;
                         }
                         else {
@@ -10248,22 +10226,6 @@ class Troll {
                                 || bypassThreshold)
                             && ((eventTrollGirl === null || eventTrollGirl === void 0 ? void 0 : eventTrollGirl.is_mythic) || getStoredValue(HHStoredVarPrefixKey + SK.useX10FightsAllowNormalEvent) === "true")) {
                             LogUtils_logHHAuto(`Going to crush 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
-                            // >>> ADR-003 / issue #1598 - troll:battleX10 begin
-                            // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                            // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                            // with the pre-fix code:
-                            //     setHHVars('Hero.infos.hc_confirm',true);
-                            //     Booster.resetBattleResponseFlag();
-                            //     battleButtonX10[0].click();
-                            //     setHHVars('Hero.infos.hc_confirm',hcConfirmValue);
-                            //     logHHAuto(`Crushed 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
-                            //     if (getStoredValue(HHStoredVarPrefixKey+TK.questRequirement) === "battle") {
-                            //         setStoredValue(HHStoredVarPrefixKey+TK.questRequirement, "none");
-                            //     }
-                            //     RewardHelper.ObserveAndGetGirlRewards();
-                            //     await Booster.waitForBattleResponse();
-                            //     return;
-                            // and (if no other ADR-003 block remains in this file) drop the imports above.
                             if (!acquirePostMutex('troll:battleX10')) {
                                 LogUtils_logHHAuto('Troll: another POST in flight, deferring x10 battle');
                                 return;
@@ -10289,7 +10251,6 @@ class Troll {
                                 yield awaitServerSettleAfterPost(x10Duration);
                             else
                                 LogUtils_logHHAuto('Troll: x10 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                            // <<< ADR-003 / issue #1598 - troll:battleX10 end
                             return;
                         }
                         else {
@@ -10322,12 +10283,6 @@ class Troll {
                         //replaceCheatClick();
                         checkPreviousFightDone();
                         setStoredValue(HHStoredVarPrefixKey + TK.trollPoints, currentPower);
-                        // >>> ADR-003 / issue #1598 - troll:battle begin
-                        // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                        // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                        // with the pre-fix code:
-                        //     battleButton[0].click();
-                        // and (if no other ADR-003 block remains in this file) drop the imports above.
                         if (!acquirePostMutex('troll:battle')) {
                             LogUtils_logHHAuto('Troll: another POST in flight, deferring single battle');
                             return;
@@ -10341,7 +10296,6 @@ class Troll {
                             yield awaitServerSettleAfterPost(battleDuration);
                         else
                             LogUtils_logHHAuto('Troll: battle AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                        // <<< ADR-003 / issue #1598 - troll:battle end
                     }
                     else {
                         // We need more power.
@@ -10359,12 +10313,6 @@ class Troll {
                     checkPreviousFightDone();
                     setStoredValue(HHStoredVarPrefixKey + TK.trollPoints, currentPower);
                     //replaceCheatClick();
-                    // >>> ADR-003 / issue #1598 - troll:battleNoEvent begin
-                    // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                    // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                    // with the pre-fix code:
-                    //     battleButton[0].click();
-                    // and (if no other ADR-003 block remains in this file) drop the imports above.
                     if (!acquirePostMutex('troll:battleNoEvent')) {
                         LogUtils_logHHAuto('Troll: another POST in flight, deferring single battle (no event)');
                         return;
@@ -10378,7 +10326,6 @@ class Troll {
                         yield awaitServerSettleAfterPost(battleNoEventDuration);
                     else
                         LogUtils_logHHAuto('Troll: battle (no event) AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                    // <<< ADR-003 / issue #1598 - troll:battleNoEvent end
                 }
             }
             else {
@@ -13602,12 +13549,7 @@ var Champion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, 
 
 
 
-// >>> ADR-003 / issue #1598 - champion:imports begin
-// CLEANUP-MODE (when stable): remove only the two marker comment lines.
-// REVERT-MODE (if unstable): if no other ADR-003 block remains in this file,
-// remove this import statement entirely.
 
-// <<< ADR-003 / issue #1598 - champion:imports end
 
 
 
@@ -13797,14 +13739,6 @@ class Champion {
                     }
                 }
                 var newDraftInterval = girlsClicked ? randomInterval(1800, 2500) : randomInterval(800, 1500);
-                // >>> ADR-003 / issue #1598 - champion:newDraft begin
-                // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                // with the pre-fix code:
-                //     setTimeout(function() {
-                //         if ($(newDraftButtonQuery).length > 0) $(newDraftButtonQuery).trigger('click');
-                //     }, newDraftInterval);
-                // and (if no other ADR-003 block remains in this file) drop the imports above.
                 setTimeout(function () {
                     return Champion_awaiter(this, void 0, void 0, function* () {
                         if ($(newDraftButtonQuery).length === 0)
@@ -13824,7 +13758,6 @@ class Champion {
                             LogUtils_logHHAuto('Champion: new-draft AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                     });
                 }, newDraftInterval);
-                // <<< ADR-003 / issue #1598 - champion:newDraft end
                 LogUtils_logHHAuto("Free drafts remanings :" + freeDrafts);
                 counterLoop++;
                 if (freeDrafts > 0 && counterLoop <= maxLoops) {
@@ -13833,12 +13766,6 @@ class Champion {
                 else {
                     Champion.ChampClearAutoTeamPopup();
                     $('#updateChampTeamButton').removeAttr('disabled').text(getTextForUI("updateChampTeamButton", "elementText") + ' x' + maxLoops);
-                    // >>> ADR-003 / issue #1598 - champion:confirmDraft begin
-                    // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                    // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                    // with the pre-fix code:
-                    //     if ($(confirmDraftButtonQuery).length > 0) $(confirmDraftButtonQuery).trigger('click');
-                    // and (if no other ADR-003 block remains in this file) drop the imports above.
                     if ($(confirmDraftButtonQuery).length > 0) {
                         if (acquirePostMutex('champion:confirmDraft')) {
                             const confirmStart = Date.now();
@@ -13856,7 +13783,6 @@ class Champion {
                             $(confirmDraftButtonQuery).trigger('click');
                         }
                     }
-                    // <<< ADR-003 / issue #1598 - champion:confirmDraft end
                     if (getStoredValue(HHStoredVarPrefixKey + SK.autoBuildChampsTeam) === "true") {
                         LogUtils_logHHAuto('Auto team ended, sort girls after build');
                         yield TimeHelper.sleep(randomInterval(800, 1200));
@@ -13926,30 +13852,6 @@ class Champion {
             const champTeamId = Number(getHHVars('championData.champion.id'));
             $("#orderTeam").attr('disabled', 'disabled');
             const isClub = getPage() == ConfigHelper.getHHScriptVars("pagesIDClubChampion");
-            // >>> ADR-003 / issue #1598 - champion:reorder begin
-            // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-            // REVERT-MODE (if unstable): replace this whole block, including the markers,
-            // with the pre-fix code:
-            //     var switchGirls = function (targettedTeam: number[]) {
-            //         return new Promise((resolve) => {
-            //             const params = {
-            //                 action: "champion_team_reorder",
-            //                 team_order: targettedTeam,
-            //                 id_champion: champTeamId,
-            //                 champion_type: isClub ? "club_champion" : "champion"
-            //             };
-            //             getHHAjax()(params, function (data: any) {
-            //                 if(data.success == false) {
-            //                     logHHAuto('Error occured during champion team reorder', data);
-            //                 }
-            //                 resolve(data.success || true);
-            //             }, function (err) {
-            //                 logHHAuto('Error occured during champion team reorder', err);
-            //                 resolve(false);
-            //             });
-            //         });
-            //     };
-            // and (if no other ADR-003 block remains in this file) drop the imports above.
             var switchGirls = function (targettedTeam) {
                 return Champion_awaiter(this, void 0, void 0, function* () {
                     if (!acquirePostMutex('champion:reorder')) {
@@ -13980,7 +13882,6 @@ class Champion {
                     return result;
                 });
             };
-            // <<< ADR-003 / issue #1598 - champion:reorder end
             let currentGirlOrder = [...champTeam.map(g => g.id_girl)]; // To be stored as string
             LogUtils_logHHAuto('Ordering champion team', currentGirlOrder);
             let oneGirlSwitched = false;
@@ -14091,16 +13992,6 @@ class Champion {
                                 }
                             }
                         }
-                        // >>> ADR-003 / issue #1598 - champion:useTicket begin
-                        // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                        // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                        // with the pre-fix code:
-                        //     logHHAuto("Using ticket");
-                        //     $('button[rel=perform].blue_button_L').trigger('click');
-                        //     await TimeHelper.sleep(randomInterval(200, 500));
-                        //     gotoPage(ConfigHelper.getHHScriptVars("pagesIDChampionsMap"));
-                        //     return true;
-                        // and (if no other ADR-003 block remains in this file) drop the imports above.
                         if (!acquirePostMutex('champion:useTicket')) {
                             LogUtils_logHHAuto('Champion: another POST in flight, deferring ticket use');
                             return true;
@@ -14117,7 +14008,6 @@ class Champion {
                             LogUtils_logHHAuto('Champion: ticket AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDChampionsMap"));
                         return true;
-                        // <<< ADR-003 / issue #1598 - champion:useTicket end
                     }
                 }
             }
@@ -27498,7 +27388,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.50";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.51";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ shows a small live counter overlay in the top-right corner.
 
 ## Latest Updates
 
+### v7.35.51 - Internal cleanup, no behaviour change
+
+- Removed the v7.35.50 marker scaffolding around the Champion and Troll race-protection changes now that those modules have been confirmed stable in the wild. Boss Bang keeps its scaffolding for the next time the event is active.
+
 ### v7.35.50 - PoP claim race protection extended to Boss Bang, Troll, Champion
 
 - **Same race protection as v7.35.48 PoP fix, now applied to Boss Bang, Troll, and Champion.** Each state-changing action in these modules now serialises through a single mutex and waits for the server to commit before triggering the next request. No behaviour change on small accounts; on large accounts these modules should now also avoid the rare "Access forbidden" page during long auto-collect or auto-fight runs. Applied pro-actively along the lines of the same architectural decision behind v7.35.48.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.50",
+  "version": "7.35.51",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Champion.ts
+++ b/src/Module/Champion.ts
@@ -16,10 +16,6 @@ import { getStoredJSON, getStoredValue, setStoredValue, deleteStoredValue } from
 import { convertTimeToInt, randomInterval, TimeHelper } from "../Helper/TimeHelper";
 import { getSecondsLeft, setTimer } from "../Helper/TimerHelper";
 import { gotoPage, safeReload } from "../Service/PageNavigationService";
-// >>> ADR-003 / issue #1598 - champion:imports begin
-// CLEANUP-MODE (when stable): remove only the two marker comment lines.
-// REVERT-MODE (if unstable): if no other ADR-003 block remains in this file,
-// remove this import statement entirely.
 import {
     waitForAjaxIdle,
     acquirePostMutex,
@@ -28,7 +24,6 @@ import {
     AJAX_IDLE_TIMEOUT_MS,
     AJAX_IDLE_SETTLE_MS,
 } from "../Service/AjaxTracker";
-// <<< ADR-003 / issue #1598 - champion:imports end
 import { logHHAuto } from "../Utils/LogUtils";
 import { getHHAjax, isJSON, safeJsonParse } from "../Utils/Utils";
 import { HHStoredVarPrefixKey } from "../config/HHStoredVars";
@@ -239,14 +234,6 @@ export class Champion {
             }
 
             var newDraftInterval = girlsClicked ? randomInterval(1800,2500) : randomInterval(800,1500);
-            // >>> ADR-003 / issue #1598 - champion:newDraft begin
-            // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-            // REVERT-MODE (if unstable): replace this whole block, including the markers,
-            // with the pre-fix code:
-            //     setTimeout(function() {
-            //         if ($(newDraftButtonQuery).length > 0) $(newDraftButtonQuery).trigger('click');
-            //     }, newDraftInterval);
-            // and (if no other ADR-003 block remains in this file) drop the imports above.
             setTimeout(async function() {
                 if ($(newDraftButtonQuery).length === 0) return;
                 if (!acquirePostMutex('champion:newDraft')) {
@@ -261,7 +248,6 @@ export class Champion {
                 if (newDraftIdle) await awaitServerSettleAfterPost(newDraftDuration);
                 else logHHAuto('Champion: new-draft AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
             }, newDraftInterval);
-            // <<< ADR-003 / issue #1598 - champion:newDraft end
 
             logHHAuto("Free drafts remanings :" + freeDrafts);
             counterLoop++;
@@ -270,12 +256,6 @@ export class Champion {
             } else {
                 Champion.ChampClearAutoTeamPopup();
                 $('#updateChampTeamButton').removeAttr('disabled').text( getTextForUI("updateChampTeamButton","elementText") +' x'+maxLoops);
-                // >>> ADR-003 / issue #1598 - champion:confirmDraft begin
-                // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                // with the pre-fix code:
-                //     if ($(confirmDraftButtonQuery).length > 0) $(confirmDraftButtonQuery).trigger('click');
-                // and (if no other ADR-003 block remains in this file) drop the imports above.
                 if ($(confirmDraftButtonQuery).length > 0) {
                     if (acquirePostMutex('champion:confirmDraft')) {
                         const confirmStart = Date.now();
@@ -290,7 +270,6 @@ export class Champion {
                         $(confirmDraftButtonQuery).trigger('click');
                     }
                 }
-                // <<< ADR-003 / issue #1598 - champion:confirmDraft end
 
                 if (getStoredValue(HHStoredVarPrefixKey+SK.autoBuildChampsTeam) === "true") {
                     logHHAuto('Auto team ended, sort girls after build');
@@ -365,30 +344,6 @@ export class Champion {
         $("#orderTeam").attr('disabled', 'disabled');
         const isClub = getPage() == ConfigHelper.getHHScriptVars("pagesIDClubChampion");
 
-        // >>> ADR-003 / issue #1598 - champion:reorder begin
-        // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-        // REVERT-MODE (if unstable): replace this whole block, including the markers,
-        // with the pre-fix code:
-        //     var switchGirls = function (targettedTeam: number[]) {
-        //         return new Promise((resolve) => {
-        //             const params = {
-        //                 action: "champion_team_reorder",
-        //                 team_order: targettedTeam,
-        //                 id_champion: champTeamId,
-        //                 champion_type: isClub ? "club_champion" : "champion"
-        //             };
-        //             getHHAjax()(params, function (data: any) {
-        //                 if(data.success == false) {
-        //                     logHHAuto('Error occured during champion team reorder', data);
-        //                 }
-        //                 resolve(data.success || true);
-        //             }, function (err) {
-        //                 logHHAuto('Error occured during champion team reorder', err);
-        //                 resolve(false);
-        //             });
-        //         });
-        //     };
-        // and (if no other ADR-003 block remains in this file) drop the imports above.
         var switchGirls = async function (targettedTeam: number[]) {
             if (!acquirePostMutex('champion:reorder')) {
                 logHHAuto('Champion: another POST in flight, deferring reorder request');
@@ -417,7 +372,6 @@ export class Champion {
             await awaitServerSettleAfterPost(reorderDuration);
             return result;
         };
-        // <<< ADR-003 / issue #1598 - champion:reorder end
 
         let currentGirlOrder = [...champTeam.map(g => g.id_girl)]; // To be stored as string
         logHHAuto('Ordering champion team', currentGirlOrder);
@@ -532,16 +486,6 @@ export class Champion {
                             }
                         }
                     }
-                    // >>> ADR-003 / issue #1598 - champion:useTicket begin
-                    // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                    // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                    // with the pre-fix code:
-                    //     logHHAuto("Using ticket");
-                    //     $('button[rel=perform].blue_button_L').trigger('click');
-                    //     await TimeHelper.sleep(randomInterval(200, 500));
-                    //     gotoPage(ConfigHelper.getHHScriptVars("pagesIDChampionsMap"));
-                    //     return true;
-                    // and (if no other ADR-003 block remains in this file) drop the imports above.
                     if (!acquirePostMutex('champion:useTicket')) {
                         logHHAuto('Champion: another POST in flight, deferring ticket use');
                         return true;
@@ -556,7 +500,6 @@ export class Champion {
                     else logHHAuto('Champion: ticket AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDChampionsMap"));
                     return true;
-                    // <<< ADR-003 / issue #1598 - champion:useTicket end
                 }
             }
         }

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -19,10 +19,6 @@ import { deleteStoredValue, getStoredJSON, getStoredValue, setStoredValue } from
 import { checkTimer, clearTimer, getSecondsLeft } from "../Helper/TimerHelper";
 import { queryStringGetParam } from "../Helper/UrlHelper";
 import { gotoPage } from "../Service/PageNavigationService";
-// >>> ADR-003 / issue #1598 - troll:imports begin
-// CLEANUP-MODE (when stable): remove only the two marker comment lines.
-// REVERT-MODE (if unstable): if no other ADR-003 block remains in this file,
-// remove this import statement entirely.
 import {
     waitForAjaxIdle,
     acquirePostMutex,
@@ -31,7 +27,6 @@ import {
     AJAX_IDLE_TIMEOUT_MS,
     AJAX_IDLE_SETTLE_MS,
 } from "../Service/AjaxTracker";
-// <<< ADR-003 / issue #1598 - troll:imports end
 import { logHHAuto } from "../Utils/LogUtils";
 import { isJSON } from "../Utils/Utils";
 import { HHStoredVarPrefixKey } from "../config/HHStoredVars";
@@ -602,22 +597,6 @@ export class Troll {
                     {
                         logHHAuto("Going to crush 50 times: "+trollz[Number(TTF)]+' for '+battleButtonX50Price+' kobans.');
 
-                        // >>> ADR-003 / issue #1598 - troll:battleX50 begin
-                        // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                        // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                        // with the pre-fix code:
-                        //     setHHVars('Hero.infos.hc_confirm',true);
-                        //     Booster.resetBattleResponseFlag();
-                        //     battleButtonX50[0].click();
-                        //     setHHVars('Hero.infos.hc_confirm',hcConfirmValue);
-                        //     logHHAuto(`Crushed 50 times: ${trollz[Number(TTF)]} for ${battleButtonX50Price} kobans.`);
-                        //     if (getStoredValue(HHStoredVarPrefixKey+TK.questRequirement) === "battle") {
-                        //         setStoredValue(HHStoredVarPrefixKey+TK.questRequirement, "none");
-                        //     }
-                        //     RewardHelper.ObserveAndGetGirlRewards();
-                        //     await Booster.waitForBattleResponse();
-                        //     return;
-                        // and (if no other ADR-003 block remains in this file) drop the imports above.
                         if (!acquirePostMutex('troll:battleX50')) {
                             logHHAuto('Troll: another POST in flight, deferring x50 battle');
                             return;
@@ -641,7 +620,6 @@ export class Troll {
                         releasePostMutex();
                         if (x50Idle) await awaitServerSettleAfterPost(x50Duration);
                         else logHHAuto('Troll: x50 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                        // <<< ADR-003 / issue #1598 - troll:battleX50 end
                         return;
                     }
                     else
@@ -665,22 +643,6 @@ export class Troll {
                     {
                         logHHAuto(`Going to crush 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
 
-                        // >>> ADR-003 / issue #1598 - troll:battleX10 begin
-                        // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                        // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                        // with the pre-fix code:
-                        //     setHHVars('Hero.infos.hc_confirm',true);
-                        //     Booster.resetBattleResponseFlag();
-                        //     battleButtonX10[0].click();
-                        //     setHHVars('Hero.infos.hc_confirm',hcConfirmValue);
-                        //     logHHAuto(`Crushed 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
-                        //     if (getStoredValue(HHStoredVarPrefixKey+TK.questRequirement) === "battle") {
-                        //         setStoredValue(HHStoredVarPrefixKey+TK.questRequirement, "none");
-                        //     }
-                        //     RewardHelper.ObserveAndGetGirlRewards();
-                        //     await Booster.waitForBattleResponse();
-                        //     return;
-                        // and (if no other ADR-003 block remains in this file) drop the imports above.
                         if (!acquirePostMutex('troll:battleX10')) {
                             logHHAuto('Troll: another POST in flight, deferring x10 battle');
                             return;
@@ -704,7 +666,6 @@ export class Troll {
                         releasePostMutex();
                         if (x10Idle) await awaitServerSettleAfterPost(x10Duration);
                         else logHHAuto('Troll: x10 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                        // <<< ADR-003 / issue #1598 - troll:battleX10 end
                         return;
                     }
                     else
@@ -748,12 +709,6 @@ export class Troll {
                     //replaceCheatClick();
                     checkPreviousFightDone();
                     setStoredValue(HHStoredVarPrefixKey+TK.trollPoints, currentPower);
-                    // >>> ADR-003 / issue #1598 - troll:battle begin
-                    // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                    // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                    // with the pre-fix code:
-                    //     battleButton[0].click();
-                    // and (if no other ADR-003 block remains in this file) drop the imports above.
                     if (!acquirePostMutex('troll:battle')) {
                         logHHAuto('Troll: another POST in flight, deferring single battle');
                         return;
@@ -765,7 +720,6 @@ export class Troll {
                     releasePostMutex();
                     if (battleIdle) await awaitServerSettleAfterPost(battleDuration);
                     else logHHAuto('Troll: battle AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                    // <<< ADR-003 / issue #1598 - troll:battle end
                 }
                 else
                 {
@@ -786,12 +740,6 @@ export class Troll {
                 checkPreviousFightDone();
                 setStoredValue(HHStoredVarPrefixKey+TK.trollPoints, currentPower);
                 //replaceCheatClick();
-                // >>> ADR-003 / issue #1598 - troll:battleNoEvent begin
-                // CLEANUP-MODE (when stable): remove only the two marker comment lines.
-                // REVERT-MODE (if unstable): replace this whole block, including the markers,
-                // with the pre-fix code:
-                //     battleButton[0].click();
-                // and (if no other ADR-003 block remains in this file) drop the imports above.
                 if (!acquirePostMutex('troll:battleNoEvent')) {
                     logHHAuto('Troll: another POST in flight, deferring single battle (no event)');
                     return;
@@ -803,7 +751,6 @@ export class Troll {
                 releasePostMutex();
                 if (battleNoEventIdle) await awaitServerSettleAfterPost(battleNoEventDuration);
                 else logHHAuto('Troll: battle (no event) AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
-                // <<< ADR-003 / issue #1598 - troll:battleNoEvent end
             }
         }
         else

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.50";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.51";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
Removes the ADR-003 begin/end markers and their inline
CLEANUP/REVERT documentation comments from Champion.ts and Troll.ts.
Both modules were confirmed stable on the Frank account during the
v7.35.50 verification window:

- Champion: 1843 events, 158 POSTs, 0 forbidden
- Troll: ~10 battles in 80s, 0 forbidden, settle pauses 7-10s

The live mutex + server-settle code stays untouched. Boss Bang keeps
its marker scaffolding because the event was inactive during the
verification window and has not been live-tested yet.

If either module ever needs to be reverted in the future, a `git revert`
of the original v7.35.50 commit on each module is the documented path.
The inline pre-fix code that lived inside the marker doc comments is
preserved in git history.

Verification:
- Build green, tsc green
- 780/780 tests green
- Lint baseline unchanged (62 errors / 859 warnings, same as main)
- HHAuto.user.js bundle rebuilt
- No behaviour change anywhere; deletions only

Refs #1598
