### PR TITLE
fix: compatibility with Kinkoid game API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.35.52 - Compatibility fixes for game API changes
+
+- **Background.** Kinkoid recently changed the shape of two game API values that the script reads from the page (the homepage event banners and the girl roster object). Without the script update the script logged TypeError exceptions on every AutoLoop tick.
+- **Auto Troll girl priority restored.** The "fight the troll that drops a missing girl" priority quietly fell back to a default troll picker because the new girl roster shape made the lookup throw. The lookup is back, troll-with-girls priority works again on the new API.
+- **Quieter console.** The event-banner timer redraw on the home page now skips silently when the banner element is not in the DOM, instead of throwing on every tick. The timer was cosmetic only; no functionality changes.
+
 ### v7.35.51 - Internal cleanup, no behaviour change
 
 - Removed the v7.35.50 marker scaffolding around the Champion and Troll race-protection changes now that those modules have been confirmed stable in the wild. Boss Bang keeps its scaffolding for the next time the event is active.

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.51
+// @version      7.35.52
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -5362,11 +5362,22 @@ class EventModule {
             }
             else {
                 if (!displayTimer) {
-                    $("#" + hhtimerId)[0].remove();
+                    const timerEl = $("#" + hhtimerId)[0];
+                    if (timerEl) {
+                        timerEl.remove();
+                    }
                 }
             }
             if (displayTimer) {
-                $("#" + hhtimerId)[0].innerText = getTimeLeft(timerName);
+                const timerEl = $("#" + hhtimerId)[0];
+                // Defensive: when the homepage banner element identified by aRel
+                // is not in the DOM (e.g. because Kinkoid removed the tile or the
+                // current event is inactive), the prepend above is a no-op and
+                // [0] is undefined here. Skip silently in that case instead of
+                // throwing a TypeError on every AutoLoop tick.
+                if (timerEl) {
+                    timerEl.innerText = getTimeLeft(timerName);
+                }
             }
         }
         else {
@@ -9101,8 +9112,16 @@ class Harem {
         }
         if (girlsDataList != null && !(girlsDataList instanceof Map)) {
             let girlNameDictionary = new Map();
-            girlsDataList.forEach((data) => {
-                girlNameDictionary.set(data.id_girl + "", data);
+            // The game returns girlsDataList as either an Array (legacy)
+            // or a plain Object keyed by girl id (current). forEach only
+            // exists on the Array form -- normalise via Object.values().
+            const entries = Array.isArray(girlsDataList)
+                ? girlsDataList
+                : (typeof girlsDataList === 'object' ? Object.values(girlsDataList) : []);
+            entries.forEach((data) => {
+                if (data != null && data.id_girl !== undefined) {
+                    girlNameDictionary.set(data.id_girl + "", data);
+                }
             });
             girlsDataList = girlNameDictionary;
         }
@@ -27388,7 +27407,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.51";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.52";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.51",
+  "version": "7.35.52",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Events/EventModule.ts
+++ b/src/Module/Events/EventModule.ts
@@ -570,12 +570,23 @@ export class EventModule {
             {
                 if (!displayTimer)
                 {
-                    $("#"+hhtimerId)[0].remove();
+                    const timerEl = $("#"+hhtimerId)[0];
+                    if (timerEl) {
+                        timerEl.remove();
+                    }
                 }
             }
             if (displayTimer)
             {
-                $("#"+hhtimerId)[0].innerText = getTimeLeft(timerName);
+                const timerEl = $("#"+hhtimerId)[0];
+                // Defensive: when the homepage banner element identified by aRel
+                // is not in the DOM (e.g. because Kinkoid removed the tile or the
+                // current event is inactive), the prepend above is a no-op and
+                // [0] is undefined here. Skip silently in that case instead of
+                // throwing a TypeError on every AutoLoop tick.
+                if (timerEl) {
+                    timerEl.innerText = getTimeLeft(timerName);
+                }
             }
         }
         else

--- a/src/Module/harem/Harem.ts
+++ b/src/Module/harem/Harem.ts
@@ -105,8 +105,16 @@ export class Harem {
         }
         if (girlsDataList != null && !(girlsDataList instanceof Map)) {
             let girlNameDictionary = new Map();
-            girlsDataList.forEach((data: any) => {
-                girlNameDictionary.set(data.id_girl +"", data);
+            // The game returns girlsDataList as either an Array (legacy)
+            // or a plain Object keyed by girl id (current). forEach only
+            // exists on the Array form -- normalise via Object.values().
+            const entries = Array.isArray(girlsDataList)
+                ? girlsDataList
+                : (typeof girlsDataList === 'object' ? Object.values(girlsDataList) : []);
+            entries.forEach((data: any) => {
+                if (data != null && data.id_girl !== undefined) {
+                    girlNameDictionary.set(data.id_girl + "", data);
+                }
             });
             girlsDataList = girlNameDictionary;
         }

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.51";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.52";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
The game changed the shape of two values the script reads from the page. Without the fix the script logged TypeErrors on every AutoLoop tick.

- `girlsDataList` (girl roster) is now an Object keyed by girl id, not an Array. `Harem.getGirlsList` called `.forEach` directly, throwing on every tick. `Troll.getTrollWithGirls` is the only consumer; the troll-with-girls priority silently fell back to the default troll picker. Normalise via `Array.isArray` + `Object.values`.
- Homepage event banners (`a[rel="season"]`, `path-of-valor`, `path-of-glory`, `seasonal_event`) are no longer in the DOM. `EventModule.displayGenericRemainingTime` would prepend a timer span on a null target and then dereference `[0]` of an empty jQuery set. Add a length check before both DOM mutations so the cosmetic timer redraw skips silently when the banner is gone.

Verified locally:
- npm run build: green
- npx jest --runInBand: 780/780 green
- npm run typecheck: green
- npm run lint: 62 errors / 859 warnings (= phase-0 baseline)
- npm run deps:circular:check: 546 cycles, baseline matches

Bumps version to 7.35.52. CHANGELOG entry explains the API drift in user-facing language without referencing the issue.
