### PR TITLE
fix: storage layer review and event-loop / league-timer hotfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.35.57 - StorageHelper review, league timer refresh, expired-event loop fix
+
+#### Fixed
+
+- The league info row in the pInfo overlay refreshes its timer even when the bot cannot fight right now (no challenge tokens, no booster equipped). Earlier versions left the row stuck on "No timer" until the next successful league battle wrote a fresh timer.
+- The script no longer reload-loops to an event tab the game has already closed. A registry entry whose game-side end is in the past is now dropped from storage before the trigger fires, so a stale entry left over from a long-running browser tab cannot drive the bot into a permanent /event.html reload cycle.
+- A few rare crash paths in the storage layer are no longer fatal:
+  - setStoredValue tolerates non-Error throws that previously killed an AutoLoop tick.
+  - The kobanUsing master-switch lookup no longer recurses, so a registry typo cannot produce a stack overflow inside every storage read.
+  - The storage-quota cleanup no longer writes while it cleans, removing the amplifier when a non-log temp value (e.g. a large HaremSize) hits the quota.
+
+#### Changed
+
+- The 33 AutoLoop pipeline handlers now run in a new user-facing priority sequence: salary first, then shop / boosters / harem-size / missions, the resource collectors, daily goals, champion ticket, place of power, club champion / champion / love raid / troll battle, boss bang, league / season / quest, pantheon, penta drill, labyrinth, generic battle, go-home. Pure data move -- handler behaviour itself is unchanged.
+- The settings-storage UI helper file was reorganised internally (lint baseline cleared, edge cases tightened around setting defaults and per-tab toggle, prefix-migration kept dormant but documented). No user-visible behaviour change beyond the points above.
+- A long-standing typo in the page-detection storage key (`Setting_unkownPagesList` → `Setting_unknownPagesList`) is corrected. The key only carried diagnostic data, so the rename starts the new key fresh on the next reload.
+
 ### v7.35.55 - AutoLoop refactor and league/booster hotfixes
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.56
+// @version      7.35.57
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -1336,7 +1336,7 @@ const TK = {
     // Misc
     sandalwoodFailure: "Temp_sandalwoodFailure",
     sandalwoodMaxUsages: "Temp_sandalwoodMaxUsages",
-    unkownPagesList: "Temp_unkownPagesList",
+    unknownPagesList: "Temp_unknownPagesList",
     userLink: "Temp_userLink",
     // Survey
     surveyShown: "Temp_surveyShown",
@@ -1857,14 +1857,14 @@ function getPage(checkUnknown = false) {
             }
         }
         if (!isKnown && page) {
-            const unknownPageList = getStoredJSON(HHStoredVarPrefixKey + TK.unkownPagesList, {});
+            const unknownPageList = getStoredJSON(HHStoredVarPrefixKey + TK.unknownPagesList, {});
             // Idempotent write: skip the JSON.stringify+setStoredValue round-trip
             // when this page was already recorded with the same pathname (avoids
             // a write per AutoLoop tick on long-running unknown pages).
             if (unknownPageList[page] !== window.location.pathname) {
-                LogUtils_logHHAuto(`Page unkown for script : ${page} / ${window.location.pathname}`);
+                LogUtils_logHHAuto(`Page unknown for script : ${page} / ${window.location.pathname}`);
                 unknownPageList[page] = window.location.pathname;
-                setStoredValue(HHStoredVarPrefixKey + TK.unkownPagesList, JSON.stringify(unknownPageList));
+                setStoredValue(HHStoredVarPrefixKey + TK.unknownPagesList, JSON.stringify(unknownPageList));
             }
         }
     }
@@ -9449,10 +9449,10 @@ class ParanoiaService {
     }
     static clearParanoiaSpendings() {
         ParanoiaService.countParanoiaLoop = 0;
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaSpendings);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.NextSwitch);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaSpendings);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.NextSwitch);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked);
     }
     static updatedParanoiaSpendings(inSpendingFunction, inSpent) {
         var currentPSpendings = new Map([]);
@@ -19864,11 +19864,22 @@ const handleEventParsing = {
  * On unexpected storage shape this returns a single sentinel ID so that the
  * caller still triggers a parse cycle (preserves the previous fallback
  * behaviour where the precondition returned true on parse errors).
+ *
+ * Expired-event side effect: entries whose `seconds_before_end` is in the
+ * past are events the game no longer hosts. parseEventPage cannot refresh
+ * them (the in-game tab has been replaced by a successor or removed
+ * entirely), so they would stay stale forever and drive
+ * handleEventParsing into a permanent reload loop (issue #1738 -- a
+ * lively_scene_event_12 entry kept the bot looping for 7+ minutes before
+ * the user gave up). pruneExpiredEvents() removes them from the registry
+ * BEFORE this filter runs so the loop terminates and storage stays
+ * bounded.
  */
 function getStaleEventIDs(now = Date.now()) {
     try {
         const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
         const eventList = storedList ? JSON.parse(storedList) : {};
+        pruneExpiredEvents(eventList, now);
         return Object.keys(eventList).filter(id => {
             const ev = eventList[id];
             if (!ev || ev.isCompleted)
@@ -19882,6 +19893,42 @@ function getStaleEventIDs(now = Date.now()) {
         // accidentally skip a refresh cycle. The actual parseEventPage call
         // tolerates an empty/garbage tab via its own "global" fallback.
         return ['__parse_error__'];
+    }
+}
+/**
+ * Drop event registry entries whose game-side end has already passed
+ * (`seconds_before_end <= now`). Such entries cannot be refreshed by
+ * parseEventPage (the in-game tab is gone), so leaving them in the
+ * registry would keep handleEventParsing.precondition firing forever
+ * (issue #1738).
+ *
+ * Mutates the input map AND persists the pruned shape so the next
+ * read sees the cleaned state. Exported for direct unit testing in
+ * Pipeline.config.spec.ts.
+ *
+ * Defensive: an entry without `seconds_before_end`, or with a
+ * non-finite value, is left in place. parseEventPage handles those
+ * via its existing "ERROR: No event Id found" path on the next visit.
+ */
+function pruneExpiredEvents(eventList, now) {
+    let mutated = false;
+    for (const id of Object.keys(eventList)) {
+        const ev = eventList[id];
+        if (!ev)
+            continue;
+        const end = Number(ev.seconds_before_end);
+        if (Number.isFinite(end) && end <= now) {
+            delete eventList[id];
+            mutated = true;
+        }
+    }
+    if (mutated) {
+        if (Object.keys(eventList).length === 0) {
+            deleteStoredValue(HHStoredVarPrefixKey + TK.eventsList);
+        }
+        else {
+            setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(eventList));
+        }
     }
 }
 // ---------------------------------------------------------------------------
@@ -19900,24 +19947,58 @@ const handleLeague = {
     minIntervalMs: 2000,
     atomic: true,
     interruptible: 'never',
-    precondition: () => {
+    precondition: (ctx) => {
+        // Trigger logic in full (lesson pipeline-inner-trigger-in-precondition):
+        //
+        //   1. League auto-mode active and feature enabled at all?
+        //   2. Bot not currently mid-action on a different module
+        //      (legacy lastActionPerformed guard from doLeagueBattle, lifted
+        //      out of step.fn so the chain doesn't fire just to log a skip).
+        //   3. Either ready to fight (energy + threshold + booster check) OR
+        //      the cool-down timer has expired and we still need to refresh
+        //      the pInfo display with a default timer value (issue raised
+        //      2026-05-26: pInfo stuck on 'No timer' when isTimeToFight is
+        //      false because the only setTimer paths live behind a fight).
+        //
         // Note (issue #1708 follow-up): handleLeague is intentionally NOT
         // gated on trollWaitForEnergy. League uses a separate energy pool
         // (challenge tokens) that is unrelated to troll combativity (fight
         // tokens). LeagueHelper.isTimeToFight() already checks challenge
-        // energy, and the 60_000 ms minIntervalMs caps re-entry. Blocking
-        // league while troll waits for combativity (as v7.35.45 did) keeps
-        // league fights from happening even though the user has the energy
-        // to do them. handleEventParsing is gated separately because it
-        // ran every 2 s and was the actual ping-pong driver in #1700.
-        return LeagueHelper.isAutoLeagueActivated() && LeagueHelper.isTimeToFight();
+        // energy, and the minIntervalMs caps re-entry. Blocking league
+        // while troll waits for combativity (as v7.35.45 did) keeps league
+        // fights from happening even though the user has the energy to do
+        // them. handleEventParsing is gated separately because it ran every
+        // 2 s and was the actual ping-pong driver in #1700.
+        if (!LeagueHelper.isAutoLeagueActivated())
+            return false;
+        const lastAction = ctx.lastActionPerformed;
+        if (lastAction !== 'none' && lastAction !== 'league')
+            return false;
+        return LeagueHelper.isTimeToFight() || checkTimer('nextLeaguesTime');
     },
     steps: [
         {
-            name: 'doLeagueBattle',
-            fn: () => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
+            name: 'doLeagueBattleOrTimer',
+            fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    LeagueHelper.doLeagueBattle();
+                    if (LeagueHelper.isTimeToFight()) {
+                        LeagueHelper.doLeagueBattle();
+                        ctx.lastActionPerformed = 'league';
+                        return { ok: true };
+                    }
+                    // Fight not possible right now (energy below threshold,
+                    // booster missing, etc.). Refresh the cool-down timer so the
+                    // pInfo display can show the next refresh time instead of
+                    // 'No timer'. Default fallback when the game has not yet
+                    // reported a next_refresh_ts is the same 15-17 min window
+                    // doLeagueBattle uses for similar idle paths.
+                    const next_refresh = Number(getHHVars('Hero.energies.challenge.next_refresh_ts'));
+                    if (Number.isFinite(next_refresh) && next_refresh > 0) {
+                        setTimer('nextLeaguesTime', randomInterval(next_refresh + 10, next_refresh + 180));
+                    }
+                    else {
+                        setTimer('nextLeaguesTime', randomInterval(15 * 60, 17 * 60));
+                    }
                     return { ok: true };
                 }
                 catch (err) {
@@ -20234,7 +20315,7 @@ const handlePlaceOfPower = {
                     if (ctx.busy === false) {
                         popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
                         if (popToStart.length === 0) {
-                            sessionStorage.removeItem(HHStoredVarPrefixKey + TK.PopToStart);
+                            deleteStoredValue(HHStoredVarPrefixKey + TK.PopToStart);
                             ctx.busy = gotoPage(ConfigHelper.getHHScriptVars('pagesIDHome'));
                         }
                     }
@@ -21165,53 +21246,56 @@ const handleGoHome = {
 //  The Scheduler walks the list once per tick, picks the first ready handler
 //  (precondition true, cool-down elapsed, state IDLE), and runs it.
 //
-//  Migration notes (3.2.G.a -> 3.2.G.i): handlers move from
-//  AutoLoopActions.ts into this array. Until the migration is complete,
-//  the classic handler block in AutoLoop.autoLoop() and the pipeline run
-//  sequentially within one tick (classic first, then pipeline). The order
-//  inside this array is kept so the same handler always runs at most once
-//  per tick across both systems (the classic block is updated to skip
-//  handlers that have already moved to the pipeline).
+//  Migration history: all 33 AutoLoop action handlers now live in this
+//  array (3.2.G.a -> 3.2.G.complete). The classic handler block in
+//  AutoLoop.autoLoop() is gone; the Scheduler is the sole driver.
 //
-//  Order matches the legacy AutoLoop call order so behaviour stays
-//  identical until the remaining handlers are migrated in 3.2.G.c-i.
+//  Order is the agreed user-facing priority sequence: high-yield /
+//  low-cost actions (salary, shop, missions) and resource collectors
+//  before the long battle / quest / labyrinth blocks. handleEventParsing
+//  is locked at slot 1 because it populates event/mythic-girl data that
+//  later handlers (handleTrollBattle, the collect handlers) read.
+//  handleGoHome is locked at the tail because it closes the tick on a
+//  non-home page. handleGenericBattle is kept just before handleGoHome
+//  as a catch-all when the bot has landed on any battle page.
 // ---------------------------------------------------------------------------
 const pipeline = [
-    // Order matches the legacy AutoLoop call order to preserve relative
-    // scheduling. handleMythicWave is intentionally skipped (no useful effect
-    // in the pipeline model -- see comment on its absent migration above).
+    // handleMythicWave is intentionally not listed: it was a legacy slot
+    // reservation used by the classic handleTrollBattle path and has no
+    // effect in the pipeline model. The mythic girl is fully covered by
+    // handleTrollBattle's activation paths.
     handleEventParsing,
+    handleSalary,
     handleShop,
     handleAutoEquipBoosters,
     handleHaremSize,
-    handlePlaceOfPower,
-    handleGenericBattle,
-    handleLoveRaid,
-    handleTrollBattle,
-    handlePachinko,
-    handleContest,
     handleMissions,
-    handleQuest,
-    handleLeague,
-    handleSeason,
-    handlePentaDrill,
-    handlePantheon,
-    handleChampionTicket,
-    handleChampion,
-    handleClubChampion,
+    handlePachinko,
+    handleSeasonalFreeCard,
+    handleFreeBundles,
     handleSeasonCollect,
     handlePentaDrillCollect,
-    handleSeasonalFreeCard,
     handleSeasonalEventCollect,
     handleSeasonalRankCollect,
     handlePoVCollect,
     handlePoGCollect,
-    handleFreeBundles,
+    handleContest,
     handleDailyGoals,
-    handleLabyrinth,
-    handleSalary,
+    handleChampionTicket,
+    handlePlaceOfPower,
+    handleClubChampion,
+    handleChampion,
+    handleLoveRaid,
+    handleTrollBattle,
     handleBossBangParse,
     handleBossBangFight,
+    handleLeague,
+    handleSeason,
+    handleQuest,
+    handlePantheon,
+    handlePentaDrill,
+    handleLabyrinth,
+    handleGenericBattle,
     handleGoHome,
 ];
 
@@ -22799,6 +22883,32 @@ class EventModule {
             }
             else {
                 if (inTab !== "global") {
+                    // Expired-event short-circuit (issue #1738): if the
+                    // entry the precondition picked is already past its
+                    // game-side end (seconds_before_end <= now), don't
+                    // navigate to /event.html with that tab. The game has
+                    // dropped the tab, so the navigation lands on a page
+                    // whose getDisplayedIdEventPage() returns '', the
+                    // outer if(getPage()===pagesIDEvent) branch is never
+                    // reached, and the loop runs forever.
+                    //
+                    // Drop the registry entry directly here so the next
+                    // tick's getStaleEventIDs() does not pick it again.
+                    // Pipeline.config.ts pruneExpiredEvents handles this
+                    // before the trigger fires; this branch is the
+                    // belt-and-braces guard for direct callers.
+                    try {
+                        const evList = getStoredJSON(HHStoredVarPrefixKey + TK.eventsList, {});
+                        const ev = evList[inTab];
+                        const end = Number(ev === null || ev === void 0 ? void 0 : ev.seconds_before_end);
+                        if (Number.isFinite(end) && end <= Date.now()) {
+                            LogUtils_logHHAuto(`Skipping navigation to expired event ${inTab}, dropping stale registry entry.`);
+                            EventModule.clearEventData(inTab);
+                            gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
+                            return true;
+                        }
+                    }
+                    catch (e) { /* fall through to normal navigation */ }
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDEvent"), { tab: inTab });
                 }
                 else {
@@ -23751,8 +23861,8 @@ class PlaceOfPower {
         }
     }
     static cleanTempPopToStart() {
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.PopUnableToStart);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.PopToStart);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.PopToStart);
     }
     static removePopFromPopToStart(index) {
         var epop;
@@ -23927,7 +24037,7 @@ class PlaceOfPower {
                     }
                 });
                 if (PopToStart.length === 0) {
-                    sessionStorage.removeItem(HHStoredVarPrefixKey + TK.PopUnableToStart);
+                    deleteStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart);
                 }
                 LogUtils_logHHAuto("build popToStart : " + PopToStart);
                 setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify(PopToStart));
@@ -26647,7 +26757,7 @@ HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.lseManualCollectAll] =
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.unkownPagesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.unknownPagesList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
@@ -26786,18 +26896,27 @@ function getBrowserData(nav) {
 /** Maximum number of log entries kept in storage before old ones are pruned. */
 const MAX_LINES = 500;
 /**
- * Wipe all existing log entries from storage and record a single
- * "cleaned" marker with the storage size before the clean.
- * Also deletes the cached league opponent list which can grow large.
+ * Wipe all existing log entries from storage and free up large temp
+ * caches. Called from setStoredValue's quota-error catch path, so this
+ * function MUST NOT itself perform any storage write -- otherwise a
+ * non-log-driven quota fault (e.g. an oversized TK.HaremSize) can be
+ * amplified, since the very recovery path would try to add a "cleaned"
+ * marker to an already-full storage, throw again, and recurse through
+ * setStoredValue's catch.
+ *
+ * Strategy:
+ *   - Drop the entire log buffer (delete, not overwrite -- frees the
+ *     full key without a new write).
+ *   - Drop the league opponent cache, which is the second-largest temp
+ *     value typically present.
+ * Console.log still receives a one-line breadcrumb so the cleanup is
+ * visible during debugging without touching storage.
  */
 function cleanLogsInStorage() {
-    var currentLoggingText = {};
-    let currDate = new Date();
-    var prefix = currDate.toLocaleString() + "." + currDate.getMilliseconds() + ":cleanLogsInStorage";
-    currentLoggingText[prefix] = 'Cleaned logging, storage size before clean ' + getLocalStorageSize();
-    setStoredValue(HHStoredVarPrefixKey + TK.Logging, JSON.stringify(currentLoggingText));
-    // Delete big temp in storage
+    const sizeBefore = getLocalStorageSize();
+    deleteStoredValue(HHStoredVarPrefixKey + TK.Logging);
     deleteStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList);
+    console.log(`HHAuto: cleanLogsInStorage cleared TK.Logging and TK.LeagueOpponentList; storage size before clean ${sizeBefore}`);
 }
 /**
  * Write a timestamped log entry to both the browser console and persistent
@@ -26933,6 +27052,16 @@ function saveHHDebugLog() {
 // Also provides export/import of settings as JSON files and a popup
 // for selecting which reward types to auto-collect.
 //
+// External callers MUST use getStoredValue / setStoredValue /
+// deleteStoredValue / getStoredJSON. Direct access to localStorage or
+// sessionStorage is reserved for the storage adapter itself, the
+// ForbiddenBackoff backoff path (see _lessons/zirkulaerer-import-tdz-
+// crash.md -- it must not import HHStoredVars to keep the dependency
+// graph cycle-free), and game-side state that the script does not own
+// (e.g. localStorage.sort_by, set by the game's harem UI). Anything
+// else is a bypass that defeats the registry, kobanUsing master-switch,
+// and quota-retry contracts.
+//
 // Used by: Every module and helper in the project.
 
 
@@ -26949,19 +27078,37 @@ function getStoredJSON(key, defaultValue, reviver) {
         return defaultValue;
     return safeJsonParse(val, defaultValue, reviver);
 }
+/**
+ * Returns the active "default" storage based on the settPerTab toggle.
+ * When settPerTab is "true", per-tab isolation is on: every Storage()
+ * key lives in sessionStorage and is therefore tab-local.
+ *
+ * IMPORTANT side-effect of toggling settPerTab at runtime: existing
+ * Storage()-typed values do NOT migrate between localStorage and
+ * sessionStorage. Settings recorded under one mode become invisible
+ * (defaults take over) when the user flips to the other mode and
+ * reappear when they flip back. This is intentional -- per-tab mode
+ * is supposed to start fresh -- but it is not currently surfaced to
+ * the user in the menu UI.
+ */
 function getStorage() {
     return getStoredValue(HHStoredVarPrefixKey + SK.settPerTab) === "true" ? sessionStorage : localStorage;
 }
 function getStoredValue(inVarName) {
-    if (HHStoredVars_HHStoredVars.hasOwnProperty(inVarName)) {
-        const storedValue = getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName];
-        if (HHStoredVars_HHStoredVars[inVarName].kobanUsing) {
-            // Check main switch for spenind Koban
-            return getStoredValue(HHStoredVarPrefixKey + 'Setting_spendKobans0') === "true" ? storedValue : "false";
-        }
+    if (!HHStoredVars_HHStoredVars.hasOwnProperty(inVarName))
+        return undefined;
+    const storedValue = getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName];
+    if (!HHStoredVars_HHStoredVars[inVarName].kobanUsing)
         return storedValue;
-    }
-    return undefined;
+    // Check main switch for spending Koban via a direct storage read,
+    // NOT recursion via getStoredValue, to avoid an infinite call stack
+    // if Setting_spendKobans0 itself were ever (accidentally) registered
+    // with kobanUsing: true. The master switch is itself a Storage()
+    // entry so we route through getStorageItem with its registered type.
+    const masterKey = HHStoredVarPrefixKey + SK.spendKobans0;
+    const masterEntry = HHStoredVars_HHStoredVars[masterKey];
+    const masterValue = masterEntry ? getStorageItem(masterEntry.storage)[masterKey] : undefined;
+    return masterValue === "true" ? storedValue : "false";
 }
 function deleteStoredValue(inVarName) {
     if (HHStoredVars_HHStoredVars.hasOwnProperty(inVarName)) {
@@ -26969,38 +27116,34 @@ function deleteStoredValue(inVarName) {
     }
 }
 function setStoredValue(inVarName, inValue, retry = false) {
-    if (HHStoredVars_HHStoredVars.hasOwnProperty(inVarName)) {
-        try {
-            getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName] = inValue;
-        }
-        catch ({ errName, message }) {
-            cleanLogsInStorage();
-            LogUtils_logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry ? 'user storage need to be cleaned' : 'retry...'}`);
-            if (!retry)
-                setStoredValue(inVarName, inValue, true);
-        }
+    if (!HHStoredVars_HHStoredVars.hasOwnProperty(inVarName))
+        return;
+    try {
+        getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName] = inValue;
+    }
+    catch (e) {
+        // Robust catch: destructuring `{ errName, message }` from a
+        // non-Error throw (primitive, plain object missing those keys)
+        // would throw a TypeError out of setStoredValue itself --
+        // catastrophic in the AutoLoop hot-loop where this runs >100x
+        // per tick. Coerce to a string message instead.
+        const message = (e instanceof Error) ? e.message : String(e);
+        cleanLogsInStorage();
+        LogUtils_logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry ? 'user storage need to be cleaned' : 'retry...'}`);
+        if (!retry)
+            setStoredValue(inVarName, inValue, true);
     }
 }
 function extractHHVars(dataToSave, extractLog = false, extractTemp = true, extractSettings = true) {
-    let storageType;
-    let storageName;
-    let currentStorageName = getStoredValue(HHStoredVarPrefixKey + SK.settPerTab) === "true" ? "sessionStorage" : "localStorage";
-    let variableName;
-    let storageItem;
-    let varType;
-    for (let i of Object.keys(HHStoredVars_HHStoredVars)) {
-        varType = HHStoredVars_HHStoredVars[i].HHType;
-        if (varType === "Setting" && extractSettings || varType === "Temp" && extractTemp) {
-            storageType = HHStoredVars_HHStoredVars[i].storage;
-            variableName = i;
-            storageName = storageType;
-            storageItem = getStorageItem(storageType);
-            if (storageType === 'Storage()') {
-                storageName = currentStorageName;
-            }
-            if (variableName !== HHStoredVarPrefixKey + TK.Logging) {
-                dataToSave[storageName + "." + variableName] = getStoredValue(variableName);
-            }
+    const currentStorageName = getStoredValue(HHStoredVarPrefixKey + SK.settPerTab) === "true" ? "sessionStorage" : "localStorage";
+    for (const i of Object.keys(HHStoredVars_HHStoredVars)) {
+        const varType = HHStoredVars_HHStoredVars[i].HHType;
+        if (!((varType === "Setting" && extractSettings) || (varType === "Temp" && extractTemp)))
+            continue;
+        const storageType = HHStoredVars_HHStoredVars[i].storage;
+        const storageName = storageType === 'Storage()' ? currentStorageName : storageType;
+        if (i !== HHStoredVarPrefixKey + TK.Logging) {
+            dataToSave[storageName + "." + i] = getStoredValue(i);
         }
     }
     if (extractLog) {
@@ -27009,9 +27152,9 @@ function extractHHVars(dataToSave, extractLog = false, extractTemp = true, extra
     return dataToSave;
 }
 function saveHHVarsSettingsAsJSON() {
-    var dataToSave = {};
+    const dataToSave = {};
     extractHHVars(dataToSave, false, false, true);
-    var name = 'HH_SaveSettings_' + Date.now() + '.json';
+    const name = 'HH_SaveSettings_' + Date.now() + '.json';
     const a = document.createElement('a');
     a.download = name;
     a.href = URL.createObjectURL(new Blob([JSON.stringify(dataToSave)], { type: 'application/json' }));
@@ -27021,48 +27164,44 @@ function getStorageItem(inStorageType) {
     switch (inStorageType) {
         case 'localStorage':
             return localStorage;
-            break;
         case 'sessionStorage':
             return sessionStorage;
-            break;
         case 'Storage()':
             return getStorage();
-            break;
     }
 }
 function migrateHHVars() {
-    /*
-    const varReplacement =
-          [
-              {from:"HHAuto_Setting_MaxAff", to:"HHAuto_Setting_maxAff"},
-              {from:"HHAuto_Setting_MaxExp", to:"HHAuto_Setting_maxExp"},
-              {from:"HHAuto_Setting_autoMissionC", to:"HHAuto_Setting_autoMissionCollect"},
-          ];
-    for(let replacement of varReplacement)
-    {
-        const oldVar = replacement.from;
-        const newVar = replacement.to;
-        if (sessionStorage[oldVar] !== undefined)
-        {
-            sessionStorage[newVar] = sessionStorage[oldVar];
-            sessionStorage.removeItem(oldVar);
-        }
-        if (localStorage[oldVar] !== undefined)
-        {
-            localStorage[newVar] = localStorage[oldVar];
-            localStorage.removeItem(oldVar);
-        }
-    }*/
-    if (HHStoredVarPrefixKey !== 'HHAuto_' && haveHHAutoSettings()) {
-        // Migrate from default to custom keys
-        for (const newKey of Object.keys(HHStoredVars_HHStoredVars)) {
-            const oldKeys = newKey.replace(HHStoredVarPrefixKey, 'HHAuto_');
-            const storageItem = getStorageItem(HHStoredVars_HHStoredVars[newKey].storage);
-            const itemValue = storageItem[oldKeys];
-            storageItem.removeItem(oldKeys);
-            if (itemValue) {
-                setStoredValue(newKey, itemValue);
-            }
+    // Custom-prefix migration: when the user runs a forked build with a
+    // non-default HHStoredVarPrefixKey and old "HHAuto_"-prefixed
+    // settings are still in storage, copy each registered key over from
+    // the legacy slot to the active prefix.
+    //
+    // Status (2026-05-26): the active HHStoredVarPrefixKey is hardcoded
+    // to "HHAuto_" in src/config/HHStoredVars.ts, so the body of this
+    // function is dormant in production. The function and its call
+    // site (StartService.ts: migrateHHVars()) are intentionally kept
+    // because:
+    //   - Flipping the prefix is the documented mechanism for
+    //     multi-account isolation (no current PR, but on the roadmap).
+    //   - The cost of keeping the migration around is negligible
+    //     (one early-return check per script start).
+    //   - If a future patch enables the custom prefix without re-
+    //     introducing the migration, every user who upgrades loses
+    //     their settings on the next reload, which is unrecoverable.
+    // Remove together with the multi-account feature, not before.
+    if (HHStoredVarPrefixKey === 'HHAuto_' || !haveHHAutoSettings())
+        return;
+    for (const newKey of Object.keys(HHStoredVars_HHStoredVars)) {
+        const oldKeys = newKey.replace(HHStoredVarPrefixKey, 'HHAuto_');
+        const storageItem = getStorageItem(HHStoredVars_HHStoredVars[newKey].storage);
+        const itemValue = storageItem[oldKeys];
+        storageItem.removeItem(oldKeys);
+        // Preserve the value if it is set at all -- including the empty
+        // string and "0" (falsy in JS but legitimate stored-string
+        // values for some toggles). Only skip when the legacy slot was
+        // never populated.
+        if (itemValue !== undefined && itemValue !== null) {
+            setStoredValue(newKey, itemValue);
         }
     }
 }
@@ -27080,12 +27219,12 @@ function getUserHHStoredVarDefault(inVarName) {
     return null;
 }
 function saveHHStoredVarsDefaults() {
-    var dataToSave = {};
+    const dataToSave = {};
     getMenuValues();
     extractHHVars(dataToSave, false, false, true);
-    let savedHHStoredVars = {};
-    for (var i of Object.keys(dataToSave)) {
-        let variableName = i.split(".")[1];
+    const savedHHStoredVars = {};
+    for (const i of Object.keys(dataToSave)) {
+        const variableName = i.split(".")[1];
         if (variableName !== HHStoredVarPrefixKey + SK.saveDefaults && HHStoredVars_HHStoredVars[variableName].default !== dataToSave[i]) {
             savedHHStoredVars[variableName] = dataToSave[i];
         }
@@ -27094,27 +27233,31 @@ function saveHHStoredVarsDefaults() {
     LogUtils_logHHAuto("HHStoredVar defaults saved !");
 }
 function setHHStoredVarToDefault(inVarName) {
-    if (HHStoredVars_HHStoredVars[inVarName] !== undefined) {
-        if (HHStoredVars_HHStoredVars[inVarName].default !== undefined && HHStoredVars_HHStoredVars[inVarName].storage !== undefined) {
-            let storageItem;
-            storageItem = getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage);
-            let userDefinedDefault = getUserHHStoredVarDefault(inVarName);
-            let isValid = HHStoredVars_HHStoredVars[inVarName].isValid === undefined ? true : HHStoredVars_HHStoredVars[inVarName].isValid.test(userDefinedDefault);
-            if (userDefinedDefault !== null && isValid) {
-                LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to user default value : " + userDefinedDefault);
-                storageItem[inVarName] = userDefinedDefault;
-            }
-            else {
-                LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to default value : " + HHStoredVars_HHStoredVars[inVarName].default);
-                storageItem[inVarName] = HHStoredVars_HHStoredVars[inVarName].default;
-            }
-        }
-        else {
-            LogUtils_logHHAuto("HHStoredVar " + inVarName + " either have no storage or default defined.");
-        }
+    const entry = HHStoredVars_HHStoredVars[inVarName];
+    if (entry === undefined) {
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
+        return;
+    }
+    if (entry.default === undefined || entry.storage === undefined) {
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " either have no storage or default defined.");
+        return;
+    }
+    const storageItem = getStorageItem(entry.storage);
+    const userDefinedDefault = getUserHHStoredVarDefault(inVarName);
+    // Null-check first, then validate: avoids running a regex against
+    // the literal string "null" (JavaScript coerces null to "null"
+    // when fed to RegExp.test). The previous implementation worked by
+    // accident through the userDefinedDefault !== null guard, but the
+    // ordering was fragile -- a refactor that simplified the guard
+    // could re-introduce the issue.
+    if (userDefinedDefault !== null
+        && (entry.isValid === undefined || entry.isValid.test(userDefinedDefault))) {
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to user default value : " + userDefinedDefault);
+        storageItem[inVarName] = userDefinedDefault;
     }
     else {
-        LogUtils_logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to default value : " + entry.default);
+        storageItem[inVarName] = entry.default;
     }
 }
 function getHHStoredVarDefault(inVarName) {
@@ -27131,43 +27274,38 @@ function getHHStoredVarDefault(inVarName) {
     }
 }
 function debugDeleteAllVars() {
-    Object.keys(localStorage).forEach((key) => {
-        if (key.startsWith(HHStoredVarPrefixKey + "Setting_")) {
-            localStorage.removeItem(key);
-        }
-    });
-    Object.keys(sessionStorage).forEach((key) => {
-        if (key.startsWith(HHStoredVarPrefixKey + "Setting_")) {
-            sessionStorage.removeItem(key);
-        }
-    });
-    Object.keys(localStorage).forEach((key) => {
-        if (key.startsWith(HHStoredVarPrefixKey + "Temp_")) {
-            localStorage.removeItem(key);
-        }
-    });
-    Object.keys(sessionStorage).forEach((key) => {
-        if (key.startsWith(HHStoredVarPrefixKey + "Temp_") && key !== HHStoredVarPrefixKey + TK.Logging) {
-            sessionStorage.removeItem(key);
-        }
-    });
+    // Iterate the registry instead of duplicating the "Setting_" /
+    // "Temp_" prefix convention here. Routing through deleteStoredValue
+    // keeps the cleanup honest: any key that getStoredValue/setStored
+    // Value would honour is in scope, anything else is intentionally
+    // out of scope (e.g. game-side localStorage entries the script
+    // does not own). TK.Logging stays so a fresh log buffer is
+    // available when the user presses the debug-delete button.
+    const loggingKey = HHStoredVarPrefixKey + TK.Logging;
+    for (const key of Object.keys(HHStoredVars_HHStoredVars)) {
+        if (key === loggingKey)
+            continue;
+        deleteStoredValue(key);
+    }
     LogUtils_logHHAuto('Deleted all script vars.');
 }
 function debugDeleteTempVars() {
-    var dataToSave = {};
+    // Snapshot Settings BEFORE wiping. extractHHVars serialises each
+    // key as "<currentStorageName>.<varName>" using the active
+    // settPerTab value. After debugDeleteAllVars + setDefaults(true)
+    // settPerTab is back to its registry default, which may not match
+    // the user's preference. Rather than restoring into the snapshot's
+    // bucket (which would write into the wrong storage), we restore
+    // each value via setStoredValue, which routes through the registry
+    // and respects the post-reset settPerTab automatically.
+    const dataToSave = {};
     extractHHVars(dataToSave, false, false, true);
-    var storageType;
-    var variableName;
-    var storageItem;
     debugDeleteAllVars();
     setDefaults(true);
-    var keys = Object.keys(dataToSave);
-    for (var i of keys) {
-        storageType = i.split(".")[0];
-        variableName = i.split(".")[1];
-        storageItem = getStorageItem(storageType);
-        LogUtils_logHHAuto(i + ':' + dataToSave[i]);
-        storageItem[variableName] = dataToSave[i];
+    for (const compoundKey of Object.keys(dataToSave)) {
+        const variableName = compoundKey.split(".")[1];
+        LogUtils_logHHAuto(compoundKey + ':' + dataToSave[compoundKey]);
+        setStoredValue(variableName, dataToSave[compoundKey]);
     }
 }
 function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextForUI("menuCollectableText", "elementText")) {
@@ -27179,7 +27317,7 @@ function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextForUI("me
         let count = 0;
         const possibleRewards = ConfigHelper.getHHScriptVars("possibleRewardsList");
         const rewardsToCollect = getStoredJSON(inVarName, []);
-        for (let currentItem of Object.keys(possibleRewards)) {
+        for (const currentItem of Object.keys(possibleRewards)) {
             //console.log(currentItem,possibleRewards[currentItem]);
             if (count === 4) {
                 count = 0;
@@ -27209,7 +27347,7 @@ function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextForUI("me
         });
     }
     function getSelectedCollectables() {
-        let collectablesList = [];
+        const collectablesList = [];
         document.querySelectorAll("#HHAutoPopupGlobalPopup.menuCollectable .menuCollectablesItem").forEach(currentInputElement => {
             const currentInput = currentInputElement;
             if (currentInput.checked) {
@@ -27221,14 +27359,19 @@ function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextForUI("me
     }
 }
 function getLocalStorageSize() {
-    var allStrings = '';
-    for (var key in localStorage) {
-        if (localStorage.hasOwnProperty(key)) {
+    // Approximate size in KB. The factor (16 / 8) converts JavaScript
+    // string length (UTF-16 code units) to bytes (16 bits per code
+    // unit / 8 bits per byte = 2 bytes). The "+3" is a small constant
+    // header allowance carried over from the original implementation;
+    // kept as-is because the value is informational only.
+    let allStrings = '';
+    for (const key in localStorage) {
+        if (Object.prototype.hasOwnProperty.call(localStorage, key)) {
             allStrings += localStorage[key];
         }
     }
-    for (var key in sessionStorage) {
-        if (sessionStorage.hasOwnProperty(key)) {
+    for (const key in sessionStorage) {
+        if (Object.prototype.hasOwnProperty.call(sessionStorage, key)) {
             allStrings += sessionStorage[key];
         }
     }
@@ -27982,7 +28125,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.56";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.57";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.56",
+  "version": "7.35.57",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Helper/PageHelper.spec.ts
+++ b/spec/Helper/PageHelper.spec.ts
@@ -11,7 +11,7 @@ describe("Page Helper", function () {
         document.body.innerHTML = `<!DOCTYPE html>`;
         restoreLocation = MockHelper.snapshotLocation();
         MockHelper.mockDomain();
-        sessionStorage.removeItem(HHStoredVarPrefixKey + "Temp_unkownPagesList");
+        sessionStorage.removeItem(HHStoredVarPrefixKey + "Temp_unknownPagesList");
     });
 
     afterEach(() => {
@@ -82,22 +82,22 @@ describe("Page Helper", function () {
         it("checkUnknown known", function () {
             MockHelper.mockPage('home');
             expect(getPage(true)).toBe('home');
-            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unkownPagesList")).toBeNull();
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unknownPagesList")).toBeNull();
         });
 
         it("checkUnknown Unknown", function () {
             MockHelper.mockDomain('www.hentaiheroes.com', 'XXX-page.html');
             MockHelper.mockPage('XXX');
             expect(getPage(true)).toBe('XXX');
-            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unkownPagesList")).toBe('{"XXX":"/XXX-page.html"}');
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unknownPagesList")).toBe('{"XXX":"/XXX-page.html"}');
         });
 
         it("checkUnknown Unknown twice", function () {
-            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unkownPagesList", '{"XXX":"/XXX-page.html"}')
+            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unknownPagesList", '{"XXX":"/XXX-page.html"}')
             MockHelper.mockDomain('www.hentaiheroes.com', 'ZZZ-page.html');
             MockHelper.mockPage('ZZZ');
             expect(getPage(true)).toBe('ZZZ');
-            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unkownPagesList")).toBe('{"XXX":"/XXX-page.html","ZZZ":"/ZZZ-page.html"}');
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unknownPagesList")).toBe('{"XXX":"/XXX-page.html","ZZZ":"/ZZZ-page.html"}');
         });
 
         it("checkUnknown idempotent: does not rewrite when same page already recorded", function () {
@@ -107,7 +107,7 @@ describe("Page Helper", function () {
             // re-serializes via JSON.stringify, the sentinel is lost and the value
             // changes; if the idempotency guard holds, the sentinel survives untouched.
             const sentinel = '{ "XXX" : "/XXX-page.html" }';
-            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unkownPagesList", sentinel);
+            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unknownPagesList", sentinel);
 
             MockHelper.mockDomain('www.hentaiheroes.com', 'XXX-page.html');
             MockHelper.mockPage('XXX');
@@ -116,17 +116,17 @@ describe("Page Helper", function () {
 
             // The whitespace-laden sentinel is still byte-identical only if the code
             // skipped the JSON.stringify+setStoredValue round-trip.
-            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unkownPagesList")).toBe(sentinel);
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unknownPagesList")).toBe(sentinel);
         });
 
         it("checkUnknown rewrites when pathname changes for a known page id", function () {
             // Same page id, different pathname -> must write.
-            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unkownPagesList", '{"XXX":"/old-path.html"}');
+            sessionStorage.setItem(HHStoredVarPrefixKey + "Temp_unknownPagesList", '{"XXX":"/old-path.html"}');
             MockHelper.mockDomain('www.hentaiheroes.com', 'XXX-page.html');
             MockHelper.mockPage('XXX');
 
             expect(getPage(true)).toBe('XXX');
-            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unkownPagesList")).toBe('{"XXX":"/XXX-page.html"}');
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + "Temp_unknownPagesList")).toBe('{"XXX":"/XXX-page.html"}');
         });
 
         it("missing root element: getPage stays a pure read, haltScript opts into shutdown", function () {

--- a/spec/Helper/StorageHelper.spec.ts
+++ b/spec/Helper/StorageHelper.spec.ts
@@ -1,0 +1,277 @@
+/**
+ * StorageHelper.spec.ts -- direct spec for src/Helper/StorageHelper.ts.
+ *
+ * Created in cluster 4.2.A (REVIEW_StorageHelper.md C1, I1, I2-A).
+ * Covers the previously-untested critical paths:
+ *   - setStoredValue quota-error retry path (C1, I2-A)
+ *   - setStoredValue robustness against primitive throws (C1)
+ *   - getStoredValue kobanUsing master-switch read without recursion (I1)
+ *   - getStoredValue kobanUsing toggling between stored value and "false"
+ *
+ * Notes on test setup:
+ *   - jsdom\'s built-in localStorage / sessionStorage cannot be made to
+ *     throw on demand without monkey-patching the prototypes. We
+ *     swap the relevant storages with a Proxy-based fake just for the
+ *     quota cases, and restore the originals between tests.
+ *   - The HHStoredVars registry is module state we cannot easily mock,
+ *     so we register / deregister test keys at runtime. The script\'s
+ *     real registry (configured at import time) is untouched between
+ *     runs because Jest re-uses the module instance within a file but
+ *     each test cleans up the keys it added.
+ */
+
+import {
+    getStoredValue,
+    setStoredValue,
+    deleteStoredValue,
+    getStoredJSON,
+} from "../../src/Helper/StorageHelper";
+import { HHStoredVarPrefixKey, HHStoredVars } from "../../src/config/HHStoredVars";
+import { SK } from "../../src/config/StorageKeys";
+
+const TEST_KEY = HHStoredVarPrefixKey + "Setting_storageHelperSpecKey";
+const TEST_KEY_KOBAN = HHStoredVarPrefixKey + "Setting_storageHelperSpecKobanKey";
+const MASTER_KEY = HHStoredVarPrefixKey + SK.spendKobans0;
+
+interface RegistryEntry {
+    storage: string;
+    HHType: string;
+    valueType?: string;
+    default?: string;
+    kobanUsing?: boolean;
+}
+
+function registerKey(key: string, entry: RegistryEntry): void {
+    (HHStoredVars as Record<string, RegistryEntry>)[key] = entry;
+}
+
+function deregisterKey(key: string): void {
+    delete (HHStoredVars as Record<string, RegistryEntry>)[key];
+}
+
+describe("StorageHelper -- registered key gating", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        registerKey(TEST_KEY, { storage: "localStorage", HHType: "Setting" });
+    });
+
+    afterEach(() => {
+        deregisterKey(TEST_KEY);
+    });
+
+    it("returns undefined for an unregistered key", () => {
+        expect(getStoredValue("HHAuto_Setting_doesNotExist")).toBeUndefined();
+    });
+
+    it("silently drops writes for an unregistered key", () => {
+        setStoredValue("HHAuto_Setting_doesNotExist", "value");
+        expect(localStorage.getItem("HHAuto_Setting_doesNotExist")).toBeNull();
+        expect(sessionStorage.getItem("HHAuto_Setting_doesNotExist")).toBeNull();
+    });
+
+    it("round-trips a registered key through localStorage", () => {
+        setStoredValue(TEST_KEY, "hello");
+        expect(getStoredValue(TEST_KEY)).toBe("hello");
+        expect(localStorage.getItem(TEST_KEY)).toBe("hello");
+    });
+
+    it("deletes a registered key", () => {
+        setStoredValue(TEST_KEY, "hello");
+        deleteStoredValue(TEST_KEY);
+        expect(getStoredValue(TEST_KEY)).toBeUndefined();
+    });
+
+    it("getStoredJSON returns default for an unregistered key", () => {
+        expect(getStoredJSON("HHAuto_Setting_doesNotExist", { fallback: true })).toEqual({ fallback: true });
+    });
+});
+
+describe("StorageHelper -- kobanUsing master-switch (I1)", () => {
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        registerKey(TEST_KEY_KOBAN, {
+            storage: "localStorage",
+            HHType: "Setting",
+            kobanUsing: true,
+        });
+    });
+
+    afterEach(() => {
+        deregisterKey(TEST_KEY_KOBAN);
+    });
+
+    it("returns the stored value when the master switch is true", () => {
+        // Master switch is registered globally with storage type "Storage()",
+        // which resolves to localStorage by default (settPerTab unset == false).
+        localStorage.setItem(MASTER_KEY, "true");
+        setStoredValue(TEST_KEY_KOBAN, "real-value");
+        expect(getStoredValue(TEST_KEY_KOBAN)).toBe("real-value");
+    });
+
+    it("returns 'false' literal when the master switch is unset (treated as off)", () => {
+        setStoredValue(TEST_KEY_KOBAN, "real-value");
+        expect(getStoredValue(TEST_KEY_KOBAN)).toBe("false");
+    });
+
+    it("returns 'false' literal when the master switch is explicitly false", () => {
+        localStorage.setItem(MASTER_KEY, "false");
+        setStoredValue(TEST_KEY_KOBAN, "real-value");
+        expect(getStoredValue(TEST_KEY_KOBAN)).toBe("false");
+    });
+
+    it("does not infinite-recurse when the master switch is itself flagged kobanUsing (defensive)", () => {
+        // Simulate a registry typo: someone marks Setting_spendKobans0
+        // itself as kobanUsing. In the old implementation this caused
+        // an unbounded call stack via getStoredValue. The patched
+        // implementation short-circuits via a direct storage read on
+        // the master key, so this case must NOT throw RangeError.
+        const masterEntry = (HHStoredVars as Record<string, RegistryEntry>)[MASTER_KEY];
+        const original = masterEntry ? { ...masterEntry } : undefined;
+        registerKey(MASTER_KEY, { storage: "localStorage", HHType: "Setting", kobanUsing: true });
+        try {
+            localStorage.setItem(MASTER_KEY, "true");
+            setStoredValue(TEST_KEY_KOBAN, "real-value");
+            // No assertion on the return value beyond "did not throw":
+            // semantics under that broken registry are not specified.
+            expect(() => getStoredValue(TEST_KEY_KOBAN)).not.toThrow();
+        } finally {
+            if (original) {
+                registerKey(MASTER_KEY, original);
+            } else {
+                deregisterKey(MASTER_KEY);
+            }
+        }
+    });
+});
+
+describe("StorageHelper -- setStoredValue catch robustness (C1, I2-A)", () => {
+    // setStoredValue performs a property-assignment
+    // (storage[key] = value), not a setItem call. To make a write of
+    // a SPECIFIC key throw on demand, we install an Object.defineProperty
+    // setter on that exact key. The setter is per-key, so it does not
+    // affect cleanLogsInStorage's deletes on TK.Logging /
+    // TK.LeagueOpponentList.
+    function installThrowingSetter(
+        storage: Storage,
+        key: string,
+        decideThrow: (currentCallCount: number) => unknown | null,
+    ): { calls: number; restore: () => void } {
+        const tracker = { calls: 0 };
+        let storedValue: string | undefined;
+        Object.defineProperty(storage, key, {
+            configurable: true,
+            get() { return storedValue; },
+            set(value: string) {
+                tracker.calls += 1;
+                const maybeThrow = decideThrow(tracker.calls);
+                if (maybeThrow !== null) {
+                    throw maybeThrow as Error;
+                }
+                storedValue = value;
+            },
+        });
+        return {
+            get calls() { return tracker.calls; },
+            restore: () => {
+                // Drop the custom property descriptor and replace with
+                // a plain data slot so subsequent reads in the same
+                // test (and future tests) work normally. delete is the
+                // cleanest way; jsdom localStorage tolerates it.
+                delete (storage as unknown as Record<string, unknown>)[key];
+                if (storedValue !== undefined) {
+                    storage.setItem(key, storedValue);
+                }
+            },
+        };
+    }
+
+    beforeEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        registerKey(TEST_KEY, { storage: "localStorage", HHType: "Setting" });
+    });
+
+    afterEach(() => {
+        deregisterKey(TEST_KEY);
+    });
+
+    it("does NOT propagate a primitive throw out of setStoredValue", () => {
+        // Old `catch ({ errName, message })` block crashed with
+        // TypeError when the throw was a primitive string -- you cannot
+        // destructure on a string. The new catch coerces via
+        // `String(e)` and survives.
+        const probe = installThrowingSetter(
+            localStorage,
+            TEST_KEY,
+            (n) => (n === 1 ? "primitive boom" : null),
+        );
+        try {
+            expect(() => setStoredValue(TEST_KEY, "value")).not.toThrow();
+            // Retry path must still have completed once the setter
+            // stopped throwing.
+            expect(localStorage.getItem(TEST_KEY)).toBe("value");
+            expect(probe.calls).toBeGreaterThanOrEqual(2);
+        } finally {
+            probe.restore();
+        }
+    });
+
+    it("does NOT propagate a plain-object throw without errName/message keys", () => {
+        const probe = installThrowingSetter(
+            localStorage,
+            TEST_KEY,
+            (n) => (n === 1 ? { code: 22 } : null),
+        );
+        try {
+            expect(() => setStoredValue(TEST_KEY, "value")).not.toThrow();
+            expect(localStorage.getItem(TEST_KEY)).toBe("value");
+            expect(probe.calls).toBeGreaterThanOrEqual(2);
+        } finally {
+            probe.restore();
+        }
+    });
+
+    it("retries once after a QuotaExceededError-shaped throw and succeeds", () => {
+        const probe = installThrowingSetter(
+            localStorage,
+            TEST_KEY,
+            (n) => {
+                if (n === 1) {
+                    const err = new Error("QuotaExceededError: storage full") as Error & { name: string };
+                    err.name = "QuotaExceededError";
+                    return err;
+                }
+                return null;
+            },
+        );
+        try {
+            setStoredValue(TEST_KEY, "value");
+            expect(localStorage.getItem(TEST_KEY)).toBe("value");
+            expect(probe.calls).toBeGreaterThanOrEqual(2);
+        } finally {
+            probe.restore();
+        }
+    });
+
+    it("gives up after the second throw without infinite recursion", () => {
+        const probe = installThrowingSetter(
+            localStorage,
+            TEST_KEY,
+            () => {
+                const err = new Error("permanent quota") as Error & { name: string };
+                err.name = "QuotaExceededError";
+                return err;
+            },
+        );
+        try {
+            expect(() => setStoredValue(TEST_KEY, "value")).not.toThrow();
+            // Two attempts: original write + one retry. No third call
+            // because the catch with retry=true falls through.
+            expect(probe.calls).toBe(2);
+        } finally {
+            probe.restore();
+        }
+    });
+});

--- a/spec/Service/Pipeline.config.spec.ts
+++ b/spec/Service/Pipeline.config.spec.ts
@@ -48,6 +48,7 @@ jest.mock('../../src/Helper/ConfigHelper', () => ({
 jest.mock('../../src/Helper/StorageHelper', () => ({
   getStoredValue: jest.fn().mockReturnValue('[]'),
   setStoredValue: jest.fn(),
+  deleteStoredValue: jest.fn(),
 }));
 
 jest.mock('../../src/config/HHStoredVars', () => ({
@@ -68,10 +69,12 @@ jest.mock('../../src/Utils/LogUtils', () => ({
   logHHAuto: jest.fn(),
 }));
 
-import { pipeline, getStaleEventIDs } from '../../src/Service/Pipeline.config';
-import { getStoredValue } from '../../src/Helper/StorageHelper';
+import { pipeline, getStaleEventIDs, pruneExpiredEvents } from '../../src/Service/Pipeline.config';
+import { getStoredValue, setStoredValue, deleteStoredValue } from '../../src/Helper/StorageHelper';
 import { AutoLoopContext } from '../../src/Service/AutoLoopContext';
 const getStoredValueMock = getStoredValue as jest.Mock;
+const setStoredValueMock = setStoredValue as jest.Mock;
+const deleteStoredValueMock = deleteStoredValue as jest.Mock;
 
 function makeCtx(overrides: Partial<AutoLoopContext> = {}): AutoLoopContext {
   return {
@@ -536,6 +539,95 @@ describe('Pipeline.config', () => {
       getStoredValueMock.mockReturnValue('not-json');
       const result = getStaleEventIDs(1000);
       expect(result).toEqual(['__parse_error__']);
+    });
+  });
+
+  describe('expired-event cleanup (issue #1738)', () => {
+    beforeEach(() => {
+      getStoredValueMock.mockReset();
+      setStoredValueMock.mockReset();
+      deleteStoredValueMock.mockReset();
+    });
+
+    it('pruneExpiredEvents drops entries with seconds_before_end <= now and persists', () => {
+      const now = 2_000_000;
+      const eventList: Record<string, any> = {
+        expired_event: { id: 'expired_event', seconds_before_end: 1_500_000, isCompleted: false },
+        future_event: { id: 'future_event', seconds_before_end: 3_000_000, isCompleted: false },
+      };
+      pruneExpiredEvents(eventList, now);
+      expect(eventList).toEqual({
+        future_event: { id: 'future_event', seconds_before_end: 3_000_000, isCompleted: false },
+      });
+      expect(setStoredValueMock).toHaveBeenCalledTimes(1);
+      expect(deleteStoredValueMock).not.toHaveBeenCalled();
+    });
+
+    it('pruneExpiredEvents deletes the storage key when every entry was expired', () => {
+      const now = 2_000_000;
+      const eventList: Record<string, any> = {
+        expired_a: { id: 'expired_a', seconds_before_end: 1_000_000 },
+        expired_b: { id: 'expired_b', seconds_before_end: 1_500_000 },
+      };
+      pruneExpiredEvents(eventList, now);
+      expect(eventList).toEqual({});
+      expect(deleteStoredValueMock).toHaveBeenCalledTimes(1);
+      expect(setStoredValueMock).not.toHaveBeenCalled();
+    });
+
+    it('pruneExpiredEvents leaves entries without seconds_before_end alone', () => {
+      const now = 2_000_000;
+      const eventList: Record<string, any> = {
+        partial_event: { id: 'partial_event', isCompleted: false },
+        bad_value: { id: 'bad_value', seconds_before_end: 'not-a-number' },
+      };
+      pruneExpiredEvents(eventList, now);
+      expect(eventList).toEqual({
+        partial_event: { id: 'partial_event', isCompleted: false },
+        bad_value: { id: 'bad_value', seconds_before_end: 'not-a-number' },
+      });
+      expect(setStoredValueMock).not.toHaveBeenCalled();
+      expect(deleteStoredValueMock).not.toHaveBeenCalled();
+    });
+
+    it('pruneExpiredEvents is a no-op when no entry is expired', () => {
+      const now = 2_000_000;
+      const eventList: Record<string, any> = {
+        future_event: { id: 'future_event', seconds_before_end: 3_000_000 },
+      };
+      pruneExpiredEvents(eventList, now);
+      expect(setStoredValueMock).not.toHaveBeenCalled();
+      expect(deleteStoredValueMock).not.toHaveBeenCalled();
+    });
+
+    it('getStaleEventIDs prunes expired entries before returning the stale list', () => {
+      const now = 2_000_000;
+      const eventList = {
+        expired_event: { id: 'expired_event', seconds_before_end: 1_500_000, next_refresh: 100, isCompleted: false },
+        stale_future_event: { id: 'stale_future_event', seconds_before_end: 3_000_000, next_refresh: 100, isCompleted: false },
+      };
+      getStoredValueMock.mockReturnValueOnce(JSON.stringify(eventList));
+      const stale = getStaleEventIDs(now);
+      expect(stale).toEqual(['stale_future_event']);
+      // Persistence call from pruneExpiredEvents.
+      expect(setStoredValueMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('getStaleEventIDs does not include the expired event in the stale list (issue #1738 loop guard)', () => {
+      const now = 2_000_000;
+      const eventList = {
+        // Mirrors the lively_scene_event_12 entry from the bug report.
+        lively_scene_event_12: {
+          id: 'lively_scene_event_12',
+          seconds_before_end: 1_000_000,
+          next_refresh: 1_500_000,
+          isCompleted: false,
+        },
+      };
+      getStoredValueMock.mockReturnValueOnce(JSON.stringify(eventList));
+      const stale = getStaleEventIDs(now);
+      expect(stale).toEqual([]);
+      expect(deleteStoredValueMock).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/Helper/PageHelper.ts
+++ b/src/Helper/PageHelper.ts
@@ -225,15 +225,15 @@ export function getPage(checkUnknown = false): string
         }
         if (!isKnown && page)
         {
-            const unknownPageList = getStoredJSON(HHStoredVarPrefixKey + TK.unkownPagesList, {});
+            const unknownPageList = getStoredJSON(HHStoredVarPrefixKey + TK.unknownPagesList, {});
             // Idempotent write: skip the JSON.stringify+setStoredValue round-trip
             // when this page was already recorded with the same pathname (avoids
             // a write per AutoLoop tick on long-running unknown pages).
             if (unknownPageList[page] !== window.location.pathname)
             {
-                logHHAuto(`Page unkown for script : ${page} / ${window.location.pathname}`);
+                logHHAuto(`Page unknown for script : ${page} / ${window.location.pathname}`);
                 unknownPageList[page] = window.location.pathname;
-                setStoredValue(HHStoredVarPrefixKey + TK.unkownPagesList, JSON.stringify(unknownPageList));
+                setStoredValue(HHStoredVarPrefixKey + TK.unknownPagesList, JSON.stringify(unknownPageList));
             }
         }
     }

--- a/src/Helper/StorageHelper.ts
+++ b/src/Helper/StorageHelper.ts
@@ -26,11 +26,21 @@
 // Also provides export/import of settings as JSON files and a popup
 // for selecting which reward types to auto-collect.
 //
+// External callers MUST use getStoredValue / setStoredValue /
+// deleteStoredValue / getStoredJSON. Direct access to localStorage or
+// sessionStorage is reserved for the storage adapter itself, the
+// ForbiddenBackoff backoff path (see _lessons/zirkulaerer-import-tdz-
+// crash.md -- it must not import HHStoredVars to keep the dependency
+// graph cycle-free), and game-side state that the script does not own
+// (e.g. localStorage.sort_by, set by the game's harem UI). Anything
+// else is a bypass that defeats the registry, kobanUsing master-switch,
+// and quota-retry contracts.
+//
 // Used by: Every module and helper in the project.
 import { setDefaults } from "../Service/StartService";
 import { fillHHPopUp } from "../Utils/HHPopup";
 import { cleanLogsInStorage, logHHAuto } from "../Utils/LogUtils";
-import { isJSON, safeJsonParse } from "../Utils/Utils";
+import { safeJsonParse } from "../Utils/Utils";
 import { HHStoredVarPrefixKey, HHStoredVars } from "../config/HHStoredVars";
 import { SK, TK } from "../config/StorageKeys";
 import { ConfigHelper } from "./ConfigHelper";
@@ -43,23 +53,38 @@ export function getStoredJSON<T>(key: string, defaultValue: T, reviver?: (key: s
     return safeJsonParse(val, defaultValue, reviver);
 }
 
+/**
+ * Returns the active "default" storage based on the settPerTab toggle.
+ * When settPerTab is "true", per-tab isolation is on: every Storage()
+ * key lives in sessionStorage and is therefore tab-local.
+ *
+ * IMPORTANT side-effect of toggling settPerTab at runtime: existing
+ * Storage()-typed values do NOT migrate between localStorage and
+ * sessionStorage. Settings recorded under one mode become invisible
+ * (defaults take over) when the user flips to the other mode and
+ * reappear when they flip back. This is intentional -- per-tab mode
+ * is supposed to start fresh -- but it is not currently surfaced to
+ * the user in the menu UI.
+ */
 export function getStorage()
 {
-    return getStoredValue(HHStoredVarPrefixKey+SK.settPerTab) === "true"?sessionStorage:localStorage;
+    return getStoredValue(HHStoredVarPrefixKey+SK.settPerTab) === "true" ? sessionStorage : localStorage;
 }
 
 export function getStoredValue(inVarName: string)
 {
-    if (HHStoredVars.hasOwnProperty(inVarName))
-    {
-        const storedValue = getStorageItem(HHStoredVars[inVarName].storage)[inVarName];
-        if(HHStoredVars[inVarName].kobanUsing) {
-            // Check main switch for spenind Koban
-            return getStoredValue(HHStoredVarPrefixKey+'Setting_spendKobans0') === "true" ? storedValue : "false";
-        }
-        return storedValue
-    }
-    return undefined;
+    if (!HHStoredVars.hasOwnProperty(inVarName)) return undefined;
+    const storedValue = getStorageItem(HHStoredVars[inVarName].storage)[inVarName];
+    if (!HHStoredVars[inVarName].kobanUsing) return storedValue;
+    // Check main switch for spending Koban via a direct storage read,
+    // NOT recursion via getStoredValue, to avoid an infinite call stack
+    // if Setting_spendKobans0 itself were ever (accidentally) registered
+    // with kobanUsing: true. The master switch is itself a Storage()
+    // entry so we route through getStorageItem with its registered type.
+    const masterKey = HHStoredVarPrefixKey + SK.spendKobans0;
+    const masterEntry = HHStoredVars[masterKey];
+    const masterValue = masterEntry ? getStorageItem(masterEntry.storage)[masterKey] : undefined;
+    return masterValue === "true" ? storedValue : "false";
 }
 
 export function deleteStoredValue(inVarName: string)
@@ -72,44 +97,35 @@ export function deleteStoredValue(inVarName: string)
 
 export function setStoredValue(inVarName: string, inValue: any, retry: boolean=false)
 {
-    if (HHStoredVars.hasOwnProperty(inVarName))
-    {
-        try {
-            getStorageItem(HHStoredVars[inVarName].storage)[inVarName] = inValue;
-        } catch ({ errName, message }) {
-            cleanLogsInStorage();
-            logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry?'user storage need to be cleaned':'retry...'}`);
-            if (!retry) setStoredValue(inVarName, inValue, true);
-        }
+    if (!HHStoredVars.hasOwnProperty(inVarName)) return;
+    try {
+        getStorageItem(HHStoredVars[inVarName].storage)[inVarName] = inValue;
+    } catch (e) {
+        // Robust catch: destructuring `{ errName, message }` from a
+        // non-Error throw (primitive, plain object missing those keys)
+        // would throw a TypeError out of setStoredValue itself --
+        // catastrophic in the AutoLoop hot-loop where this runs >100x
+        // per tick. Coerce to a string message instead.
+        const message = (e instanceof Error) ? e.message : String(e);
+        cleanLogsInStorage();
+        logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry?'user storage need to be cleaned':'retry...'}`);
+        if (!retry) setStoredValue(inVarName, inValue, true);
     }
 }
 
 
 export function extractHHVars(dataToSave,extractLog = false,extractTemp=true,extractSettings=true)
 {
-    let storageType;
-    let storageName;
-    let currentStorageName = getStoredValue(HHStoredVarPrefixKey+SK.settPerTab) ==="true"?"sessionStorage":"localStorage";
-    let variableName;
-    let storageItem;
-    let varType;
-    for (let i of Object.keys(HHStoredVars))
+    const currentStorageName = getStoredValue(HHStoredVarPrefixKey+SK.settPerTab) === "true" ? "sessionStorage" : "localStorage";
+    for (const i of Object.keys(HHStoredVars))
     {
-        varType = HHStoredVars[i].HHType;
-        if (varType === "Setting" && extractSettings || varType === "Temp" && extractTemp)
+        const varType = HHStoredVars[i].HHType;
+        if (!((varType === "Setting" && extractSettings) || (varType === "Temp" && extractTemp))) continue;
+        const storageType = HHStoredVars[i].storage;
+        const storageName = storageType === 'Storage()' ? currentStorageName : storageType;
+        if (i !== HHStoredVarPrefixKey + TK.Logging)
         {
-            storageType = HHStoredVars[i].storage;
-            variableName = i;
-            storageName = storageType;
-            storageItem = getStorageItem(storageType);
-            if (storageType === 'Storage()')
-            {
-                storageName = currentStorageName;
-            }
-            if (variableName !== HHStoredVarPrefixKey + TK.Logging)
-            {
-                dataToSave[storageName+"."+variableName] = getStoredValue(variableName);
-            }
+            dataToSave[storageName + "." + i] = getStoredValue(i);
         }
     }
     if (extractLog)
@@ -120,68 +136,61 @@ export function extractHHVars(dataToSave,extractLog = false,extractTemp=true,ext
 }
 
 export function saveHHVarsSettingsAsJSON() {
-    var dataToSave={};
-    extractHHVars(dataToSave,false,false,true);
-    var name='HH_SaveSettings_'+Date.now()+'.json';
-    const a = document.createElement('a')
-    a.download = name
-    a.href = URL.createObjectURL(new Blob([JSON.stringify(dataToSave)], {type: 'application/json'}))
-    a.click()
+    const dataToSave = {};
+    extractHHVars(dataToSave, false, false, true);
+    const name = 'HH_SaveSettings_' + Date.now() + '.json';
+    const a = document.createElement('a');
+    a.download = name;
+    a.href = URL.createObjectURL(new Blob([JSON.stringify(dataToSave)], { type: 'application/json' }));
+    a.click();
 }
 
 export function getStorageItem(inStorageType)
 {
     switch (inStorageType)
     {
-        case 'localStorage' :
+        case 'localStorage':
             return localStorage;
-            break;
-        case 'sessionStorage' :
+        case 'sessionStorage':
             return sessionStorage;
-            break;
-        case 'Storage()' :
+        case 'Storage()':
             return getStorage();
-            break;
     }
 }
 
 export function migrateHHVars()
 {
-    /*
-    const varReplacement =
-          [
-              {from:"HHAuto_Setting_MaxAff", to:"HHAuto_Setting_maxAff"},
-              {from:"HHAuto_Setting_MaxExp", to:"HHAuto_Setting_maxExp"},
-              {from:"HHAuto_Setting_autoMissionC", to:"HHAuto_Setting_autoMissionCollect"},
-          ];
-    for(let replacement of varReplacement)
+    // Custom-prefix migration: when the user runs a forked build with a
+    // non-default HHStoredVarPrefixKey and old "HHAuto_"-prefixed
+    // settings are still in storage, copy each registered key over from
+    // the legacy slot to the active prefix.
+    //
+    // Status (2026-05-26): the active HHStoredVarPrefixKey is hardcoded
+    // to "HHAuto_" in src/config/HHStoredVars.ts, so the body of this
+    // function is dormant in production. The function and its call
+    // site (StartService.ts: migrateHHVars()) are intentionally kept
+    // because:
+    //   - Flipping the prefix is the documented mechanism for
+    //     multi-account isolation (no current PR, but on the roadmap).
+    //   - The cost of keeping the migration around is negligible
+    //     (one early-return check per script start).
+    //   - If a future patch enables the custom prefix without re-
+    //     introducing the migration, every user who upgrades loses
+    //     their settings on the next reload, which is unrecoverable.
+    // Remove together with the multi-account feature, not before.
+    if(HHStoredVarPrefixKey === 'HHAuto_' || !haveHHAutoSettings()) return;
+    for (const newKey of Object.keys(HHStoredVars))
     {
-        const oldVar = replacement.from;
-        const newVar = replacement.to;
-        if (sessionStorage[oldVar] !== undefined)
-        {
-            sessionStorage[newVar] = sessionStorage[oldVar];
-            sessionStorage.removeItem(oldVar);
-        }
-        if (localStorage[oldVar] !== undefined)
-        {
-            localStorage[newVar] = localStorage[oldVar];
-            localStorage.removeItem(oldVar);
-        }
-    }*/
-
-    if(HHStoredVarPrefixKey !== 'HHAuto_' && haveHHAutoSettings()) {
-        // Migrate from default to custom keys
-        for (const newKey of Object.keys(HHStoredVars))
-        {
-            const oldKeys = newKey.replace(HHStoredVarPrefixKey,'HHAuto_');
-            const storageItem = getStorageItem(HHStoredVars[newKey].storage);
-            const itemValue = storageItem[oldKeys];
-
-            storageItem.removeItem(oldKeys);
-            if (itemValue) {
-                setStoredValue(newKey, itemValue);
-            }
+        const oldKeys = newKey.replace(HHStoredVarPrefixKey, 'HHAuto_');
+        const storageItem = getStorageItem(HHStoredVars[newKey].storage);
+        const itemValue = storageItem[oldKeys];
+        storageItem.removeItem(oldKeys);
+        // Preserve the value if it is set at all -- including the empty
+        // string and "0" (falsy in JS but legitimate stored-string
+        // values for some toggles). Only skip when the legacy slot was
+        // never populated.
+        if (itemValue !== undefined && itemValue !== null) {
+            setStoredValue(newKey, itemValue);
         }
     }
 }
@@ -205,13 +214,13 @@ export function getUserHHStoredVarDefault(inVarName)
 
 export function saveHHStoredVarsDefaults()
 {
-    var dataToSave={};
+    const dataToSave = {};
     getMenuValues();
-    extractHHVars(dataToSave,false,false,true);
-    let savedHHStoredVars={};
-    for(var i of Object.keys(dataToSave))
+    extractHHVars(dataToSave, false, false, true);
+    const savedHHStoredVars = {};
+    for (const i of Object.keys(dataToSave))
     {
-        let variableName = i.split(".")[1];
+        const variableName = i.split(".")[1];
         if (variableName !== HHStoredVarPrefixKey+SK.saveDefaults && HHStoredVars[variableName].default !== dataToSave[i])
         {
             savedHHStoredVars[variableName] = dataToSave[i];
@@ -223,34 +232,35 @@ export function saveHHStoredVarsDefaults()
 
 export function setHHStoredVarToDefault(inVarName)
 {
-    if (HHStoredVars[inVarName] !== undefined)
+    const entry = HHStoredVars[inVarName];
+    if (entry === undefined)
     {
-        if (HHStoredVars[inVarName].default !== undefined && HHStoredVars[inVarName].storage !== undefined)
-        {
-            let storageItem;
-            storageItem = getStorageItem(HHStoredVars[inVarName].storage);
-
-            let userDefinedDefault = getUserHHStoredVarDefault(inVarName);
-            let isValid = HHStoredVars[inVarName].isValid===undefined?true:HHStoredVars[inVarName].isValid.test(userDefinedDefault);
-            if (userDefinedDefault !== null && isValid)
-            {
-                logHHAuto("HHStoredVar "+inVarName+" set to user default value : "+userDefinedDefault);
-                storageItem[inVarName] = userDefinedDefault;
-            }
-            else
-            {
-                logHHAuto("HHStoredVar "+inVarName+" set to default value : "+HHStoredVars[inVarName].default);
-                storageItem[inVarName] = HHStoredVars[inVarName].default;
-            }
-        }
-        else
-        {
-            logHHAuto("HHStoredVar "+inVarName+" either have no storage or default defined.");
-        }
+        logHHAuto("HHStoredVar "+inVarName+" doesn't exist.");
+        return;
+    }
+    if (entry.default === undefined || entry.storage === undefined)
+    {
+        logHHAuto("HHStoredVar "+inVarName+" either have no storage or default defined.");
+        return;
+    }
+    const storageItem = getStorageItem(entry.storage);
+    const userDefinedDefault = getUserHHStoredVarDefault(inVarName);
+    // Null-check first, then validate: avoids running a regex against
+    // the literal string "null" (JavaScript coerces null to "null"
+    // when fed to RegExp.test). The previous implementation worked by
+    // accident through the userDefinedDefault !== null guard, but the
+    // ordering was fragile -- a refactor that simplified the guard
+    // could re-introduce the issue.
+    if (userDefinedDefault !== null
+        && (entry.isValid === undefined || entry.isValid.test(userDefinedDefault)))
+    {
+        logHHAuto("HHStoredVar "+inVarName+" set to user default value : "+userDefinedDefault);
+        storageItem[inVarName] = userDefinedDefault;
     }
     else
     {
-        logHHAuto("HHStoredVar "+inVarName+" doesn't exist.");
+        logHHAuto("HHStoredVar "+inVarName+" set to default value : "+entry.default);
+        storageItem[inVarName] = entry.default;
     }
 }
 
@@ -275,56 +285,44 @@ export function getHHStoredVarDefault(inVarName)
 
 export function debugDeleteAllVars()
 {
-    Object.keys(localStorage).forEach((key) =>
-                                      {
-        if (key.startsWith(HHStoredVarPrefixKey+"Setting_"))
-        {
-            localStorage.removeItem(key);
-        }
-    });
-    Object.keys(sessionStorage).forEach((key) =>
-                                        {
-        if (key.startsWith(HHStoredVarPrefixKey+"Setting_"))
-        {
-            sessionStorage.removeItem(key);
-        }
-    });
-    Object.keys(localStorage).forEach((key) =>
-                                      {
-        if (key.startsWith(HHStoredVarPrefixKey+"Temp_"))
-        {
-            localStorage.removeItem(key);
-        }
-    });
-    Object.keys(sessionStorage).forEach((key) =>
-                                        {
-        if (key.startsWith(HHStoredVarPrefixKey+"Temp_") && key !== HHStoredVarPrefixKey+TK.Logging)
-        {
-            sessionStorage.removeItem(key);
-        }
-    });
+    // Iterate the registry instead of duplicating the "Setting_" /
+    // "Temp_" prefix convention here. Routing through deleteStoredValue
+    // keeps the cleanup honest: any key that getStoredValue/setStored
+    // Value would honour is in scope, anything else is intentionally
+    // out of scope (e.g. game-side localStorage entries the script
+    // does not own). TK.Logging stays so a fresh log buffer is
+    // available when the user presses the debug-delete button.
+    const loggingKey = HHStoredVarPrefixKey + TK.Logging;
+    for (const key of Object.keys(HHStoredVars))
+    {
+        if (key === loggingKey) continue;
+        deleteStoredValue(key);
+    }
     logHHAuto('Deleted all script vars.');
 }
 
 
 export function debugDeleteTempVars()
 {
-    var dataToSave={};
-    extractHHVars(dataToSave,false,false,true);
-    var storageType;
-    var variableName;
-    var storageItem;
+    // Snapshot Settings BEFORE wiping. extractHHVars serialises each
+    // key as "<currentStorageName>.<varName>" using the active
+    // settPerTab value. After debugDeleteAllVars + setDefaults(true)
+    // settPerTab is back to its registry default, which may not match
+    // the user's preference. Rather than restoring into the snapshot's
+    // bucket (which would write into the wrong storage), we restore
+    // each value via setStoredValue, which routes through the registry
+    // and respects the post-reset settPerTab automatically.
+    const dataToSave = {};
+    extractHHVars(dataToSave, false, false, true);
 
     debugDeleteAllVars();
     setDefaults(true);
-    var keys=Object.keys(dataToSave);
-    for(var i of keys)
+
+    for (const compoundKey of Object.keys(dataToSave))
     {
-        storageType=i.split(".")[0];
-        variableName=i.split(".")[1];
-        storageItem = getStorageItem(storageType);
-        logHHAuto(i+':'+ dataToSave[i]);
-        storageItem[variableName] = dataToSave[i];
+        const variableName = compoundKey.split(".")[1];
+        logHHAuto(compoundKey + ':' + dataToSave[compoundKey]);
+        setStoredValue(variableName, dataToSave[compoundKey]);
     }
 }
 
@@ -340,7 +338,7 @@ export function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextFo
         let count = 0;
         const possibleRewards = ConfigHelper.getHHScriptVars("possibleRewardsList");
         const rewardsToCollect = getStoredJSON(inVarName, []);
-        for (let currentItem of Object.keys(possibleRewards))
+        for (const currentItem of Object.keys(possibleRewards))
         {
             //console.log(currentItem,possibleRewards[currentItem]);
             if (count === 4)
@@ -375,7 +373,7 @@ export function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextFo
 
     function getSelectedCollectables()
     {
-        let collectablesList:string[] = [];
+        const collectablesList: string[] = [];
         document.querySelectorAll("#HHAutoPopupGlobalPopup.menuCollectable .menuCollectablesItem").forEach(currentInputElement =>
                                                                                                            {
             const currentInput = <HTMLInputElement> currentInputElement;
@@ -390,14 +388,19 @@ export function getAndStoreCollectPreferences(inVarName, inPopUpText = getTextFo
 }
 
 export function getLocalStorageSize() {
-    var allStrings = '';
-    for (var key in localStorage) {
-        if (localStorage.hasOwnProperty(key)) {
+    // Approximate size in KB. The factor (16 / 8) converts JavaScript
+    // string length (UTF-16 code units) to bytes (16 bits per code
+    // unit / 8 bits per byte = 2 bytes). The "+3" is a small constant
+    // header allowance carried over from the original implementation;
+    // kept as-is because the value is informational only.
+    let allStrings = '';
+    for (const key in localStorage) {
+        if (Object.prototype.hasOwnProperty.call(localStorage, key)) {
             allStrings += localStorage[key];
         }
     }
-    for (var key in sessionStorage) {
-        if (sessionStorage.hasOwnProperty(key)) {
+    for (const key in sessionStorage) {
+        if (Object.prototype.hasOwnProperty.call(sessionStorage, key)) {
             allStrings += sessionStorage[key];
         }
     }

--- a/src/Module/Events/EventModule.ts
+++ b/src/Module/Events/EventModule.ts
@@ -348,6 +348,31 @@ export class EventModule {
         {
             if (inTab !== "global")
             {
+                // Expired-event short-circuit (issue #1738): if the
+                // entry the precondition picked is already past its
+                // game-side end (seconds_before_end <= now), don't
+                // navigate to /event.html with that tab. The game has
+                // dropped the tab, so the navigation lands on a page
+                // whose getDisplayedIdEventPage() returns '', the
+                // outer if(getPage()===pagesIDEvent) branch is never
+                // reached, and the loop runs forever.
+                //
+                // Drop the registry entry directly here so the next
+                // tick's getStaleEventIDs() does not pick it again.
+                // Pipeline.config.ts pruneExpiredEvents handles this
+                // before the trigger fires; this branch is the
+                // belt-and-braces guard for direct callers.
+                try {
+                    const evList = getStoredJSON(HHStoredVarPrefixKey + TK.eventsList, {});
+                    const ev = (evList as Record<string, any>)[inTab];
+                    const end = Number(ev?.seconds_before_end);
+                    if (Number.isFinite(end) && end <= Date.now()) {
+                        logHHAuto(`Skipping navigation to expired event ${inTab}, dropping stale registry entry.`);
+                        EventModule.clearEventData(inTab);
+                        gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
+                        return true;
+                    }
+                } catch (e) { /* fall through to normal navigation */ }
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDEvent"),{tab:inTab});
             }
             else

--- a/src/Module/PlaceOfPower.ts
+++ b/src/Module/PlaceOfPower.ts
@@ -142,8 +142,8 @@ export class PlaceOfPower {
     }
     static cleanTempPopToStart()
     {
-        sessionStorage.removeItem(HHStoredVarPrefixKey+TK.PopUnableToStart);
-        sessionStorage.removeItem(HHStoredVarPrefixKey+TK.PopToStart);
+        deleteStoredValue(HHStoredVarPrefixKey+TK.PopUnableToStart);
+        deleteStoredValue(HHStoredVarPrefixKey+TK.PopToStart);
     }
     static removePopFromPopToStart(index)
     {
@@ -354,7 +354,7 @@ export class PlaceOfPower {
             });
             if (PopToStart.length === 0)
             {
-                sessionStorage.removeItem(HHStoredVarPrefixKey+TK.PopUnableToStart);
+                deleteStoredValue(HHStoredVarPrefixKey+TK.PopUnableToStart);
             }
             logHHAuto("build popToStart : "+PopToStart);
             setStoredValue(HHStoredVarPrefixKey+TK.PopToStart, JSON.stringify(PopToStart));

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.56";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.57";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/ParanoiaService.ts
+++ b/src/Service/ParanoiaService.ts
@@ -12,7 +12,7 @@
 import { ConfigHelper } from "../Helper/ConfigHelper";
 import { getHero } from "../Helper/HeroHelper";
 import { getHHVars } from "../Helper/HHHelper";
-import { getStoredJSON, getStoredValue, setStoredValue } from "../Helper/StorageHelper";
+import { deleteStoredValue, getStoredJSON, getStoredValue, setStoredValue } from "../Helper/StorageHelper";
 import { randomInterval } from "../Helper/TimeHelper";
 import { getSecondsLeft, getTimer, setTimer } from "../Helper/TimerHelper";
 import { EventModule } from "../Module/Events/EventModule";
@@ -77,10 +77,10 @@ export class ParanoiaService {
 
     static clearParanoiaSpendings() {
         ParanoiaService.countParanoiaLoop = 0;
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaSpendings);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.NextSwitch);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked);
-        sessionStorage.removeItem(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaSpendings);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.NextSwitch);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked);
+        deleteStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked);
     }
 
     static updatedParanoiaSpendings(inSpendingFunction, inSpent) {

--- a/src/Service/Pipeline.config.ts
+++ b/src/Service/Pipeline.config.ts
@@ -227,11 +227,22 @@ const handleEventParsing: HandlerConfig = {
  * On unexpected storage shape this returns a single sentinel ID so that the
  * caller still triggers a parse cycle (preserves the previous fallback
  * behaviour where the precondition returned true on parse errors).
+ *
+ * Expired-event side effect: entries whose `seconds_before_end` is in the
+ * past are events the game no longer hosts. parseEventPage cannot refresh
+ * them (the in-game tab has been replaced by a successor or removed
+ * entirely), so they would stay stale forever and drive
+ * handleEventParsing into a permanent reload loop (issue #1738 -- a
+ * lively_scene_event_12 entry kept the bot looping for 7+ minutes before
+ * the user gave up). pruneExpiredEvents() removes them from the registry
+ * BEFORE this filter runs so the loop terminates and storage stays
+ * bounded.
  */
 export function getStaleEventIDs(now: number = Date.now()): string[] {
   try {
     const storedList = getStoredValue(HHStoredVarPrefixKey + TK.eventsList);
     const eventList = storedList ? JSON.parse(storedList) : {};
+    pruneExpiredEvents(eventList, now);
     return Object.keys(eventList).filter(id => {
       const ev = eventList[id];
       if (!ev || ev.isCompleted) return false;
@@ -243,6 +254,41 @@ export function getStaleEventIDs(now: number = Date.now()): string[] {
     // accidentally skip a refresh cycle. The actual parseEventPage call
     // tolerates an empty/garbage tab via its own "global" fallback.
     return ['__parse_error__'];
+  }
+}
+
+/**
+ * Drop event registry entries whose game-side end has already passed
+ * (`seconds_before_end <= now`). Such entries cannot be refreshed by
+ * parseEventPage (the in-game tab is gone), so leaving them in the
+ * registry would keep handleEventParsing.precondition firing forever
+ * (issue #1738).
+ *
+ * Mutates the input map AND persists the pruned shape so the next
+ * read sees the cleaned state. Exported for direct unit testing in
+ * Pipeline.config.spec.ts.
+ *
+ * Defensive: an entry without `seconds_before_end`, or with a
+ * non-finite value, is left in place. parseEventPage handles those
+ * via its existing "ERROR: No event Id found" path on the next visit.
+ */
+export function pruneExpiredEvents(eventList: Record<string, any>, now: number): void {
+  let mutated = false;
+  for (const id of Object.keys(eventList)) {
+    const ev = eventList[id];
+    if (!ev) continue;
+    const end = Number(ev.seconds_before_end);
+    if (Number.isFinite(end) && end <= now) {
+      delete eventList[id];
+      mutated = true;
+    }
+  }
+  if (mutated) {
+    if (Object.keys(eventList).length === 0) {
+      deleteStoredValue(HHStoredVarPrefixKey + TK.eventsList);
+    } else {
+      setStoredValue(HHStoredVarPrefixKey + TK.eventsList, JSON.stringify(eventList));
+    }
   }
 }
 
@@ -263,24 +309,55 @@ const handleLeague: HandlerConfig = {
   minIntervalMs: 2_000,
   atomic: true,
   interruptible: 'never',
-  precondition: () => {
+  precondition: (ctx) => {
+    // Trigger logic in full (lesson pipeline-inner-trigger-in-precondition):
+    //
+    //   1. League auto-mode active and feature enabled at all?
+    //   2. Bot not currently mid-action on a different module
+    //      (legacy lastActionPerformed guard from doLeagueBattle, lifted
+    //      out of step.fn so the chain doesn't fire just to log a skip).
+    //   3. Either ready to fight (energy + threshold + booster check) OR
+    //      the cool-down timer has expired and we still need to refresh
+    //      the pInfo display with a default timer value (issue raised
+    //      2026-05-26: pInfo stuck on 'No timer' when isTimeToFight is
+    //      false because the only setTimer paths live behind a fight).
+    //
     // Note (issue #1708 follow-up): handleLeague is intentionally NOT
     // gated on trollWaitForEnergy. League uses a separate energy pool
     // (challenge tokens) that is unrelated to troll combativity (fight
     // tokens). LeagueHelper.isTimeToFight() already checks challenge
-    // energy, and the 60_000 ms minIntervalMs caps re-entry. Blocking
-    // league while troll waits for combativity (as v7.35.45 did) keeps
-    // league fights from happening even though the user has the energy
-    // to do them. handleEventParsing is gated separately because it
-    // ran every 2 s and was the actual ping-pong driver in #1700.
-    return LeagueHelper.isAutoLeagueActivated() && LeagueHelper.isTimeToFight();
+    // energy, and the minIntervalMs caps re-entry. Blocking league
+    // while troll waits for combativity (as v7.35.45 did) keeps league
+    // fights from happening even though the user has the energy to do
+    // them. handleEventParsing is gated separately because it ran every
+    // 2 s and was the actual ping-pong driver in #1700.
+    if (!LeagueHelper.isAutoLeagueActivated()) return false;
+    const lastAction = ctx.lastActionPerformed;
+    if (lastAction !== 'none' && lastAction !== 'league') return false;
+    return LeagueHelper.isTimeToFight() || checkTimer('nextLeaguesTime');
   },
   steps: [
     {
-      name: 'doLeagueBattle',
-      fn: async (): Promise<StepResult> => {
+      name: 'doLeagueBattleOrTimer',
+      fn: async (ctx): Promise<StepResult> => {
         try {
-          LeagueHelper.doLeagueBattle();
+          if (LeagueHelper.isTimeToFight()) {
+            LeagueHelper.doLeagueBattle();
+            ctx.lastActionPerformed = 'league';
+            return { ok: true };
+          }
+          // Fight not possible right now (energy below threshold,
+          // booster missing, etc.). Refresh the cool-down timer so the
+          // pInfo display can show the next refresh time instead of
+          // 'No timer'. Default fallback when the game has not yet
+          // reported a next_refresh_ts is the same 15-17 min window
+          // doLeagueBattle uses for similar idle paths.
+          const next_refresh = Number(getHHVars('Hero.energies.challenge.next_refresh_ts'));
+          if (Number.isFinite(next_refresh) && next_refresh > 0) {
+            setTimer('nextLeaguesTime', randomInterval(next_refresh + 10, next_refresh + 180));
+          } else {
+            setTimer('nextLeaguesTime', randomInterval(15 * 60, 17 * 60));
+          }
           return { ok: true };
         } catch (err) {
           return { ok: false, reason: String(err), retryable: true };
@@ -590,7 +667,7 @@ const handlePlaceOfPower: HandlerConfig = {
         if (ctx.busy === false) {
           popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
           if (popToStart.length === 0) {
-            sessionStorage.removeItem(HHStoredVarPrefixKey + TK.PopToStart);
+            deleteStoredValue(HHStoredVarPrefixKey + TK.PopToStart);
             ctx.busy = gotoPage(ConfigHelper.getHHScriptVars('pagesIDHome'));
           }
         }
@@ -1430,53 +1507,56 @@ const handleGoHome: HandlerConfig = {
 //  The Scheduler walks the list once per tick, picks the first ready handler
 //  (precondition true, cool-down elapsed, state IDLE), and runs it.
 //
-//  Migration notes (3.2.G.a -> 3.2.G.i): handlers move from
-//  AutoLoopActions.ts into this array. Until the migration is complete,
-//  the classic handler block in AutoLoop.autoLoop() and the pipeline run
-//  sequentially within one tick (classic first, then pipeline). The order
-//  inside this array is kept so the same handler always runs at most once
-//  per tick across both systems (the classic block is updated to skip
-//  handlers that have already moved to the pipeline).
+//  Migration history: all 33 AutoLoop action handlers now live in this
+//  array (3.2.G.a -> 3.2.G.complete). The classic handler block in
+//  AutoLoop.autoLoop() is gone; the Scheduler is the sole driver.
 //
-//  Order matches the legacy AutoLoop call order so behaviour stays
-//  identical until the remaining handlers are migrated in 3.2.G.c-i.
+//  Order is the agreed user-facing priority sequence: high-yield /
+//  low-cost actions (salary, shop, missions) and resource collectors
+//  before the long battle / quest / labyrinth blocks. handleEventParsing
+//  is locked at slot 1 because it populates event/mythic-girl data that
+//  later handlers (handleTrollBattle, the collect handlers) read.
+//  handleGoHome is locked at the tail because it closes the tick on a
+//  non-home page. handleGenericBattle is kept just before handleGoHome
+//  as a catch-all when the bot has landed on any battle page.
 // ---------------------------------------------------------------------------
 
 export const pipeline: HandlerConfig[] = [
-  // Order matches the legacy AutoLoop call order to preserve relative
-  // scheduling. handleMythicWave is intentionally skipped (no useful effect
-  // in the pipeline model -- see comment on its absent migration above).
+  // handleMythicWave is intentionally not listed: it was a legacy slot
+  // reservation used by the classic handleTrollBattle path and has no
+  // effect in the pipeline model. The mythic girl is fully covered by
+  // handleTrollBattle's activation paths.
   handleEventParsing,
+  handleSalary,
   handleShop,
   handleAutoEquipBoosters,
   handleHaremSize,
-  handlePlaceOfPower,
-  handleGenericBattle,
-  handleLoveRaid,
-  handleTrollBattle,
-  handlePachinko,
-  handleContest,
   handleMissions,
-  handleQuest,
-  handleLeague,
-  handleSeason,
-  handlePentaDrill,
-  handlePantheon,
-  handleChampionTicket,
-  handleChampion,
-  handleClubChampion,
+  handlePachinko,
+  handleSeasonalFreeCard,
+  handleFreeBundles,
   handleSeasonCollect,
   handlePentaDrillCollect,
-  handleSeasonalFreeCard,
   handleSeasonalEventCollect,
   handleSeasonalRankCollect,
   handlePoVCollect,
   handlePoGCollect,
-  handleFreeBundles,
+  handleContest,
   handleDailyGoals,
-  handleLabyrinth,
-  handleSalary,
+  handleChampionTicket,
+  handlePlaceOfPower,
+  handleClubChampion,
+  handleChampion,
+  handleLoveRaid,
+  handleTrollBattle,
   handleBossBangParse,
   handleBossBangFight,
+  handleLeague,
+  handleSeason,
+  handleQuest,
+  handlePantheon,
+  handlePentaDrill,
+  handleLabyrinth,
+  handleGenericBattle,
   handleGoHome,
 ];

--- a/src/Utils/LogUtils.ts
+++ b/src/Utils/LogUtils.ts
@@ -23,19 +23,27 @@ import { safeJsonParse } from './Utils';
 const MAX_LINES = 500
 
 /**
- * Wipe all existing log entries from storage and record a single
- * "cleaned" marker with the storage size before the clean.
- * Also deletes the cached league opponent list which can grow large.
+ * Wipe all existing log entries from storage and free up large temp
+ * caches. Called from setStoredValue's quota-error catch path, so this
+ * function MUST NOT itself perform any storage write -- otherwise a
+ * non-log-driven quota fault (e.g. an oversized TK.HaremSize) can be
+ * amplified, since the very recovery path would try to add a "cleaned"
+ * marker to an already-full storage, throw again, and recurse through
+ * setStoredValue's catch.
+ *
+ * Strategy:
+ *   - Drop the entire log buffer (delete, not overwrite -- frees the
+ *     full key without a new write).
+ *   - Drop the league opponent cache, which is the second-largest temp
+ *     value typically present.
+ * Console.log still receives a one-line breadcrumb so the cleanup is
+ * visible during debugging without touching storage.
  */
 export function cleanLogsInStorage() {
-    var currentLoggingText: any = {};
-    let currDate = new Date();
-    var prefix = currDate.toLocaleString() + "." + currDate.getMilliseconds() + ":cleanLogsInStorage";
-    currentLoggingText[prefix] = 'Cleaned logging, storage size before clean ' + getLocalStorageSize();
-    setStoredValue(HHStoredVarPrefixKey + TK.Logging, JSON.stringify(currentLoggingText));
-
-    // Delete big temp in storage
+    const sizeBefore = getLocalStorageSize();
+    deleteStoredValue(HHStoredVarPrefixKey + TK.Logging);
     deleteStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList);
+    console.log(`HHAuto: cleanLogsInStorage cleared TK.Logging and TK.LeagueOpponentList; storage size before clean ${sizeBefore}`);
 }
 
 /**

--- a/src/config/HHStoredVars.ts
+++ b/src/config/HHStoredVars.ts
@@ -2504,7 +2504,7 @@ HHStoredVars[HHStoredVarPrefixKey + TK.lseManualCollectAll] =
     storage: "localStorage",
     HHType: "Temp"
 };
-HHStoredVars[HHStoredVarPrefixKey + TK.unkownPagesList] =
+HHStoredVars[HHStoredVarPrefixKey + TK.unknownPagesList] =
     {
     storage:"sessionStorage",
     HHType:"Temp"

--- a/src/config/StorageKeys.ts
+++ b/src/config/StorageKeys.ts
@@ -372,7 +372,7 @@ export const TK = {
     // Misc
     sandalwoodFailure: "Temp_sandalwoodFailure",
     sandalwoodMaxUsages: "Temp_sandalwoodMaxUsages",
-    unkownPagesList: "Temp_unkownPagesList",
+    unknownPagesList: "Temp_unknownPagesList",
     userLink: "Temp_userLink",
 
     // Survey


### PR DESCRIPTION
StorageHelper review (step 4 of the refactor) plus two user-visible hotfixes squashed from refactor/v7.36.0-staging:

- League pInfo timer refresh when fight is not possible.
- Stale event registry no longer drives a /event.html reload loop.
- New 33-handler pipeline order.

See CHANGELOG.md for the user-facing summary.

Refs #1722 #1738 #1718