### PR TITLE
docs(internal): add session handover for 2026-05-22

### DIFF
--- a/docs-internal/SESSION_HANDOVER_2026-05-22.md
+++ b/docs-internal/SESSION_HANDOVER_2026-05-22.md
@@ -1,0 +1,117 @@
+# Session-Handover -- HHAuto Refactor
+
+**Datum letzter Stand:** 2026-05-22 (am Ende einer langen Session)
+**Aktueller Branch:** ``main`` (Version 7.35.53)
+**Refactor-Branch:** ``refactor/v7.36.0-staging`` (synchron mit ``main``, Reset 2026-05-22)
+
+## Was abgeschlossen ist
+
+### Schritt 1 -- PageNavigationService Refactor (komplett auf main)
+
+7 Cluster, alle in einem Squash auf main gemerged via PR #1727 (Commit ``a42d330d``, Version 7.35.53):
+
+- A: Service intern aufraeumen (I3, I4, I6, I8, I9, I10, N1-N7)
+- B: Default-Branch / Returnwert / Quest-Recursion (I1, I2, N7)
+- C: Service entkoppeln von Quest (I7) -- Quest-URL-Resolution wandert in Quest.ts
+- D: C1-Migration AutoLoopActions + StartService (4 Stellen)
+- E: C1-Migration Events/harem (4 Stellen)
+- F: C1-Migration League/PentaDrill/TeamModule + Utils (6 Stellen)
+- G: ESLint-Guard via no-restricted-syntax verhindert kuenftige location.*-Calls ausserhalb des Service
+
+CHANGELOG.md auf main hat den Eintrag ``v7.35.53 - More robust page navigation and reload handling``.
+
+Issue #1722 hat den aktualisierten Status-Kommentar (https://github.com/OldRon1977/HHauto/issues/1722#issuecomment-4513449854).
+
+### Side-Effekte auf main
+
+- 7.35.52 (PR #1726): Kinkoid-API-Drift Hotfix (EventModule length-Check, Harem.getGirlsList Object/Array-Normalisierung).
+- Cycle-Baseline auf main: 509 (war 546 vor Cluster C).
+
+### Reverted Experimente (nur auf staging waehrend Schritt 1, **nicht** auf main)
+
+- Cluster C+ -- setLastPageCalled mit page-id statt URL. Brach StartService.ts:503-Korrektur-Pfad. Reverted.
+- Cluster D' -- handleGoHome Self-Heal mid-session. Greift im Test-Szenario nicht (Storage-Wert war leer). Reverted.
+- Beide tracken einen praeexistenten **handleGoHome-Bug**: ctx.currentPage (page-id) vs lastPageCalled.page (URL) -- Equality-Check schlaegt nie an. In ``REVIEW_BACKLOG.md`` als Phase-2-Hot-Spot eingetragen.
+
+## Was als naechstes ansteht
+
+### Schritt 2 (Roadmap) -- ``Helper/PageHelper.ts`` Code-Review
+
+Aus ``REVIEW_ROADMAP.md``:
+
+> 2.1 ``docs-internal/REVIEW_PageHelper.md`` erstellen (5 Achsen, Severity).
+> 2.2 Findings besprechen, Critical/Important in Fix-PRs.
+
+Hot-Spot-Begruendung aus ``REVIEW_PHASE0.md``: PageHelper.ts ist Sub-Tab-Routing fuer Activities, hat einen 35-LoC-Patch in 7.35.36 bekommen, beruehrt direkt das Routing-Verhalten von Cluster D-F.
+
+### Vorbereitung fuer Schritt 2
+
+- Kein Code-Aenderungen heute. Erst Review-Datei schreiben.
+- Branch fuer Code-Review: ``review/PageHelper`` (nur Doku, keine Versions-Bumps -- die Datei landet ausserhalb des Repos via Gitignore-Pattern ``REVIEW_*.md``).
+- Pre-Phase Re-Verify-Pflicht aus Roadmap entfaellt fuer Schritt 2.1, weil **kein bestehendes Review** existiert. 2.2 wird die Pre-Verify auf das in 2.1 erstellte File anwenden.
+
+### Roadmap-Reihenfolge
+
+1. Schritt 2 (PageHelper Code-Review + Findings-Umsetzung)
+2. Schritt 3 (AutoLoop-Cluster: AutoLoop.ts + AutoLoopActions.ts + AutoLoopPageHandlers.ts)
+3. weiter laut Roadmap
+
+## Wichtige Files fuer den Wiedereinstieg
+
+| Datei | Zweck |
+|---|---|
+| ``docs-internal/REVIEW_ROADMAP.md`` | Steuerungsdatei, Schritt-Status |
+| ``docs-internal/REVIEW_HANDOVER.md`` | Phase-2-Methodik (5-Achsen-Review, Severity-Schema) |
+| ``docs-internal/REVIEW_PHASE0.md`` | Hot-Spot-Ranking, Coverage-Baseline |
+| ``docs-internal/REVIEW_BACKLOG.md`` | Offene Backlog-Eintraege (handleGoHome-Bug eingetragen) |
+| ``docs-internal/REVIEW_PageNavigationService.md`` | Vorbild fuer das naechste Review-File (Schritt 2.1) |
+
+## Branch-Modell
+
+Aus ``REVIEW_ROADMAP.md`` Sektion **Refactor-Branch-Modell**:
+
+- Sammel-Branch: ``refactor/v7.36.0-staging``. Aktuell synchron mit main (Reset 2026-05-22).
+- Pro Cluster ein Sub-Branch (``refactor/<modul>-<aspect>``), Direkt-Merge auf staging via fast-forward.
+- Versionierung auf staging: patch-bumpen, weiter ab letzter staging-Version (war 7.35.69, naechster bump waere 7.35.70). Aber: weil staging jetzt bei main-Stand 7.35.53 ist, beginnt die Refactor-Linie de facto neu. Naechster Bump auf staging: **7.35.54** (frisch ab main).
+- Cherry-Pick / Squash nach main bei stabilen Stand.
+- Hotfixes auf main: 9-von-10-Faellen direkt auf der Refactor-Linie bauen, mit naechstem stabilen Stand nach main.
+
+## Ueblicher Workflow je Cluster
+
+1. Pre-Phase Re-Verify (Pflicht, alle Befunde einzeln pruefen).
+2. Branch von staging anlegen.
+3. Code-Aenderung + Spec-Erweiterung.
+4. Verifikation: ``npm run typecheck``, ``npm run build``, ``npx jest --runInBand --no-coverage``, ``npm run lint``, ``npm run deps:circular:check``.
+5. Versions-Bump in ``package.json`` + ``src/Service/FeaturePopupService.ts``, Build erneut, kein CHANGELOG.
+6. Commit auf Cluster-Branch, Direkt-Merge fast-forward auf staging, push.
+7. User-Test in Tampermonkey.
+8. Roadmap mit Cluster-Status [x] aktualisieren.
+
+## Prompt fuer naechste Session
+
+```
+Refactor an HHAuto fortsetzen.
+
+Lies zuerst:
+1. docs-internal/REVIEW_ROADMAP.md (Steuerungsdatei, Status der Schritte)
+2. docs-internal/SESSION_HANDOVER_2026-05-22.md (dieser Handover)
+3. docs-internal/REVIEW_PHASE0.md (Hot-Spot-Begruendung fuer Schritt 2)
+
+Naechster Schritt: Schritt 2.1 -- Erstelle docs-internal/REVIEW_PageHelper.md
+nach dem Vorbild von docs-internal/REVIEW_PageNavigationService.md (5 Achsen,
+Severity Critical/Important/Nit/FYI). Quelldatei: src/Helper/PageHelper.ts.
+Aktive Tests: spec/Helper/ (falls vorhanden).
+
+Branch fuer das Review: review/PageHelper (nur Doku, gitignored, kein PR auf
+main, kein Versions-Bump).
+
+Findings am Ende mit mir besprechen, dann nach Severity in Cluster aufteilen
+und auf der Refactor-Linie umsetzen (Sammel-Branch refactor/v7.36.0-staging).
+
+Beachte:
+- KEINE ABKUERZUNGEN beim Re-Verify, jeder Befund einzeln gegen Code geprueft.
+- Pause nach jedem Cluster, Test-Freigabe vom User abwarten.
+- Refactor-Stille: kein CHANGELOG-Eintrag bis 7.36.0 (ausser bei Hotfix-PRs auf main).
+- Issue-Refs nur in Commit-/PR-Body, nicht in CHANGELOG/README.
+- Versions-Bumps auf staging fortlaufend ab 7.35.54.
+```


### PR DESCRIPTION
Drops the post-step-1 session handover into docs-internal/. Captures what shipped to main as v7.35.53, what stays on staging, the two reverted experiments and the handleGoHome backlog item, the reading order for the next agent session, and a copy-paste prompt to resume.

Internal documentation only, no code change.

Refs #1722
