### PR TITLE
fix(troll): yield battle-result pages so raid girl shards update (#1740)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.35.59 - raid girl skin endless-fight fix
+
+#### Fixed
+
+- **An already-won raid girl no longer traps the bot in an endless troll fight.** After a raid girl reached 100 shards, the post-fight reward was not being read on the battle-result page, so the script never noticed she was finished and kept fighting the same raid troll. The reward popup is now parsed again before the next fight, so the raid selector clears as soon as the girl is complete.
 ### v7.35.58 - loop-module review (Quest, Contest, Daily Goals, Champion, Place of Power)
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.58
+// @version      7.35.59
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -20367,6 +20367,27 @@ const handlePlaceOfPower = {
             }),
         }],
 };
+/**
+ * Battle-result pages handled by handleGenericBattle (GenericBattle.doBattle).
+ * On these pages the post-fight reward popup must be parsed
+ * (RewardHelper.ObserveAndGetGirlRewards) so girl/raid shard progress is written
+ * back to storage. handleTrollBattle runs earlier in the pipeline and has no
+ * page guard, so it must explicitly yield these pages -- otherwise doBossBattle()
+ * navigates away ("Navigating to chosen Troll") before the reward is read, the
+ * raid girl's shard count never reaches 100, and getRaidToFight never clears the
+ * selector: an endless troll fight loop on an already-won raid girl (issue #1740).
+ */
+function isGenericBattleResultPage(currentPage) {
+    const battlePages = [
+        ConfigHelper.getHHScriptVars('pagesIDLeagueBattle'),
+        ConfigHelper.getHHScriptVars('pagesIDTrollBattle'),
+        ConfigHelper.getHHScriptVars('pagesIDSeasonBattle'),
+        ConfigHelper.getHHScriptVars('pagesIDPentaDrillBattle'),
+        ConfigHelper.getHHScriptVars('pagesIDPantheonBattle'),
+        ConfigHelper.getHHScriptVars('pagesIDLabyrinthBattle'),
+    ];
+    return battlePages.includes(currentPage);
+}
 const handleGenericBattle = {
     name: 'handleGenericBattle',
     minIntervalMs: 2000,
@@ -20379,15 +20400,7 @@ const handleGenericBattle = {
             return false;
         if (getStoredValue(HHStoredVarPrefixKey + TK.autoLoop) !== 'true')
             return false;
-        const battlePages = [
-            ConfigHelper.getHHScriptVars('pagesIDLeagueBattle'),
-            ConfigHelper.getHHScriptVars('pagesIDTrollBattle'),
-            ConfigHelper.getHHScriptVars('pagesIDSeasonBattle'),
-            ConfigHelper.getHHScriptVars('pagesIDPentaDrillBattle'),
-            ConfigHelper.getHHScriptVars('pagesIDPantheonBattle'),
-            ConfigHelper.getHHScriptVars('pagesIDLabyrinthBattle'),
-        ];
-        return battlePages.includes(ctx.currentPage);
+        return isGenericBattleResultPage(ctx.currentPage);
     },
     steps: [{
             name: 'doBattle',
@@ -20425,6 +20438,10 @@ const handleTrollBattle = {
         if (getStoredValue(HHStoredVarPrefixKey + TK.autoLoop) !== 'true')
             return false;
         if (!ctx.canCollectCompetitionActive)
+            return false;
+        // Yield battle-result pages to handleGenericBattle so the post-fight reward
+        // popup is parsed and raid girl shards are written back (issue #1740).
+        if (isGenericBattleResultPage(ctx.currentPage))
             return false;
         if (ctx.lastActionPerformed !== 'none' && ctx.lastActionPerformed !== 'troll' && ctx.lastActionPerformed !== 'quest')
             return false;
@@ -28213,7 +28230,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.58";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.59";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.58",
+  "version": "7.35.59",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/Pipeline.config.spec.ts
+++ b/spec/Service/Pipeline.config.spec.ts
@@ -740,4 +740,68 @@ describe('Pipeline.config', () => {
       jest.restoreAllMocks();
     });
   });
+
+  describe('battle-result page guard (issue #1740)', () => {
+    // Regression for issue #1740: v7.35.57 reordered the pipeline so
+    // handleGenericBattle (which parses the post-fight reward popup and writes
+    // raid girl shards back to storage) runs AFTER handleTrollBattle. Because
+    // handleTrollBattle had no page guard, on the troll-battle result page it
+    // won the tick and navigated away before the reward was read. The raid
+    // girl's shard count never reached 100, so getRaidToFight never cleared the
+    // selector and the bot fought the same raid troll forever. The fix gives
+    // handleTrollBattle the same battle-result-page guard handleGenericBattle
+    // already has, so it yields those pages.
+    const trollHandler = pipeline.find(h => h.name === 'handleTrollBattle')!;
+    const genericHandler = pipeline.find(h => h.name === 'handleGenericBattle')!;
+    const TrollMock = jest.requireMock('../../src/Module/Troll').Troll as Record<string, jest.Mock>;
+    const ConfigHelperMock = jest.requireMock('../../src/Helper/ConfigHelper').ConfigHelper as { getHHScriptVars: jest.Mock };
+    const originalGetHHScriptVars = ConfigHelperMock.getHHScriptVars.getMockImplementation();
+
+    beforeEach(() => {
+      getStoredValueMock.mockReset();
+      getStoredValueMock.mockImplementation((key: string) => key.endsWith('Temp_autoLoop') ? 'true' : undefined);
+      // Make page-ID lookups echo the key so currentPage can match exactly.
+      ConfigHelperMock.getHHScriptVars.mockImplementation((key: string) => key);
+      TrollMock.isTrollFightActivated = jest.fn().mockReturnValue(true);
+    });
+
+    afterEach(() => {
+      getStoredValueMock.mockReset();
+      ConfigHelperMock.getHHScriptVars.mockImplementation(originalGetHHScriptVars ?? (() => true));
+    });
+
+    it('handleTrollBattle runs before handleGenericBattle in the pipeline', () => {
+      const idxTroll = pipeline.findIndex(h => h.name === 'handleTrollBattle');
+      const idxGeneric = pipeline.findIndex(h => h.name === 'handleGenericBattle');
+      expect(idxTroll).toBeGreaterThanOrEqual(0);
+      expect(idxGeneric).toBeGreaterThan(idxTroll);
+    });
+
+    it('handleTrollBattle precondition returns false on the troll-battle result page', () => {
+      const ctx = makeCtx({ canCollectCompetitionActive: true, currentPage: 'pagesIDTrollBattle' });
+      expect(trollHandler.precondition(ctx)).toBe(false);
+    });
+
+    it('handleGenericBattle precondition returns true on the troll-battle result page', () => {
+      const ctx = makeCtx({ canCollectCompetitionActive: true, currentPage: 'pagesIDTrollBattle' });
+      expect(genericHandler.precondition(ctx)).toBe(true);
+    });
+
+    it('handleTrollBattle precondition still passes on a non-battle page (e.g. pre-battle)', () => {
+      const ctx = makeCtx({ canCollectCompetitionActive: true, currentPage: 'troll-pre-battle.html' });
+      expect(trollHandler.precondition(ctx)).toBe(true);
+    });
+
+    it.each([
+      'pagesIDLeagueBattle',
+      'pagesIDTrollBattle',
+      'pagesIDSeasonBattle',
+      'pagesIDPentaDrillBattle',
+      'pagesIDPantheonBattle',
+      'pagesIDLabyrinthBattle',
+    ])('handleTrollBattle yields battle-result page %s', (page) => {
+      const ctx = makeCtx({ canCollectCompetitionActive: true, currentPage: page });
+      expect(trollHandler.precondition(ctx)).toBe(false);
+    });
+  });
 });

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.58";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.59";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/Pipeline.config.ts
+++ b/src/Service/Pipeline.config.ts
@@ -679,6 +679,28 @@ const handlePlaceOfPower: HandlerConfig = {
   }],
 };
 
+/**
+ * Battle-result pages handled by handleGenericBattle (GenericBattle.doBattle).
+ * On these pages the post-fight reward popup must be parsed
+ * (RewardHelper.ObserveAndGetGirlRewards) so girl/raid shard progress is written
+ * back to storage. handleTrollBattle runs earlier in the pipeline and has no
+ * page guard, so it must explicitly yield these pages -- otherwise doBossBattle()
+ * navigates away ("Navigating to chosen Troll") before the reward is read, the
+ * raid girl's shard count never reaches 100, and getRaidToFight never clears the
+ * selector: an endless troll fight loop on an already-won raid girl (issue #1740).
+ */
+function isGenericBattleResultPage(currentPage: string): boolean {
+  const battlePages = [
+    ConfigHelper.getHHScriptVars('pagesIDLeagueBattle'),
+    ConfigHelper.getHHScriptVars('pagesIDTrollBattle'),
+    ConfigHelper.getHHScriptVars('pagesIDSeasonBattle'),
+    ConfigHelper.getHHScriptVars('pagesIDPentaDrillBattle'),
+    ConfigHelper.getHHScriptVars('pagesIDPantheonBattle'),
+    ConfigHelper.getHHScriptVars('pagesIDLabyrinthBattle'),
+  ];
+  return battlePages.includes(currentPage);
+}
+
 const handleGenericBattle: HandlerConfig = {
   name: 'handleGenericBattle',
   minIntervalMs: 2_000,
@@ -688,15 +710,7 @@ const handleGenericBattle: HandlerConfig = {
     if (ctx.busy) return false;
     if (!ctx.canCollectCompetitionActive) return false;
     if (getStoredValue(HHStoredVarPrefixKey + TK.autoLoop) !== 'true') return false;
-    const battlePages = [
-      ConfigHelper.getHHScriptVars('pagesIDLeagueBattle'),
-      ConfigHelper.getHHScriptVars('pagesIDTrollBattle'),
-      ConfigHelper.getHHScriptVars('pagesIDSeasonBattle'),
-      ConfigHelper.getHHScriptVars('pagesIDPentaDrillBattle'),
-      ConfigHelper.getHHScriptVars('pagesIDPantheonBattle'),
-      ConfigHelper.getHHScriptVars('pagesIDLabyrinthBattle'),
-    ];
-    return battlePages.includes(ctx.currentPage);
+    return isGenericBattleResultPage(ctx.currentPage);
   },
   steps: [{
     name: 'doBattle',
@@ -731,6 +745,9 @@ const handleTrollBattle: HandlerConfig = {
     if (!Troll.isTrollFightActivated()) return false;
     if (getStoredValue(HHStoredVarPrefixKey + TK.autoLoop) !== 'true') return false;
     if (!ctx.canCollectCompetitionActive) return false;
+    // Yield battle-result pages to handleGenericBattle so the post-fight reward
+    // popup is parsed and raid girl shards are written back (issue #1740).
+    if (isGenericBattleResultPage(ctx.currentPage)) return false;
     if (ctx.lastActionPerformed !== 'none' && ctx.lastActionPerformed !== 'troll' && ctx.lastActionPerformed !== 'quest') return false;
     return true;
   },


### PR DESCRIPTION
## Summary

Fixes the endless raid-troll fight loop reported in #1740. With +Girl Skins OFF, the bot kept fighting a raid troll for a girl that was already at 100 shards instead of stopping.

## Root cause

`handleTrollBattle` had no page guard. On a battle-result page (e.g. `troll-battle`) it ran before `handleGenericBattle` and called `doBossBattle()`, which navigates straight back to the troll ("Navigating to chosen Troll") before the reward popup is parsed. The reward popup is what writes the updated raid girl shard count back to storage (`RewardHelper.ObserveAndGetGirlRewards` -> `LoveRaidManager.saveLoveRaids`). Because that never ran, `girl_shards` stayed below 100, `getRaidToFight` never cleared the raid selector, and the bot looped on the same troll.

The reporter's log shows ~16 cycles of `pre-battle -> troll-battle -> pre-battle` with no reward/shard processing in between.

## Fix

Extract the battle-result-page list `handleGenericBattle` already uses into a shared `isGenericBattleResultPage()` helper, and add the same guard to `handleTrollBattle` so it yields those pages to `handleGenericBattle`. The reward is then parsed, the shard count updates, and the selector clears once the girl hits 100.

Pipeline handler order is unchanged.

## Tests

- New regression block `battle-result page guard (issue #1740)` in `spec/Service/Pipeline.config.spec.ts` (ordering + page guard across all six battle-result pages).
- Full suite green: 873 tests, 62 suites.
- `npm run build` succeeds; `HHAuto.user.js` rebuilt at v7.35.59.

## Version bump

package.json -> 7.35.59, FEATURE_POPUP_TITLE, CHANGELOG entry, rebuilt userscript included.

Refs #1740