### PR TITLE
fix: loop-module review -- PoP, Quest, Contest, Daily Goals, Champion (Step 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.35.58 - loop-module review (Quest, Contest, Daily Goals, Champion, Place of Power)
+
+#### Fixed
+
+- A locked Place of Power no longer traps the bot in an endless "navigating to powerplace" cycle. When a spot cannot be entered, the bot now records it after the second attempt and moves on instead of retrying every tick. This also removes one of the access-forbidden triggers at its root, since the rapid retry loop was part of what provoked the server.
+- A quest step that requires an outfit change no longer spins forever on an unrecognised state. Auto-quest now bails out cleanly and asks you to proceed that screen manually, the same way it already handles other quest steps it cannot complete on its own.
+- Multi-tier contest finishes collect their rewards across consecutive ticks instead of doing a full page reload after every single reward.
+- Daily-goals detection no longer wipes its own cache when the bot passes through the missions or contests pages. Previously the cached goal list was cleared on those pages, so the pantheon daily-goal booster override could report "no active goal" between two daily-goals visits. The override now fires reliably.
+
+#### Changed
+
+- Internal hardening with no visible behaviour change: number-coercion on the champion auto-team configuration values, defensive error handling in the daily-goals collector, and removal of a small amount of dead code.
+
 ### v7.35.57 - StorageHelper review, league timer refresh, expired-event loop fix
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.57
+// @version      7.35.58
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -6099,8 +6099,15 @@ class DailyGoals {
                         return false;
                     }
                 }
-                catch ({ errName, message }) {
-                    LogUtils_logHHAuto(`ERROR during daily goals run: ${message}, retry in 1h`);
+                catch (err) {
+                    // Pre-fix this destructured `{ errName, message }` from the
+                    // thrown value, which crashed on primitive throws (the
+                    // destructure itself raised TypeError) and silently logged
+                    // `undefined` on non-Error objects. Standard catch handles
+                    // both safely; the message extraction stays defensive so a
+                    // primitive throw still produces a readable log line.
+                    const errMessage = err instanceof Error ? err.message : String(err);
+                    LogUtils_logHHAuto(`ERROR during daily goals run: ${errMessage}, retry in 1h`);
                     setTimer('nextDailyGoalsCollectTime', randomInterval(3600, 4000));
                     return false;
                 }
@@ -6111,26 +6118,40 @@ class DailyGoals {
                 return true;
             }
         }
+        // Default branch: timer not yet elapsed or autoDailyGoalsCollect
+        // disabled. Pre-fix the function fell through with an implicit
+        // `undefined` return that the Pipeline adapter coerced to falsy
+        // (busy=false). Spell that out explicitly to match the declared
+        // boolean return type and to survive a future strict-TS push.
+        return false;
     }
     static parse() {
-        const supportedGoals = [];
-        if (getPage() === ConfigHelper.getHHScriptVars("pagesIDDailyGoals") && unsafeWindow.daily_goals_list) {
-            for (let currentTier = 0; currentTier < unsafeWindow.daily_goals_list.length; currentTier++) {
-                const goal = unsafeWindow.daily_goals_list[currentTier];
-                if (goal && goal.progress_data.current < goal.progress_data.max)
-                    switch (goal.anchor) {
-                        // case ConfigHelper.getHHScriptVars("pagesURLLabyrinth"):
-                        // case ConfigHelper.getHHScriptVars("pagesURLSeasonArena"):
-                        // case ConfigHelper.getHHScriptVars("pagesURLHarem"):
-                        case ConfigHelper.getHHScriptVars("pagesURLChampionsMap"):
-                        case ConfigHelper.getHHScriptVars("pagesURLPantheon"):
-                            supportedGoals.push(goal);
-                            break;
-                    }
-            }
+        // parse() is registered as a page handler on the missions and
+        // contests pages too (AutoLoopPageHandlers), not just on the
+        // daily-goals page. On those pages unsafeWindow.daily_goals_list
+        // is not populated, so the method used to fall through, log
+        // "Can't parse Daily Goals", and then overwrite the dailyGoalsList
+        // cache with an empty array. That wiped the cache between two real
+        // daily-goals visits, so isPantheonDailyGoal() reported false and
+        // the pantheon booster-override for an active daily goal never
+        // fired. Guard with an early return that leaves the cache intact
+        // and hands back whatever was last parsed.
+        if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDDailyGoals") || !unsafeWindow.daily_goals_list) {
+            return getStoredJSON(HHStoredVarPrefixKey + TK.dailyGoalsList, []);
         }
-        else {
-            LogUtils_logHHAuto("Can't parse Daily Goals");
+        const supportedGoals = [];
+        for (let currentTier = 0; currentTier < unsafeWindow.daily_goals_list.length; currentTier++) {
+            const goal = unsafeWindow.daily_goals_list[currentTier];
+            if (goal && goal.progress_data.current < goal.progress_data.max)
+                switch (goal.anchor) {
+                    // case ConfigHelper.getHHScriptVars("pagesURLLabyrinth"):
+                    // case ConfigHelper.getHHScriptVars("pagesURLSeasonArena"):
+                    // case ConfigHelper.getHHScriptVars("pagesURLHarem"):
+                    case ConfigHelper.getHHScriptVars("pagesURLChampionsMap"):
+                    case ConfigHelper.getHHScriptVars("pagesURLPantheon"):
+                        supportedGoals.push(goal);
+                        break;
+                }
         }
         setStoredValue(HHStoredVarPrefixKey + TK.dailyGoalsList, JSON.stringify(supportedGoals));
         LogUtils_logHHAuto("Daily Goals", supportedGoals);
@@ -11906,7 +11927,15 @@ class Contest {
                 // see stale claim buttons and create an infinite collect loop.
                 contestContainer.remove();
                 if (contest_list.length > 1) {
-                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));
+                    // Multi-reward contests previously triggered a full page
+                    // reload after every claim, producing N-1 reloads in
+                    // quick succession on a 5-tier finish. The reloads put
+                    // unnecessary pressure on the Forbidden race window we
+                    // already mitigated via ADR-003. Stay on the page, set
+                    // busy=true so the scheduler comes back next tick, and
+                    // collect the next reward then. The DOM-removal above
+                    // ensures getClaimsButton() reports the remaining
+                    // reward count correctly on the follow-up tick.
                     return true;
                 }
             }
@@ -12898,6 +12927,14 @@ var Champion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, 
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+// Champion.ts -- Automates the Champions game mode.
+//
+// Handles map navigation, ticket-based fights, and reward collection for the
+// Champions feature. Manages fight energy (tickets), selects opponents, and
+// tracks cooldown timers between rounds.
+//
+// Used by: Service/index.ts (main automation loop)
+//
 
 
 
@@ -12917,8 +12954,6 @@ var Champion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, 
 
 
 class Champion {
-    run() {
-    }
     static ChampDisplayAutoTeamPopup(numberDone, numberEnd, remainingTime) {
         $(".champions-top__inner-wrapper").prepend('<div id="popup_message_champ" class="HHpopup_message" name="popup_message_champ" style="margin:0px;width:400px" ><a id="popup_message_champ_close" class="close">&times;</a>'
             + getTextForUI("autoChampsTeamLoop", "elementText") + ' : <br>' + numberDone + '/' + numberEnd + ' (' + remainingTime + 'sec)</div>');
@@ -12944,8 +12979,13 @@ class Champion {
             });
             return poses;
         };
-        var getChampMaxLoop = function () { var _a; return (_a = getStoredValue(HHStoredVarPrefixKey + SK.autoChampsTeamLoop)) !== null && _a !== void 0 ? _a : 10; };
-        var getMinGirlPower = function () { var _a; return (_a = getStoredValue(HHStoredVarPrefixKey + SK.autoChampsGirlThreshold)) !== null && _a !== void 0 ? _a : 50000; };
+        // Storage values come back as strings; coerce explicitly so the
+        // numeric comparisons further down (counterLoop <= maxLoops,
+        // damage >= girlMinPower) stay strict-typed instead of relying
+        // on JavaScript's loose-equality coercion. Empty-string storage
+        // returns NaN via Number(""), which the `||` fallback rescues.
+        var getChampMaxLoop = function () { return Number(getStoredValue(HHStoredVarPrefixKey + SK.autoChampsTeamLoop)) || 10; };
+        var getMinGirlPower = function () { return Number(getStoredValue(HHStoredVarPrefixKey + SK.autoChampsGirlThreshold)) || 50000; };
         var getChampSecondLine = function () { return getStoredValue(HHStoredVarPrefixKey + SK.autoChampsTeamKeepSecondLine) === 'true'; };
         //let champTeamButton = '<div style="position: absolute;left: 330px;top: 10px;width:90px;z-index:10" class="tooltipHH"><span class="tooltipHHtext">'+getTextForUI("ChampTeamButton","tooltip")+'</span><label class="myButton" id="ChampTeamButton">'+getTextForUI("ChampTeamButton","elementText")+'</label></div>';
         GM_addStyle('.girl-box__draggable.switching {background-color: #ffb827;}');
@@ -20656,6 +20696,34 @@ const handleQuest = {
                         setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
                         ctx.busy = false;
                     }
+                    else if (questRequirement === 'outfit') {
+                        // Quest step requires an outfit change. Quest.ts:215 writes the
+                        // 'outfit' marker but no else-if matched it before, so the
+                        // pipeline fell through to the catch-all 'Invalid quest
+                        // requirement' branch every tick: the marker was never reset,
+                        // so the bot stayed in an infinite log-spam loop on outfit-
+                        // gated quests until the user manually intervened. Auto-quest
+                        // also stayed enabled (unlike unknownQuestButton), so the
+                        // pInfo gave no hint that the bot was stuck.
+                        //
+                        // Mirror the unknownQuestButton path: disable autoQuest /
+                        // autoSideQuest, log a user-actionable message, reset the
+                        // marker, set paranoiaQuestBlocked so other handlers know not
+                        // to wait for quest progress.
+                        setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
+                        if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) === 'true') {
+                            LogUtils_logHHAuto('AutoQuest disabled. The current quest step requires an outfit change. Please manually proceed the current quest screen.');
+                            document.getElementById('autoQuest').checked = false;
+                            setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, 'false');
+                        }
+                        if (getStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest) === 'true') {
+                            LogUtils_logHHAuto('AutoQuest disabled. The current side-quest step requires an outfit change. Please manually proceed the current quest screen.');
+                            document.getElementById('autoSideQuest').checked = false;
+                            setStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest, 'false');
+                        }
+                        setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
+                        ctx.busy = false;
+                    }
                     else if (questRequirement === 'none') {
                         if (checkTimer('nextMainQuestAttempt') && checkTimer('nextSideQuestAttempt')) {
                             if (QuestHelper.getEnergy() > Number(getStoredValue(HHStoredVarPrefixKey + SK.autoQuestThreshold)) || ParanoiaService.checkParanoiaSpendings('quest') > 0) {
@@ -21255,6 +21323,19 @@ const handleGoHome = {
 //  before the long battle / quest / labyrinth blocks. handleEventParsing
 //  is locked at slot 1 because it populates event/mythic-girl data that
 //  later handlers (handleTrollBattle, the collect handlers) read.
+//
+//  Producer/consumer chain in the upper block (slots 2-5):
+//   - slot 2 handleHaremSize: refreshes the TK.HaremSize cache (girl
+//     count + timestamp) consumed by every battle handler's synergy
+//     and team-power calculation.
+//   - slot 3 handleSalary: cheap one-click action with no dependents,
+//     parked here because it is essentially free.
+//   - slot 4 handleShop: writes the storeContents / charLevel /
+//     boosterStatus / boosterIdMap snapshot.
+//   - slot 5 handleAutoEquipBoosters: reads the booster snapshot
+//     produced by handleShop. Must run after handleShop in the same
+//     tick so equip decisions see fresh inventory.
+//
 //  handleGoHome is locked at the tail because it closes the tick on a
 //  non-home page. handleGenericBattle is kept just before handleGoHome
 //  as a catch-all when the bot has landed on any battle page.
@@ -21265,10 +21346,10 @@ const pipeline = [
     // effect in the pipeline model. The mythic girl is fully covered by
     // handleTrollBattle's activation paths.
     handleEventParsing,
+    handleHaremSize,
     handleSalary,
     handleShop,
     handleAutoEquipBoosters,
-    handleHaremSize,
     handleMissions,
     handlePachinko,
     handleSeasonalFreeCard,
@@ -23865,16 +23946,14 @@ class PlaceOfPower {
         deleteStoredValue(HHStoredVarPrefixKey + TK.PopToStart);
     }
     static removePopFromPopToStart(index) {
-        var epop;
-        var popToSart;
-        var newPopToStart;
-        popToSart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
-        newPopToStart = [];
-        for (epop of popToSart) {
-            if (epop != index) {
-                newPopToStart.push(epop);
-            }
-        }
+        const popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
+        // Coerce both sides to Number for the comparison: the storage round-
+        // trip can turn the index into a string when callers pass through
+        // setStoredValue/getStoredValue, while popToStart is JSON-parsed
+        // back to numbers. Strict-equality across the mixed types would
+        // never match and the entry would never be removed.
+        const indexNum = Number(index);
+        const newPopToStart = popToStart.filter(p => p !== indexNum);
         setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify(newPopToStart));
     }
     static collectAndUpdate() {
@@ -24065,7 +24144,16 @@ class PlaceOfPower {
     static doPowerPlacesStuff(index) {
         return PlaceOfPower_awaiter(this, void 0, void 0, function* () {
             if (getPage() !== "powerplace" + index) {
-                if (getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted) != null && index === getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted)) {
+                // Self-heal for failed PoP navigation: storage round-trips numbers as
+                // strings, so the previous strict-equality check (index === stored)
+                // never matched and this branch was dead code -- the bot stayed in
+                // an infinite "Navigating to powerplaceN page" loop on locked PoPs
+                // (issue #1598 root cause). Coerce the stored value to a Number
+                // before comparing so the index goes onto the unable-to-start list
+                // and the loop terminates.
+                const storedPopTarget = getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);
+                const storedPopTargetNum = storedPopTarget !== undefined ? Number(storedPopTarget) : NaN;
+                if (!isNaN(storedPopTargetNum) && index === storedPopTargetNum) {
                     PlaceOfPower.addPopToUnableToStart(index, "Navigation to powerplace" + index + " page failed back to home page.");
                     PlaceOfPower.removePopFromPopToStart(index);
                     deleteStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);
@@ -28125,7 +28213,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.57";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.58";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.57",
+  "version": "7.35.58",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/DailyGoals.spec.ts
+++ b/spec/Module/DailyGoals.spec.ts
@@ -1,0 +1,76 @@
+import { DailyGoals } from "../../src/Module/DailyGoals";
+import { setStoredValue, getStoredJSON } from "../../src/Helper/StorageHelper";
+import { HHStoredVarPrefixKey } from "../../src/config/HHStoredVars";
+import { TK } from "../../src/config/StorageKeys";
+import { MockHelper } from "../testHelpers/MockHelpers";
+
+describe("DailyGoals", function () {
+    afterEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        delete (unsafeWindow as any).daily_goals_list;
+    });
+
+    describe("parse", function () {
+        it("parses supported goals (pantheon) on the daily-goals page", function () {
+            MockHelper.mockDomain("www.hentaiheroes.com", "activities.html", "tab=daily_goals");
+            MockHelper.mockPage("daily_goals");
+            (unsafeWindow as any).daily_goals_list = [
+                { anchor: "/pantheon.html", progress_data: { current: 0, max: 5 } },
+                { anchor: "/some-other.html", progress_data: { current: 0, max: 5 } },
+            ];
+
+            const result = DailyGoals.parse();
+
+            expect(result).toHaveLength(1);
+            expect(result[0].anchor).toBe("/pantheon.html");
+            // cache written with the parsed goals
+            const cached = getStoredJSON<any[]>(HHStoredVarPrefixKey + TK.dailyGoalsList, []);
+            expect(cached).toHaveLength(1);
+        });
+
+        it("does NOT overwrite the cache when called on a non-daily-goals page", function () {
+            // Seed the cache as if a previous daily-goals visit had parsed a
+            // pantheon goal.
+            const seeded = [{ anchor: "/pantheon.html", progress_data: { current: 0, max: 5 } }];
+            setStoredValue(HHStoredVarPrefixKey + TK.dailyGoalsList, JSON.stringify(seeded));
+
+            // Now parse() fires as a page handler on the contests page, where
+            // unsafeWindow.daily_goals_list is undefined.
+            MockHelper.mockDomain("www.hentaiheroes.com", "contests.html");
+            MockHelper.mockPage("contests");
+
+            const result = DailyGoals.parse();
+
+            // Pre-fix this returned [] and wrote [] to the cache, wiping the
+            // pantheon goal so isPantheonDailyGoal() reported false. Post-fix
+            // the cache is preserved and returned untouched.
+            expect(result).toHaveLength(1);
+            expect(result[0].anchor).toBe("/pantheon.html");
+            const cached = getStoredJSON<any[]>(HHStoredVarPrefixKey + TK.dailyGoalsList, []);
+            expect(cached).toHaveLength(1);
+            expect(cached[0].anchor).toBe("/pantheon.html");
+        });
+
+        it("returns the empty cache when called off-page with no prior cache", function () {
+            MockHelper.mockDomain("www.hentaiheroes.com", "contests.html");
+            MockHelper.mockPage("contests");
+
+            const result = DailyGoals.parse();
+
+            expect(result).toEqual([]);
+        });
+
+        it("skips completed goals (current >= max)", function () {
+            MockHelper.mockDomain("www.hentaiheroes.com", "activities.html", "tab=daily_goals");
+            MockHelper.mockPage("daily_goals");
+            (unsafeWindow as any).daily_goals_list = [
+                { anchor: "/pantheon.html", progress_data: { current: 5, max: 5 } },
+            ];
+
+            const result = DailyGoals.parse();
+
+            expect(result).toEqual([]);
+        });
+    });
+});

--- a/spec/Module/PlaceOfPower.spec.ts
+++ b/spec/Module/PlaceOfPower.spec.ts
@@ -1,9 +1,88 @@
 import { PlaceOfPower } from "../../src/Module/PlaceOfPower";
+import { setStoredValue, getStoredJSON } from "../../src/Helper/StorageHelper";
+import { HHStoredVarPrefixKey } from "../../src/config/HHStoredVars";
+import { TK } from "../../src/config/StorageKeys";
 
 describe("PlaceOfPower", function () {
+    afterEach(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
     describe("styles", function () {
         it("default", function () {
             expect(() => PlaceOfPower.styles()).not.toThrow()
+        });
+    });
+
+    describe("removePopFromPopToStart", function () {
+        it("removes a number index from the JSON array", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify([1, 2, 3, 5]));
+
+            PlaceOfPower.removePopFromPopToStart(2);
+
+            const result = getStoredJSON<number[]>(HHStoredVarPrefixKey + TK.PopToStart, []);
+            expect(result).toEqual([1, 3, 5]);
+        });
+
+        it("removes a string index from the JSON array (Number coercion)", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify([1, 2, 3, 5]));
+
+            // Pre-fix this would not match (epop != index used loose equality but
+            // the post-fix uses strict comparison after Number coercion). Either
+            // way, the canonical use case is stripping `index` from the list.
+            PlaceOfPower.removePopFromPopToStart("3");
+
+            const result = getStoredJSON<number[]>(HHStoredVarPrefixKey + TK.PopToStart, []);
+            expect(result).toEqual([1, 2, 5]);
+        });
+
+        it("leaves the list unchanged when the index is not present", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify([1, 2, 3]));
+
+            PlaceOfPower.removePopFromPopToStart(99);
+
+            const result = getStoredJSON<number[]>(HHStoredVarPrefixKey + TK.PopToStart, []);
+            expect(result).toEqual([1, 2, 3]);
+        });
+
+        it("leaves the list empty when the source is empty", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify([]));
+
+            PlaceOfPower.removePopFromPopToStart(1);
+
+            const result = getStoredJSON<number[]>(HHStoredVarPrefixKey + TK.PopToStart, []);
+            expect(result).toEqual([]);
+        });
+    });
+
+    describe("addPopToUnableToStart", function () {
+        it("writes the index as a string when the list is empty", function () {
+            PlaceOfPower.addPopToUnableToStart(5, "test message");
+
+            // Storage round-trips numbers as strings; the stored value is the
+            // semicolon-joined string form.
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + TK.PopUnableToStart)).toBe("5");
+        });
+
+        it("appends to an existing list", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart, "1;3");
+
+            PlaceOfPower.addPopToUnableToStart(7, "test message");
+
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + TK.PopUnableToStart)).toBe("1;3;7");
+        });
+    });
+
+    describe("cleanTempPopToStart", function () {
+        it("clears both temp keys", function () {
+            setStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart, "1;2;3");
+            setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify([4, 5]));
+
+            PlaceOfPower.cleanTempPopToStart();
+
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + TK.PopUnableToStart)).toBeNull();
+            expect(sessionStorage.getItem(HHStoredVarPrefixKey + TK.PopToStart)).toBeNull();
         });
     });
 });

--- a/spec/Service/Pipeline.config.spec.ts
+++ b/spec/Service/Pipeline.config.spec.ts
@@ -31,6 +31,25 @@ jest.mock('../../src/Module/Booster', () => ({
   },
 }));
 
+jest.mock('../../src/Module/Quest', () => ({
+  QuestHelper: {
+    getEnergy: jest.fn().mockReturnValue(0),
+    run: jest.fn(),
+  },
+}));
+
+jest.mock('../../src/Service/ParanoiaService', () => ({
+  ParanoiaService: {
+    checkParanoiaSpendings: jest.fn().mockReturnValue(0),
+  },
+}));
+
+jest.mock('../../src/Module/Troll', () => ({
+  Troll: {
+    doBossBattle: jest.fn().mockResolvedValue(false),
+  },
+}));
+
 jest.mock('../../src/Helper/HHHelper', () => ({
   getHHVars: jest.fn().mockReturnValue(100),
 }));
@@ -56,12 +75,19 @@ jest.mock('../../src/config/HHStoredVars', () => ({
 }));
 
 jest.mock('../../src/config/StorageKeys', () => ({
-  SK: { master: 'master', autoEquipBoosters: 'Setting_autoEquipBoosters' },
+  SK: {
+    master: 'master',
+    autoEquipBoosters: 'Setting_autoEquipBoosters',
+    autoQuest: 'Setting_autoQuest',
+    autoSideQuest: 'Setting_autoSideQuest',
+  },
   TK: {
     eventsList: 'Temp_eventsList',
     trollWaitForEnergy: 'Temp_trollWaitForEnergy',
     charLevel: 'Temp_charLevel',
     autoLoop: 'Temp_autoLoop',
+    questRequirement: 'Temp_questRequirement',
+    paranoiaQuestBlocked: 'Temp_paranoiaQuestBlocked',
   },
 }));
 
@@ -628,6 +654,90 @@ describe('Pipeline.config', () => {
       const stale = getStaleEventIDs(now);
       expect(stale).toEqual([]);
       expect(deleteStoredValueMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('handleQuest', () => {
+    const handler = pipeline.find(h => h.name === 'handleQuest')!;
+
+    beforeEach(() => {
+      getStoredValueMock.mockReset();
+      setStoredValueMock.mockReset();
+      deleteStoredValueMock.mockReset();
+    });
+
+    it('exists in pipeline', () => {
+      expect(handler).toBeDefined();
+    });
+
+    it('outfit marker disables autoQuest, resets the marker, and sets paranoiaQuestBlocked', async () => {
+      // Storage reads return 'true' for autoQuest, 'false' for autoSideQuest,
+      // 'false' for autoTrollBattleSaveQuest, 'outfit' for the marker.
+      // Order matches the reads inside step.fn.
+      getStoredValueMock.mockImplementation((key: string) => {
+        if (key.endsWith('autoTrollBattleSaveQuest')) return 'false';
+        if (key.endsWith('Temp_questRequirement')) return 'outfit';
+        if (key.endsWith('Setting_autoQuest')) return 'true';
+        if (key.endsWith('Setting_autoSideQuest')) return 'false';
+        return undefined;
+      });
+      // Provide a stub DOM input so the autoQuest checkbox toggle does not
+      // throw. The handler reads document.getElementById('autoQuest').
+      const stubInput = { checked: true } as unknown as HTMLInputElement;
+      jest.spyOn(document, 'getElementById').mockImplementation((id: string) =>
+        id === 'autoQuest' || id === 'autoSideQuest' ? (stubInput as unknown as HTMLElement) : null
+      );
+
+      const ctx = makeCtx({ canCollectCompetitionActive: true });
+      await handler.steps[0].fn(ctx);
+
+      // Marker reset to 'none', autoQuest disabled, paranoiaQuestBlocked set.
+      const writes = setStoredValueMock.mock.calls.map(c => [c[0], c[1]]);
+      expect(writes).toContainEqual([
+        expect.stringContaining('Temp_paranoiaQuestBlocked'),
+        'true',
+      ]);
+      expect(writes).toContainEqual([
+        expect.stringContaining('Setting_autoQuest'),
+        'false',
+      ]);
+      expect(writes).toContainEqual([
+        expect.stringContaining('Temp_questRequirement'),
+        'none',
+      ]);
+      // ctx.busy stays false (no continuation).
+      expect(ctx.busy).toBe(false);
+
+      jest.restoreAllMocks();
+    });
+
+    it('outfit marker also disables autoSideQuest when it is enabled', async () => {
+      getStoredValueMock.mockImplementation((key: string) => {
+        if (key.endsWith('autoTrollBattleSaveQuest')) return 'false';
+        if (key.endsWith('Temp_questRequirement')) return 'outfit';
+        if (key.endsWith('Setting_autoQuest')) return 'false';
+        if (key.endsWith('Setting_autoSideQuest')) return 'true';
+        return undefined;
+      });
+      const stubInput = { checked: true } as unknown as HTMLInputElement;
+      jest.spyOn(document, 'getElementById').mockImplementation((id: string) =>
+        id === 'autoQuest' || id === 'autoSideQuest' ? (stubInput as unknown as HTMLElement) : null
+      );
+
+      const ctx = makeCtx({ canCollectCompetitionActive: true });
+      await handler.steps[0].fn(ctx);
+
+      const writes = setStoredValueMock.mock.calls.map(c => [c[0], c[1]]);
+      expect(writes).toContainEqual([
+        expect.stringContaining('Setting_autoSideQuest'),
+        'false',
+      ]);
+      expect(writes).toContainEqual([
+        expect.stringContaining('Temp_questRequirement'),
+        'none',
+      ]);
+
+      jest.restoreAllMocks();
     });
   });
 });

--- a/src/Module/Champion.ts
+++ b/src/Module/Champion.ts
@@ -6,7 +6,6 @@
 //
 // Used by: Service/index.ts (main automation loop)
 //
-import { get } from 'jquery';
 import { ConfigHelper } from "../Helper/ConfigHelper";
 import { getHHVars } from "../Helper/HHHelper";
 import { hhButton } from "../Helper/HHMenuHelper";
@@ -34,8 +33,6 @@ import { EventModule } from "./Events/EventModule";
 import { QuestHelper } from "./Quest";
 
 export class Champion {
-    run(){
-    }
 
     static ChampDisplayAutoTeamPopup(numberDone,numberEnd,remainingTime)
     {
@@ -69,8 +66,13 @@ export class Champion {
             });
             return poses;
         }
-        var getChampMaxLoop = function() { return getStoredValue(HHStoredVarPrefixKey+SK.autoChampsTeamLoop) ?? 10; }
-        var getMinGirlPower = function() { return getStoredValue(HHStoredVarPrefixKey+SK.autoChampsGirlThreshold) ?? 50000; }
+        // Storage values come back as strings; coerce explicitly so the
+        // numeric comparisons further down (counterLoop <= maxLoops,
+        // damage >= girlMinPower) stay strict-typed instead of relying
+        // on JavaScript's loose-equality coercion. Empty-string storage
+        // returns NaN via Number(""), which the `||` fallback rescues.
+        var getChampMaxLoop = function() { return Number(getStoredValue(HHStoredVarPrefixKey+SK.autoChampsTeamLoop)) || 10; }
+        var getMinGirlPower = function() { return Number(getStoredValue(HHStoredVarPrefixKey+SK.autoChampsGirlThreshold)) || 50000; }
         var getChampSecondLine = function(){return getStoredValue(HHStoredVarPrefixKey+SK.autoChampsTeamKeepSecondLine) === 'true';}
 
         //let champTeamButton = '<div style="position: absolute;left: 330px;top: 10px;width:90px;z-index:10" class="tooltipHH"><span class="tooltipHHtext">'+getTextForUI("ChampTeamButton","tooltip")+'</span><label class="myButton" id="ChampTeamButton">'+getTextForUI("ChampTeamButton","elementText")+'</label></div>';

--- a/src/Module/Contest.ts
+++ b/src/Module/Contest.ts
@@ -50,7 +50,15 @@ export class Contest {
                 contestContainer.remove();
                 if ( contest_list.length > 1 )
                 {
-                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));
+                    // Multi-reward contests previously triggered a full page
+                    // reload after every claim, producing N-1 reloads in
+                    // quick succession on a 5-tier finish. The reloads put
+                    // unnecessary pressure on the Forbidden race window we
+                    // already mitigated via ADR-003. Stay on the page, set
+                    // busy=true so the scheduler comes back next tick, and
+                    // collect the next reward then. The DOM-removal above
+                    // ensures getClaimsButton() reports the remaining
+                    // reward count correctly on the follow-up tick.
                     return true;
                 }
             }

--- a/src/Module/DailyGoals.ts
+++ b/src/Module/DailyGoals.ts
@@ -165,8 +165,15 @@ export class DailyGoals {
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         return false;
                     }
-                } catch ({ errName, message }) {
-                    logHHAuto(`ERROR during daily goals run: ${message}, retry in 1h`);
+                } catch (err) {
+                    // Pre-fix this destructured `{ errName, message }` from the
+                    // thrown value, which crashed on primitive throws (the
+                    // destructure itself raised TypeError) and silently logged
+                    // `undefined` on non-Error objects. Standard catch handles
+                    // both safely; the message extraction stays defensive so a
+                    // primitive throw still produces a readable log line.
+                    const errMessage = err instanceof Error ? err.message : String(err);
+                    logHHAuto(`ERROR during daily goals run: ${errMessage}, retry in 1h`);
                     setTimer('nextDailyGoalsCollectTime', randomInterval(3600, 4000));
                     return false;
                 }
@@ -178,29 +185,43 @@ export class DailyGoals {
                 return true;
             }
         }
+        // Default branch: timer not yet elapsed or autoDailyGoalsCollect
+        // disabled. Pre-fix the function fell through with an implicit
+        // `undefined` return that the Pipeline adapter coerced to falsy
+        // (busy=false). Spell that out explicitly to match the declared
+        // boolean return type and to survive a future strict-TS push.
+        return false;
     }
 
     static parse(): KKDailyGoal[] {
-        const supportedGoals: KKDailyGoal[] = [];
-        if (getPage() === ConfigHelper.getHHScriptVars("pagesIDDailyGoals") && unsafeWindow.daily_goals_list) {
-            for (let currentTier = 0; currentTier < unsafeWindow.daily_goals_list.length; currentTier++)
-            {
-                const goal = unsafeWindow.daily_goals_list[currentTier];
-                if (goal && goal.progress_data.current < goal.progress_data.max )
-                    switch (goal.anchor){
-                        // case ConfigHelper.getHHScriptVars("pagesURLLabyrinth"):
-                        // case ConfigHelper.getHHScriptVars("pagesURLSeasonArena"):
-                        // case ConfigHelper.getHHScriptVars("pagesURLHarem"):
-                        case ConfigHelper.getHHScriptVars("pagesURLChampionsMap"):
-                        case ConfigHelper.getHHScriptVars("pagesURLPantheon"):
-                            supportedGoals.push(goal);
-                        break;
-                    }
-            }
+        // parse() is registered as a page handler on the missions and
+        // contests pages too (AutoLoopPageHandlers), not just on the
+        // daily-goals page. On those pages unsafeWindow.daily_goals_list
+        // is not populated, so the method used to fall through, log
+        // "Can't parse Daily Goals", and then overwrite the dailyGoalsList
+        // cache with an empty array. That wiped the cache between two real
+        // daily-goals visits, so isPantheonDailyGoal() reported false and
+        // the pantheon booster-override for an active daily goal never
+        // fired. Guard with an early return that leaves the cache intact
+        // and hands back whatever was last parsed.
+        if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDDailyGoals") || !unsafeWindow.daily_goals_list) {
+            return getStoredJSON(HHStoredVarPrefixKey + TK.dailyGoalsList, []);
         }
-        else
+
+        const supportedGoals: KKDailyGoal[] = [];
+        for (let currentTier = 0; currentTier < unsafeWindow.daily_goals_list.length; currentTier++)
         {
-            logHHAuto("Can't parse Daily Goals");
+            const goal = unsafeWindow.daily_goals_list[currentTier];
+            if (goal && goal.progress_data.current < goal.progress_data.max )
+                switch (goal.anchor){
+                    // case ConfigHelper.getHHScriptVars("pagesURLLabyrinth"):
+                    // case ConfigHelper.getHHScriptVars("pagesURLSeasonArena"):
+                    // case ConfigHelper.getHHScriptVars("pagesURLHarem"):
+                    case ConfigHelper.getHHScriptVars("pagesURLChampionsMap"):
+                    case ConfigHelper.getHHScriptVars("pagesURLPantheon"):
+                        supportedGoals.push(goal);
+                    break;
+                }
         }
 
         setStoredValue(HHStoredVarPrefixKey + TK.dailyGoalsList, JSON.stringify(supportedGoals));

--- a/src/Module/PlaceOfPower.ts
+++ b/src/Module/PlaceOfPower.ts
@@ -145,21 +145,17 @@ export class PlaceOfPower {
         deleteStoredValue(HHStoredVarPrefixKey+TK.PopUnableToStart);
         deleteStoredValue(HHStoredVarPrefixKey+TK.PopToStart);
     }
-    static removePopFromPopToStart(index)
+    static removePopFromPopToStart(index: number | string)
     {
-        var epop;
-        var popToSart;
-        var newPopToStart;
-        popToSart= getStoredJSON(HHStoredVarPrefixKey+TK.PopToStart, []);
-        newPopToStart=[];
-        for (epop of popToSart)
-        {
-            if (epop != index)
-            {
-                newPopToStart.push(epop);
-            }
-        }
-        setStoredValue(HHStoredVarPrefixKey+TK.PopToStart, JSON.stringify(newPopToStart));
+        const popToStart: number[] = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
+        // Coerce both sides to Number for the comparison: the storage round-
+        // trip can turn the index into a string when callers pass through
+        // setStoredValue/getStoredValue, while popToStart is JSON-parsed
+        // back to numbers. Strict-equality across the mixed types would
+        // never match and the entry would never be removed.
+        const indexNum = Number(index);
+        const newPopToStart = popToStart.filter(p => p !== indexNum);
+        setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify(newPopToStart));
     }
 
     static async collectAndUpdate()
@@ -383,7 +379,16 @@ export class PlaceOfPower {
     {
         if(getPage() !== "powerplace"+index)
         {
-            if (getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted) != null && index === getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted)) {
+            // Self-heal for failed PoP navigation: storage round-trips numbers as
+            // strings, so the previous strict-equality check (index === stored)
+            // never matched and this branch was dead code -- the bot stayed in
+            // an infinite "Navigating to powerplaceN page" loop on locked PoPs
+            // (issue #1598 root cause). Coerce the stored value to a Number
+            // before comparing so the index goes onto the unable-to-start list
+            // and the loop terminates.
+            const storedPopTarget = getStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);
+            const storedPopTargetNum = storedPopTarget !== undefined ? Number(storedPopTarget) : NaN;
+            if (!isNaN(storedPopTargetNum) && index === storedPopTargetNum) {
                 PlaceOfPower.addPopToUnableToStart(index, "Navigation to powerplace" + index + " page failed back to home page.");
                 PlaceOfPower.removePopFromPopToStart(index);
                 deleteStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.57";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.58";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/Pipeline.config.ts
+++ b/src/Service/Pipeline.config.ts
@@ -998,6 +998,33 @@ const handleQuest: HandlerConfig = {
           }
           setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
           ctx.busy = false;
+        } else if (questRequirement === 'outfit') {
+          // Quest step requires an outfit change. Quest.ts:215 writes the
+          // 'outfit' marker but no else-if matched it before, so the
+          // pipeline fell through to the catch-all 'Invalid quest
+          // requirement' branch every tick: the marker was never reset,
+          // so the bot stayed in an infinite log-spam loop on outfit-
+          // gated quests until the user manually intervened. Auto-quest
+          // also stayed enabled (unlike unknownQuestButton), so the
+          // pInfo gave no hint that the bot was stuck.
+          //
+          // Mirror the unknownQuestButton path: disable autoQuest /
+          // autoSideQuest, log a user-actionable message, reset the
+          // marker, set paranoiaQuestBlocked so other handlers know not
+          // to wait for quest progress.
+          setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
+          if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) === 'true') {
+            logHHAuto('AutoQuest disabled. The current quest step requires an outfit change. Please manually proceed the current quest screen.');
+            (document.getElementById('autoQuest') as HTMLInputElement).checked = false;
+            setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, 'false');
+          }
+          if (getStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest) === 'true') {
+            logHHAuto('AutoQuest disabled. The current side-quest step requires an outfit change. Please manually proceed the current quest screen.');
+            (document.getElementById('autoSideQuest') as HTMLInputElement).checked = false;
+            setStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest, 'false');
+          }
+          setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
+          ctx.busy = false;
         } else if (questRequirement === 'none') {
           if (checkTimer('nextMainQuestAttempt') && checkTimer('nextSideQuestAttempt')) {
             if (QuestHelper.getEnergy() > Number(getStoredValue(HHStoredVarPrefixKey + SK.autoQuestThreshold)) || ParanoiaService.checkParanoiaSpendings('quest') > 0) {
@@ -1516,6 +1543,19 @@ const handleGoHome: HandlerConfig = {
 //  before the long battle / quest / labyrinth blocks. handleEventParsing
 //  is locked at slot 1 because it populates event/mythic-girl data that
 //  later handlers (handleTrollBattle, the collect handlers) read.
+//
+//  Producer/consumer chain in the upper block (slots 2-5):
+//   - slot 2 handleHaremSize: refreshes the TK.HaremSize cache (girl
+//     count + timestamp) consumed by every battle handler's synergy
+//     and team-power calculation.
+//   - slot 3 handleSalary: cheap one-click action with no dependents,
+//     parked here because it is essentially free.
+//   - slot 4 handleShop: writes the storeContents / charLevel /
+//     boosterStatus / boosterIdMap snapshot.
+//   - slot 5 handleAutoEquipBoosters: reads the booster snapshot
+//     produced by handleShop. Must run after handleShop in the same
+//     tick so equip decisions see fresh inventory.
+//
 //  handleGoHome is locked at the tail because it closes the tick on a
 //  non-home page. handleGenericBattle is kept just before handleGoHome
 //  as a catch-all when the bot has landed on any battle page.
@@ -1527,10 +1567,10 @@ export const pipeline: HandlerConfig[] = [
   // effect in the pipeline model. The mythic girl is fully covered by
   // handleTrollBattle's activation paths.
   handleEventParsing,
+  handleHaremSize,
   handleSalary,
   handleShop,
   handleAutoEquipBoosters,
-  handleHaremSize,
   handleMissions,
   handlePachinko,
   handleSeasonalFreeCard,


### PR DESCRIPTION
Squash of the step-5 loop-module cluster from refactor/v7.36.0-staging.

Five modules reviewed (Quest, Contest, Daily Goals, Champion, Place of Power). Behaviour-affecting fixes:

- **Place of Power**: failed-navigation self-heal compared a Number index against the String round-tripped from storage, so the branch was dead code and a locked PoP looped forever on "Navigating to powerplaceN page". Coerced; the locked spot now lands on the unable-to-start list on the second attempt and the loop ends. Root-cause fix behind the access-forbidden retry storm.
- **Quest**: outfit-gated steps wrote a marker handleQuest had no branch for, looping on "Invalid quest requirement" every tick. Added an explicit outfit branch (disable auto-quest, reset marker, user-actionable log).
- **Contest**: multi-tier finishes reloaded the page after every claim. Dropped the reload; the scheduler collects the rest next tick.
- **Daily Goals**: parse() wiped its own cache on the missions/contests pages, so the pantheon daily-goal booster override never fired between daily-goals visits. Guarded with an early return that preserves the cache off-page.
- **Champion**: number-coercion on the auto-team config, dead-code removal.

Test hardening: new DailyGoals.spec.ts, expanded PlaceOfPower.spec.ts, new handleQuest outfit cases in Pipeline.config.spec.ts. 62 suites / 863 specs green, cycles 377 unchanged, bundle 1.46 MiB.

Bumps version to 7.35.58.

Refs #1598
Refs #1722