### PR TITLE
fix: make team builder blessing-aware via candidate matrix

### DIFF
--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.59
+// @version      7.35.60
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -12660,6 +12660,32 @@ class BlessingService {
         return result;
     }
     /**
+     * Resolve a girl's value for a blessing trait kind, accepting both
+     * raw API girls (snake_case: eye_color1, hair_color1, position_img)
+     * and GirlData (camelCase: eyeColor, hairColor, position). Single
+     * source of truth shared by detectActiveBlessings and the team
+     * builder's blessing matcher, so a future game field rename is a
+     * one-place change (see lesson mapping-fix-vollstaendig-pruefen).
+     * position is normalised (the '.png' suffix is stripped).
+     */
+    static resolveTraitField(g, kind) {
+        var _a, _b, _c;
+        switch (kind) {
+            case 'eyeColor': return (_a = g.eye_color1) !== null && _a !== void 0 ? _a : g.eyeColor;
+            case 'hairColor': return (_b = g.hair_color1) !== null && _b !== void 0 ? _b : g.hairColor;
+            case 'zodiac': return g.zodiac;
+            case 'position': {
+                const raw = (_c = g.position_img) !== null && _c !== void 0 ? _c : g.position;
+                if (raw === undefined || raw === null)
+                    return undefined;
+                return String(raw).replace(/\.png$/i, '');
+            }
+            case 'element': return g.element;
+            case 'rarity': return g.rarity;
+            default: return undefined;
+        }
+    }
+    /**
      * Detect active blessings DIRECTLY from the girls in the pool, without
      * relying on String-Parsing of the API description (which is locale-
      * dependent: 'eye color' / 'couleur des yeux' / 'augenfarbe' ...).
@@ -12718,23 +12744,7 @@ class BlessingService {
         const candidates = [];
         // Read a girl's value for a given trait kind, accepting both
         // snake_case (raw API) and camelCase (GirlData) forms.
-        const fieldOf = (g, kind) => {
-            var _a, _b, _c;
-            switch (kind) {
-                case 'eyeColor': return (_a = g.eye_color1) !== null && _a !== void 0 ? _a : g.eyeColor;
-                case 'hairColor': return (_b = g.hair_color1) !== null && _b !== void 0 ? _b : g.hairColor;
-                case 'zodiac': return g.zodiac;
-                case 'position': {
-                    // Raw position_img is '5.png', GirlData.position is '5'.
-                    const raw = (_c = g.position_img) !== null && _c !== void 0 ? _c : g.position;
-                    if (raw === undefined || raw === null)
-                        return undefined;
-                    return String(raw).replace(/\.png$/i, '');
-                }
-                case 'element': return g.element;
-                case 'rarity': return g.rarity;
-            }
-        };
+        const fieldOf = (g, kind) => BlessingService.resolveTraitField(g, kind);
         const kinds = ['eyeColor', 'hairColor', 'zodiac', 'position', 'element', 'rarity'];
         // For every (percent, kind), find the field+value that uniquely
         // identifies girls receiving that blessing percent. We need both:
@@ -17100,7 +17110,12 @@ class TeamScoringService {
      */
     static scoreBestPossible(girl, _playerClass) {
         const current = TeamScoringService.caracsSum(girl);
-        const level = girl.level || 1;
+        // Clamp the level into [1, PROJECTION_LEVEL_CAP]. 750 is the hard
+        // girl cap (a girl can be developed to 750 regardless of player
+        // level), so level > 750 should not occur; the guard is pure
+        // game-drift defence -- without it a drifted level > 750 would
+        // make the factor < 1 and wrongly devalue a fully-developed girl.
+        const level = Math.min(Math.max(girl.level || 1, 1), PROJECTION_LEVEL_CAP);
         const currentGrades = girl.graded || 0;
         const maxGrades = girl.nb_grades || 0;
         return current
@@ -17204,6 +17219,11 @@ class TeamScoringService {
 
 const TEAM_SIZE = 7;
 const POS_2_TO_7 = 6;
+// Two candidate teams within this relative stat-sum margin are treated
+// as a near-tie; the higher Tier-5 leader skill (Shield > Stun > Execute
+// > Reflect) then decides. Keeps a Shield leader from being traded away
+// for a marginal stat gain the sum-only metric cannot otherwise see.
+const LEADER_TIEBREAK_MARGIN = 0.02;
 // Element pairs that share a Tier-3 category.
 const ELEMENT_PAIRS_BY_CATEGORY = {
     eyeColor: ['darkness', 'fire'],
@@ -17235,44 +17255,52 @@ class TeamBuilderService {
         const summaries = blessings.map(b => ({
             kind: b.kind, value: b.value, percent: b.percent, pool_size: b.pool_size,
         }));
-        // Build up to three candidates in parallel.
+        // ---- Candidate matrix --------------------------------------
+        //
+        // For each pool (bless1, bless2, full eligible) we build a SET of
+        // candidate teams: one clustered candidate per trait category that
+        // forms a >= TEAM_SIZE element-pair group, plus one flat candidate
+        // (no cluster constraint). Every candidate is a fully-formed 7-girl
+        // team. The strongest by mode-aware stat-sum wins; on a near-tie
+        // (<= LEADER_TIEBREAK_MARGIN) the higher Tier-5 leader skill wins,
+        // so a Shield leader is never silently traded away for a marginal
+        // stat gain. Spreading the cluster axis into explicit candidates
+        // means the builder never has to guess whether to cluster on the
+        // blessed axis -- it simply tries them all and compares.
         const candidates = [];
         const bless1 = blessings[0];
         const bless2 = blessings[1];
+        const addCandidatesForPool = (pool, label) => {
+            if (pool.length < TEAM_SIZE)
+                return;
+            // One clustered candidate per enumerable trait cluster.
+            for (const cluster of TeamBuilderService.enumerateClusters(pool)) {
+                const built = TeamBuilderService.buildWithCluster(pool, eligible, scoreMap, cluster);
+                if (built)
+                    candidates.push(Object.assign(Object.assign({}, built), { poolUsed: label }));
+            }
+            // One flat candidate (no cluster constraint).
+            const flat = TeamBuilderService.buildFlat(pool, eligible, scoreMap);
+            if (flat) {
+                const flatLabel = (label === 'default' ? 'default-flat' : (label + '-flat'));
+                candidates.push(Object.assign(Object.assign({}, flat), { poolUsed: flatLabel }));
+            }
+        };
         if (bless1) {
-            const pool = eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless1));
-            const built = TeamBuilderService.buildFromPool(pool, eligible, scoreMap);
-            if (built)
-                candidates.push(Object.assign(Object.assign({}, built), { poolUsed: 'bless1' }));
+            addCandidatesForPool(eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless1)), 'bless1');
         }
         if (bless2) {
-            const pool = eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless2));
-            const built = TeamBuilderService.buildFromPool(pool, eligible, scoreMap);
-            if (built)
-                candidates.push(Object.assign(Object.assign({}, built), { poolUsed: 'bless2' }));
+            addCandidatesForPool(eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless2)), 'bless2');
         }
-        // Default team: full eligible pool, no Bless filter, cluster from
-        // the trait hierarchy.
-        {
-            const built = TeamBuilderService.buildFromPool(eligible, eligible, scoreMap);
-            if (built)
-                candidates.push(Object.assign(Object.assign({}, built), { poolUsed: 'default' }));
-        }
-        // Score each candidate and pick the best by mode-aware sum.
+        addCandidatesForPool(eligible, 'default');
+        // Score each candidate by mode-aware sum across all 7 picks.
         for (const c of candidates) {
             c.score = c.team.reduce((s, g) => { var _a; return s + ((_a = scoreMap.get(g.id_girl)) !== null && _a !== void 0 ? _a : TeamScoringService.caracsSum(g)); }, 0);
         }
         if (candidates.length === 0) {
             return TeamBuilderService.buildFallback(eligible, scoreMap, playerClass, 'No candidate pool produced 7 girls; fell back to caracs_sum picks.');
         }
-        // Tiebreak: bless1 > bless2 > default. Stable sort already preserves
-        // this since we appended in that order. We just take the highest score.
-        // For ties, keep the first occurrence (already in priority order).
-        let best = candidates[0];
-        for (let i = 1; i < candidates.length; i++) {
-            if (candidates[i].score > best.score)
-                best = candidates[i];
-        }
+        const best = TeamBuilderService.selectBestCandidate(candidates);
         return TeamBuilderService.buildResult(best.team, scoreMap, eligible, playerClass, best.cluster, summaries, best.poolUsed);
     }
     // ---- Bless classification ------------------------------------------
@@ -17284,52 +17312,25 @@ class TeamBuilderService {
      * than 1 (so she is actually blessed by something).
      */
     static matchesBlessing(girl, bless) {
-        var _a;
         if (BlessingService.getEffectiveMultiplier(girl) <= 1)
             return false;
-        const raw = girl;
-        const valueOf = (kind) => {
-            var _a, _b, _c;
-            switch (kind) {
-                case 'eyeColor': return (_a = raw.eyeColor) !== null && _a !== void 0 ? _a : raw.eye_color1;
-                case 'hairColor': return (_b = raw.hairColor) !== null && _b !== void 0 ? _b : raw.hair_color1;
-                case 'zodiac': return raw.zodiac;
-                case 'position': {
-                    const v = (_c = raw.position) !== null && _c !== void 0 ? _c : raw.position_img;
-                    if (v === undefined || v === null)
-                        return undefined;
-                    return String(v).replace(/\.png$/i, '');
-                }
-                case 'element': return raw.element;
-                case 'rarity': return raw.rarity;
-                default: return undefined;
-            }
-        };
-        return String((_a = valueOf(bless.kind)) !== null && _a !== void 0 ? _a : '') === bless.value;
+        // Field resolution is shared with BlessingService.detectActiveBlessings
+        // via resolveTraitField (single source of truth, lesson mapping-fix).
+        const value = BlessingService.resolveTraitField(girl, bless.kind);
+        return String(value !== null && value !== void 0 ? value : '') === bless.value;
     }
-    // ---- One pool -> one team ------------------------------------------
+    // ---- One pool + one cluster -> one team ----------------------------
     /**
-     * Build a single team from one pool (Spec step 2). Sequence:
-     *   A. Choose cluster from the trait hierarchy.
-     *   B. Pick leader from the FULL eligible pool (the leader does
-     *      not have to satisfy the bless filter, it just has to fit
-     *      the chosen cluster -- a strong Mythic Shield from outside
-     *      the bless pool wins over a weaker bless-pool mythic).
-     *   C. Fill positions 2..7 from the local pool, minus the leader.
-     * Returns null if the pool cannot fill 7 slots.
+     * Build a clustered candidate from a pool and a GIVEN cluster.
+     *   A. Leader from the FULL eligible pool via Leaderauswahl-Regel
+     *      against this cluster (a strong Mythic Shield from outside the
+     *      bless pool can lead -- spec rule).
+     *   B. Fill positions 2..7 from the pool, cluster-constrained.
+     * Returns null if the pool cannot fill 7 slots for this cluster.
      */
-    static buildFromPool(pool, eligibleAll, scoreMap) {
+    static buildWithCluster(pool, eligibleAll, scoreMap, cluster) {
         if (pool.length < TEAM_SIZE)
             return null;
-        const cluster = TeamBuilderService.chooseTeamCluster(pool);
-        if (!cluster)
-            return null;
-        // Leader-Kandidaten = gesamter eligible Pool. Die 7-key sort
-        // (Mythic > Tier-5 > Element-Pair > Trait-Match > blessed >
-        // caracs_sum > Element-Coeff) bevorzugt automatisch eine
-        // Mythic Shield mit Trait-Match, faellt zu Mythic Shield ohne
-        // Trait-Match wenn keine vorhanden, und erst dann zu Mythic
-        // Stun/Execute/Reflect.
         const leader = TeamBuilderService.pickLeader(eligibleAll, cluster, scoreMap);
         if (!leader)
             return null;
@@ -17339,13 +17340,163 @@ class TeamBuilderService {
             return null;
         return { team: [leader, ...positions], cluster, score: 0 };
     }
+    // ---- Flat candidate (no cluster constraint) ------------------------
+    /**
+     * Build a flat candidate: a rule-leader plus the strongest remaining
+     * TEAM_SIZE-1 girls from `pool`, with NO cluster constraint. This is
+     * NOT guaranteed to be the absolute stat-sum maximum of the pool --
+     * the leader is chosen by the Leaderauswahl-Regel (Tier-5 / blessed
+     * before raw score), so a slightly lower-score leader can be fixed by
+     * design. Its purpose is to keep a fully-blessed, no-cluster-constraint
+     * team in the comparison so the blessing multiplier is never dropped
+     * on filler slots by over-constraining on a cluster.
+     *
+     * Leader is picked from the FULL eligible pool with a CLUSTER-NEUTRAL
+     * sentinel: an empty element set and an impossible trait value, so
+     * Leaderauswahl-Regel keys 3 (element-pair match) and 4 (trait match)
+     * never fire. The leader is therefore decided by keys 1 (Mythic),
+     * 2 (Tier-5 Shield priority), 5 (blessed before unblessed), 6
+     * (caracs_sum), 7 (element coeff). That makes the strongest blessed
+     * Mythic Shield lead when one exists (-> fully blessed team), and the
+     * strongest Mythic Shield overall otherwise. The display cluster is
+     * derived from the FINAL fielded team (not a pre-pick top-7), so the
+     * reported traitCategory/value actually describes the team.
+     * Returns null if the pool cannot fill 7 slots.
+     */
+    static buildFlat(pool, eligibleAll, scoreMap) {
+        var _a;
+        if (pool.length < TEAM_SIZE)
+            return null;
+        const scoreOf = (g) => { var _a; return (_a = scoreMap.get(g.id_girl)) !== null && _a !== void 0 ? _a : TeamScoringService.caracsSum(g); };
+        // Cluster-neutral sentinel: keys 3+4 of the leader rule cannot match.
+        const NEUTRAL_CLUSTER = {
+            category: 'eyeColor',
+            value: '\u0000__none__',
+            elements: [],
+        };
+        // Leader from the full eligible pool (spec rule: a strong Mythic
+        // Shield can lead even from outside the pool). Cluster-neutral, so
+        // blessed-vs-unblessed (key 5) breaks Shield-vs-Shield ties in
+        // favour of the blessed Shield.
+        const leader = TeamBuilderService.pickLeader(eligibleAll, NEUTRAL_CLUSTER, scoreMap);
+        if (!leader)
+            return null;
+        // Pos 2..7 = strongest pool girls by score, leader excluded.
+        const positions = [...pool]
+            .filter(g => g.id_girl !== leader.id_girl)
+            .sort((a, b) => {
+            const sa = scoreOf(a);
+            const sb = scoreOf(b);
+            if (sb !== sa)
+                return sb - sa;
+            return TeamScoringService.getElementPowerCoeff(b.element)
+                - TeamScoringService.getElementPowerCoeff(a.element);
+        })
+            .slice(0, POS_2_TO_7);
+        if (positions.length < POS_2_TO_7)
+            return null;
+        const team = [leader, ...positions];
+        // Display cluster derived from the FINAL team (dominant element pair).
+        const cluster = (_a = TeamBuilderService.chooseTeamCluster(team)) !== null && _a !== void 0 ? _a : NEUTRAL_CLUSTER;
+        return { team, cluster, score: 0 };
+    }
+    // ---- Cluster enumeration + choice ----------------------------------
+    /**
+     * Enumerate candidate clusters for a pool: one per trait category whose
+     * element-pair holds at least TEAM_SIZE girls, with the largest trait
+     * sub-group as the cluster value. This replaces the single hierarchy
+     * pick with an explicit set so the builder can try every meaningful
+     * cluster axis and compare the resulting teams. Always includes the
+     * hierarchy fallback (chooseTeamCluster) so a pool with no >= 7 pair
+     * still yields one cluster.
+     */
+    static enumerateClusters(pool) {
+        const clusters = [];
+        const seen = new Set();
+        const push = (c) => {
+            if (!c)
+                return;
+            const key = c.category + '=' + c.value;
+            if (seen.has(key))
+                return;
+            seen.add(key);
+            clusters.push(c);
+        };
+        for (const category of TRAIT_HIERARCHY) {
+            const pair = ELEMENT_PAIRS_BY_CATEGORY[category];
+            const subset = pool.filter(g => pair.includes(g.element));
+            if (subset.length < TEAM_SIZE)
+                continue;
+            const buckets = new Map();
+            for (const g of subset) {
+                const v = TeamScoringService.getTraitValue(g);
+                if (!v)
+                    continue;
+                buckets.set(v, (buckets.get(v) || 0) + 1);
+            }
+            if (buckets.size === 0)
+                continue;
+            const [topVal, topCount] = [...buckets.entries()].sort((a, b) => b[1] - a[1])[0];
+            // The cluster value must itself be fillable: at least one full
+            // sub-group is not required (Pos 2-7 falls back across the
+            // element pair), but a topVal sub-group below a useful size
+            // would key Tier-3 on a near-empty trait. Keep clusters whose
+            // dominant trait has more than one carrier; degenerate
+            // single-carrier clusters are skipped (the flat candidate and
+            // other axes still cover the pool).
+            if (topCount < 2)
+                continue;
+            push({ category, value: topVal, elements: pair });
+        }
+        // Guarantee at least one cluster (hierarchy fallback).
+        if (clusters.length === 0)
+            push(TeamBuilderService.chooseTeamCluster(pool));
+        return clusters;
+    }
+    /**
+     * Pick the winning candidate with a TRANSITIVE, order-independent
+     * rule (two passes):
+     *   1. Find the global maximum mode-aware stat-sum.
+     *   2. Among all candidates within LEADER_TIEBREAK_MARGIN of that
+     *      global max, take the one with the highest Tier-5 leader skill
+     *      (Shield > Stun > Execute > Reflect); break further ties by
+     *      higher score, then by append order (candidate priority).
+     *
+     * Anchoring the near-tie window on the GLOBAL max (not a drifting
+     * running best) guarantees the winner is always within the margin of
+     * the strongest team -- the pairwise running-best variant was
+     * non-transitive and could drift several margins below the max.
+     */
+    static selectBestCandidate(candidates) {
+        // buildTeam guards candidates.length === 0 before calling this;
+        // the guard here keeps the method total in isolation.
+        if (candidates.length === 0) {
+            throw new Error('selectBestCandidate called with no candidates');
+        }
+        const tier5 = (c) => TeamScoringService.getTier5Skill(c.team[0].element).priority;
+        const maxScore = candidates.reduce((m, c) => Math.max(m, c.score), -Infinity);
+        const denom = Math.abs(maxScore) || 1;
+        const contenders = candidates.filter(c => (maxScore - c.score) / denom <= LEADER_TIEBREAK_MARGIN);
+        let best = contenders[0];
+        for (let i = 1; i < contenders.length; i++) {
+            const c = contenders[i];
+            const t5c = tier5(c);
+            const t5b = tier5(best);
+            if (t5c > t5b)
+                best = c;
+            else if (t5c === t5b && c.score > best.score)
+                best = c;
+        }
+        return best;
+    }
     // ---- Cluster choice ------------------------------------------------
     /**
-     * Walk the trait hierarchy eyes -> hair -> zodiac -> position. The
-     * first hierarchy step that yields any sub-group inside the matching
-     * element-pair wins. Within the step, the largest sub-group is the
-     * primary cluster value. Falls through to the dominant element with
-     * Element-Coeff tiebreak when no trait category resolves.
+     * Single-cluster pick: walk the trait hierarchy eyes -> hair -> zodiac
+     * -> position, first non-empty element-pair sub-group wins (largest
+     * sub-group = cluster value). Falls through to the dominant element
+     * with Element-Coeff tiebreak when no trait category resolves. Used as
+     * the display-cluster deriver (buildFlat) and the no->=7-pair fallback
+     * (enumerateClusters).
      */
     static chooseTeamCluster(pool) {
         var _a, _b, _c;
@@ -17372,6 +17523,11 @@ class TeamBuilderService {
             const [topVal, topGirls] = sorted[0];
             return { category, value: topVal, girls: topGirls };
         };
+        // Hierarchy fallback: first trait category with a non-empty
+        // sub-group wins. Only used by buildFlat's display-cluster
+        // derivation and as the >=7-pair-less fallback in
+        // enumerateClusters; the main candidate set comes from
+        // enumerateClusters, which tries every >= 7 trait axis explicitly.
         for (const category of TRAIT_HIERARCHY) {
             const dominant = dominantBucketFor(category);
             if (dominant && dominant.girls.length >= 1) {
@@ -17997,13 +18153,6 @@ class TeamModule {
                 }
             });
         }
-        // else if (getPage().match(/^\/characters\/\d+$/)) {
-        // TODO unequip from harem page
-        //     logHHAuto('Unequip from harem page');
-        //     if ($('#unequip_all').length > 0) {
-        //         $('#unequip_all').trigger('click');
-        //     }
-        // }
     }
     static manageSkillScrollTooltip() {
         $('.hhScrollTooltip').remove();
@@ -18015,12 +18164,6 @@ class TeamModule {
         }, 100);
     }
     static createSkillScrollTooltip(teamGirls = null, displayTooltip = true) {
-        // if (!teamGirls || teamGirls.length != 7) {
-        //     teamGirls = TeamModule.getSelectedGirls();
-        //     if (teamGirls.length != 7) {
-        //         return;
-        //     }
-        // }
         const teamGirlWithoutMain = teamGirls.slice(1);
         const heroCurrencies = getHero().currencies;
         let scrollTooltipDetail = '';
@@ -18066,10 +18209,6 @@ class TeamModule {
             $('.team-right-part-container').append(scrollTooltip);
         return team;
     }
-    static stuffAllGirls() {
-        if (getPage() === ConfigHelper.getHHScriptVars("pagesIDBattleTeams")) {
-        }
-    }
     static buildStuffTeamSelectPopUp() {
         const teamGirls = TeamModule.getSelectedGirls();
         if (teamGirls.length == 0) {
@@ -18085,7 +18224,7 @@ class TeamModule {
             <div ${!showToggle ? '' : 'style="display:none;"'}>${getTextForUI("enoughBulbsOwned", "elementText")}</div>
             <span>Needed: ${team['scrolls_' + rarity.toLowerCase()]}/Owned: ${heroCurrencies['scrolls_' + rarity.toLowerCase()]} <span><br/>`;
         };
-        const estimatedCost = 5 * (team.scrolls_mythic || 0 + team.scrolls_legendary || 0 + team.scrolls_epic || 0 + team.scrolls_rare || 0 + team.scrolls_common || 0);
+        const estimatedCost = 5 * ((team.scrolls_mythic || 0) + (team.scrolls_legendary || 0) + (team.scrolls_epic || 0) + (team.scrolls_rare || 0) + (team.scrolls_common || 0));
         let stuffTeamMenu = `<div style="padding:5px; display:flex;flex-direction:column;font-size:15px; max-width:550px" class="HHAutoScriptMenu">
             <div class="rowLine">
                 <p>${getTextForUI("StuffTeam", "tooltip")}</p>
@@ -18163,15 +18302,6 @@ class TeamModule {
             }
         });
     }
-    // static getSkillNeededScrollsOneGirl(girl: KKTeamGirl): number {
-    //     const rarity = girl.girl.rarity;
-    //     const nbGrades = girl.girl.nb_grades;
-    //     const skills: any[] = Object.values(girl.skill_tiers_info);
-    //     const usedScrolls = Number(skills.reduce((accumulator, skill) => accumulator + (skill.skill_points_used || 0), 0));
-    //     const fullNeededScrolls = HaremGirl.SCROLLS_NEED_5[rarity + '_' + nbGrades];
-    //     logHHAuto(`Total skill points used by ${girl.girl.name}: ${usedScrolls}/${fullNeededScrolls}`);
-    //     return fullNeededScrolls - usedScrolls;
-    // }
     static getSkillNeededScrolls(mainGirl, teamGirls, rarity, nbGrades) {
         const girls = teamGirls.filter(girl => girl.girl && girl.girl.rarity === rarity && girl.girl.nb_grades == nbGrades);
         if (girls.length > 0)
@@ -18250,7 +18380,7 @@ class TeamModule {
         const selectedTeam = $('.team-slot-container.selected-team').attr('data-team-index');
         if (isNaN(Number(selectedTeam))) {
             LogUtils_logHHAuto('Error: can\'t get selected team index, cancel action');
-            return;
+            return [];
         }
         const girlIds = [...unsafeWindow.teams_data[selectedTeam].girls_ids];
         if (girlIds.length != 7) {
@@ -18318,21 +18448,33 @@ class TeamModule {
             TeamModule.setTopTeamLegacy(sumFormulaType);
         }
     }
+    /**
+     * Map one raw availableGirls entry (game DOM/window data) onto the
+     * GirlData interface the team builder consumes. Extracted from
+     * setTopTeamV2 so the mapping is unit-testable in isolation (the rest
+     * of setTopTeamV2 is DOM/UI). Pure: no side effects, no DOM access.
+     *
+     * can_be_blessed / can_be_blessed_pvp4 are passed through as untyped
+     * bonus properties so BlessingService.detectActiveBlessings has an
+     * authoritative blessed-or-not flag (issue 1679 phase 2); the static
+     * type stays GirlData.
+     */
+    static mapAvailableGirl(g) {
+        var _a;
+        return (Object.assign(Object.assign({ id_girl: Number(g.id_girl), name: g.name || '', carac1: Number(g.carac1 || 0), carac2: Number(g.carac2 || 0), carac3: Number(g.carac3 || 0), level: Number(g.level || 1), class: typeof g.class === 'number' ? g.class : undefined, element: (((_a = g.element_data) === null || _a === void 0 ? void 0 : _a.type) || g.element || 'fire'), rarity: (g.rarity || 'common'), graded: Number(g.graded || 0), nb_grades: Number(g.nb_grades || 0), caracs: g.caracs ? {
+                carac1: Number(g.caracs.carac1 || 0),
+                carac2: Number(g.caracs.carac2 || 0),
+                carac3: Number(g.caracs.carac3 || 0),
+            } : undefined, skill_tiers_info: g.skill_tiers_info, 
+            // Keep raw zodiac glyph; TraitMappings.resolveZodiac strips it for display
+            zodiac: g.zodiac || undefined, hairColor: g.hair_color1 || undefined, eyeColor: g.eye_color1 || undefined, position: g.position_img ? String(g.position_img).replace('.png', '') : undefined, blessingBonuses: g.blessing_bonuses || undefined }, (typeof g.can_be_blessed === 'boolean' ? { can_be_blessed: g.can_be_blessed } : {})), (typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_pvp4: g.can_be_blessed_pvp4 } : {})));
+    }
     static setTopTeamV2(mode, availableGirls) {
         const playerLevel = Number(HeroHelper.getLevel());
         const rawClass = Number(HeroHelper.getClass());
         const playerClass = (rawClass === 1 || rawClass === 2 || rawClass === 3) ? rawClass : 1;
-        // Map availableGirls to GirlData interface
-        const girls = availableGirls.map(g => {
-            var _a;
-            return (Object.assign(Object.assign({ id_girl: Number(g.id_girl), name: g.name || '', carac1: Number(g.carac1 || 0), carac2: Number(g.carac2 || 0), carac3: Number(g.carac3 || 0), level: Number(g.level || 1), class: typeof g.class === 'number' ? g.class : undefined, element: (((_a = g.element_data) === null || _a === void 0 ? void 0 : _a.type) || g.element || 'fire'), rarity: (g.rarity || 'common'), graded: Number(g.graded || 0), nb_grades: Number(g.nb_grades || 0), caracs: g.caracs ? {
-                    carac1: Number(g.caracs.carac1 || 0),
-                    carac2: Number(g.caracs.carac2 || 0),
-                    carac3: Number(g.caracs.carac3 || 0),
-                } : undefined, skill_tiers_info: g.skill_tiers_info, 
-                // Keep raw zodiac glyph; TraitMappings.resolveZodiac strips it for display
-                zodiac: g.zodiac || undefined, hairColor: g.hair_color1 || undefined, eyeColor: g.eye_color1 || undefined, position: g.position_img ? String(g.position_img).replace('.png', '') : undefined, blessingBonuses: g.blessing_bonuses || undefined }, (typeof g.can_be_blessed === 'boolean' ? { can_be_blessed: g.can_be_blessed } : {})), (typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_pvp4: g.can_be_blessed_pvp4 } : {})));
-        });
+        // Map availableGirls (raw game data) to the GirlData interface.
+        const girls = availableGirls.map(g => TeamModule.mapAvailableGirl(g));
         // Build BOTH modes so we can detect when "Best Possible" produces
         // the same team as "Current Best" — this happens when the top 7
         // girls are already at full development potential (max level + max
@@ -28230,7 +28372,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.59";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.60";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.59",
+  "version": "7.35.60",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/TeamModule.spec.ts
+++ b/spec/Module/TeamModule.spec.ts
@@ -1,0 +1,93 @@
+import { TeamModule } from "../../src/Module/TeamModule";
+
+describe("TeamModule.getSelectedGirlsId -- I1 regression (return type)", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+        localStorage.clear();
+        sessionStorage.clear();
+    });
+
+    it("returns [] (not undefined) when no team is selected", () => {
+        // No .team-slot-container.selected-team in the DOM -> first guard hits.
+        document.body.innerHTML = "<div id=\"hh_hentai\" page=\"edit-team\"></div>";
+        const result = TeamModule.getSelectedGirlsId();
+        // Regression: previously returned undefined (bare `return;`), which made
+        // the consumer crash on `.length`. Must be an empty array now.
+        expect(Array.isArray(result)).toBe(true);
+        expect(result).toEqual([]);
+        // The exact crash path: equipAllGirls does `if (girlIds.length == 0)`.
+        expect(() => result.length).not.toThrow();
+        expect(result.length).toBe(0);
+    });
+
+    it("returns [] when the selected team does not have 7 members", () => {
+        document.body.innerHTML =
+            "<div id=\"hh_hentai\" page=\"edit-team\">" +
+            "<div class=\"team-slot-container selected-team\" data-team-index=\"0\"></div>" +
+            "</div>";
+        unsafeWindow.teams_data = { 0: { girls_ids: [1, 2, 3] } };
+        const result = TeamModule.getSelectedGirlsId();
+        expect(result).toEqual([]);
+    });
+
+    it("returns the 7 girl ids on a valid selected team", () => {
+        document.body.innerHTML =
+            "<div id=\"hh_hentai\" page=\"edit-team\">" +
+            "<div class=\"team-slot-container selected-team\" data-team-index=\"2\"></div>" +
+            "</div>";
+        unsafeWindow.teams_data = { 2: { girls_ids: [11, 22, 33, 44, 55, 66, 77] } };
+        const result = TeamModule.getSelectedGirlsId();
+        expect(result).toEqual([11, 22, 33, 44, 55, 66, 77]);
+    });
+});
+
+describe('TeamModule.mapAvailableGirl -- TM-C raw->GirlData mapping', () => {
+    it('maps the core fields and coerces numerics', () => {
+        const g = TeamModule.mapAvailableGirl({
+            id_girl: '42', name: 'Ada', carac1: '10', carac2: 20, carac3: '30',
+            level: '750', class: 3, rarity: 'mythic', graded: '6', nb_grades: 6,
+            element_data: { type: 'stone' },
+            caracs: { carac1: '11', carac2: 22, carac3: '33' },
+            hair_color1: 'FF0', eye_color1: '00F', zodiac: 'GLYPH Belier',
+            position_img: '5.png', blessing_bonuses: { pvp_v3: { carac1: [40] } },
+            can_be_blessed: true,
+        });
+        expect(g.id_girl).toBe(42);
+        expect(g.name).toBe('Ada');
+        expect(g.carac1).toBe(10);
+        expect(g.carac3).toBe(30);
+        expect(g.level).toBe(750);
+        expect(g.class).toBe(3);
+        expect(g.element).toBe('stone');
+        expect(g.rarity).toBe('mythic');
+        expect(g.nb_grades).toBe(6);
+        expect(g.caracs).toEqual({ carac1: 11, carac2: 22, carac3: 33 });
+        expect(g.hairColor).toBe('FF0');
+        expect(g.eyeColor).toBe('00F');
+        expect(g.zodiac).toBe('GLYPH Belier');
+        expect(g.position).toBe('5'); // .png stripped
+        expect((g as any).can_be_blessed).toBe(true);
+    });
+
+    it('prefers element_data.type over element, falls back to fire', () => {
+        expect(TeamModule.mapAvailableGirl({ id_girl: 1, element_data: { type: 'water' }, element: 'fire' }).element).toBe('water');
+        expect(TeamModule.mapAvailableGirl({ id_girl: 1, element: 'light' }).element).toBe('light');
+        expect(TeamModule.mapAvailableGirl({ id_girl: 1 }).element).toBe('fire');
+    });
+
+    it('defaults missing numerics and rarity safely', () => {
+        const g = TeamModule.mapAvailableGirl({ id_girl: 7 });
+        expect(g.carac1).toBe(0);
+        expect(g.level).toBe(1);
+        expect(g.graded).toBe(0);
+        expect(g.rarity).toBe('common');
+        expect(g.caracs).toBeUndefined();
+        expect(g.class).toBeUndefined();
+        expect(g.position).toBeUndefined();
+    });
+
+    it('omits can_be_blessed flags when not boolean', () => {
+        const g = TeamModule.mapAvailableGirl({ id_girl: 9, can_be_blessed: 'yes' as any });
+        expect('can_be_blessed' in (g as any)).toBe(false);
+    });
+});

--- a/spec/Service/TeamBuilderService.fixtures.spec.ts
+++ b/spec/Service/TeamBuilderService.fixtures.spec.ts
@@ -20,6 +20,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 import { TeamBuilderService } from '../../src/Service/TeamBuilderService';
+import { BlessingService } from '../../src/Service/BlessingService';
 import { GirlData, ElementType, PlayerClass } from '../../src/Service/TeamScoringService';
 
 interface FixtureGirl {
@@ -109,7 +110,12 @@ describe('Issue 1679 pool -- Trait-bless week (hair-Green +40%, eye-Red +25%)', 
         // eyeColor as per spec.
         const r = TeamBuilderService.buildTeam(girls, 1, fixture.hero.level, fixture.hero.class as PlayerClass);
         expect(r).not.toBeNull();
-        expect(r!.poolUsed).toBe('bless1');
+        // Philosophy B (candidate matrix): the strongest fully-blessed
+        // team wins. With two active blessings (hair=0F0 +40%, eye=F00
+        // +25%) the default-flat candidate -- top 7 blessed girls across
+        // both blessing axes -- outscores the single-axis clustered teams.
+        // Still 7/7 blessed; the display cluster keys on eyeColor=0F0.
+        expect(['bless1', 'bless1-flat', 'default-flat']).toContain(r!.poolUsed);
         expect(r!.traitCategory).toBe('eyeColor');
         expect(r!.traitValue).toBe('0F0');
     });
@@ -124,11 +130,13 @@ describe('Issue 1679 pool -- Trait-bless week (hair-Green +40%, eye-Red +25%)', 
         expect(r.girls[0].rarity).toBe('mythic');
     });
 
-    it('every team girl carries the blessed hair value (multiplier still applies)', () => {
+    it('fields a fully-blessed team (7/7 carry an active blessing)', () => {
         const r = TeamBuilderService.buildTeam(girls, 1, fixture.hero.level, fixture.hero.class as PlayerClass)!;
-        // All 7 girls come from the hair=0F0 bless1 pool.
-        const hairMatches = r.girls.filter(g => g.hairColor === '0F0').length;
-        expect(hairMatches).toBe(7);
+        // Philosophy B optimises across BOTH active blessings (hair=0F0
+        // and eye=F00), so all 7 picks are blessed even if not all share
+        // the same hair value (one is blessed via the eye axis).
+        const blessed = r.girls.filter(g => BlessingService.getEffectiveMultiplier(g as any) > 1).length;
+        expect(blessed).toBe(7);
     });
 });
 
@@ -144,7 +152,9 @@ describe('Issue 1679 pool -- Element-bless week (Stone +40%)', () => {
     it('builds a Mono-Stone team in the bless1 pool', () => {
         const r = TeamBuilderService.buildTeam(girls, 1, fixture.hero.level, fixture.hero.class as PlayerClass)!;
         expect(r).not.toBeNull();
-        expect(r.poolUsed).toBe('bless1');
+        // Fix C: flat candidate wins (sum 223056 vs 196361, +13.6%);
+        // still an all-stone team, stronger individual picks.
+        expect(['bless1', 'bless1-flat']).toContain(r.poolUsed);
         const stoneCount = r.girls.filter(g => g.element === 'stone').length;
         expect(stoneCount).toBe(7);
     });
@@ -157,13 +167,55 @@ describe('Issue 1679 pool -- Element-bless week (Stone +40%)', () => {
         expect(r.traitValue).toBe('\u2648\ufe0e B\u00e9lier');
     });
 
-    it('picks a Bélier-Stone Mythic Shield as leader (Kira Navel or Andra Palpitante)', () => {
+    it('picks a Stone Mythic Shield as leader (Tier-5 Shield, strongest team)', () => {
         const r = TeamBuilderService.buildTeam(girls, 1, fixture.hero.level, fixture.hero.class as PlayerClass)!;
+        // Philosophy B: the strongest all-stone team wins. Leader is a
+        // Stone Mythic (Tier-5 Shield); the trait-match leader bias (old
+        // key 4) no longer forces a specific girl -- the leader is now the
+        // one belonging to the strongest fielded team.
         expect(r.girls[0].element).toBe('stone');
         expect(r.girls[0].rarity).toBe('mythic');
-        // Both candidates carry the Trait-Wert-Match (zodiac=Bélier) which
-        // beats other Stone Shield candidates that lack the trait per
-        // spec key 4.
-        expect(['Kira Navel', 'Andra Palpitante']).toContain(r.girls[0].name);
+        expect(r.leaderTier5.name).toBe('Shield');
     });
+});
+
+describe('TB-A regression -- HH hairColor=FF0 +40% week (bless-aware cluster)', () => {
+    // The HH accounts have a hairColor=FF0 (blond) +40% blessing plus a
+    // weaker zodiac=Balance +20%. The eligible pool contains a strong
+    // eyeColor=00F (blue) cluster among darkness/fire girls. Before the
+    // Fix B/C, the static trait hierarchy (eyeColor first) made the
+    // builder cluster on eye=00F and fill the last two slots with
+    // UNBLESSED girls (5/7 blessed), dropping the 40% blond bonus on
+    // two slots. After the fix the builder must surface an all-blond
+    // candidate (7/7 hairColor=FF0).
+    const cases = [
+        { file: 'hh-bless-cluster-frank.json', label: 'Frank' },
+        { file: 'hh-bless-cluster-julien.json', label: 'Julien' },
+    ];
+
+    for (const c of cases) {
+        describe(c.label, () => {
+            let girls: GirlData[];
+            beforeEach(() => { girls = load(c.file).girls.map(toGirlData); });
+
+            it('detects the hairColor=FF0 blessing as bless1', () => {
+                const r = TeamBuilderService.buildTeam(girls, 1, 0, 1)!;
+                expect(r).not.toBeNull();
+                const b1 = r.activeBlessings[0];
+                expect(b1.kind).toBe('hairColor');
+                expect(b1.value).toBe('FF0');
+            });
+
+            it('builds an all-blond team (7/7 hairColor=FF0) in mode 1', () => {
+                const r = TeamBuilderService.buildTeam(girls, 1, 0, 1)!;
+                const blond = r.girls.filter(g => g.hairColor === 'FF0').length;
+                expect(blond).toBe(7);
+            });
+
+            it('uses a bless1-derived pool, not the default pool', () => {
+                const r = TeamBuilderService.buildTeam(girls, 1, 0, 1)!;
+                expect(['bless1', 'bless1-flat']).toContain(r.poolUsed);
+            });
+        });
+    }
 });

--- a/spec/Service/TeamBuilderService.spec.ts
+++ b/spec/Service/TeamBuilderService.spec.ts
@@ -266,17 +266,24 @@ describe('TeamBuilderService -- Leaderauswahl-Regel 7 keys', () => {
         expect(r.girls[0].id_girl).toBe(1); // shieldA
     });
 
-    it('4: Trait-Wert-Match in cluster category', () => {
-        // Cluster is zodiac=Bélier (stones). The decisive contest is
-        // between two Shield mythics with identical caracs_sum:
-        //   shieldNoTrait: zodiac=Balance (no match)
-        //   shieldTrait:   zodiac=Bélier (matches the cluster)
-        // Keys 1-3 tie. Key 4 (Trait-Wert-Match) decides; shieldTrait wins.
-        const shieldNoTrait = girl({
+    it('4: cluster forms on the dominant trait value (Belier), leader is a Stone Shield', () => {
+        // Cluster is zodiac=Belier (7 of 8 stones). Two Shield mythics
+        // with identical caracs_sum: id1 zodiac=Balance, id2 zodiac=Belier.
+        //
+        // Philosophy B (candidate matrix): the strongest fielded team
+        // wins. The flat candidate fields the 7 strongest stones (which
+        // includes BOTH shields, since they outscore the weaker fillers)
+        // and outscores any cluster-constrained team that has to drop one
+        // shield. The old key-4 trait-match leader bias no longer forces a
+        // specific girl; the cluster value is still reported as Belier and
+        // the leader is a Stone Mythic Shield. Which of the two equal-stat
+        // shields leads is decided by candidate/append order, not by
+        // trait-match, so we assert the invariants, not the exact id.
+        const shieldBalance = girl({
             id_girl: 1, rarity: 'mythic', element: 'stone',
             zodiac: 'Balance', carac3: 5000,
         });
-        const shieldTrait = girl({
+        const shieldBelier = girl({
             id_girl: 2, rarity: 'mythic', element: 'stone',
             zodiac: 'Bélier', carac3: 5000,
         });
@@ -284,9 +291,14 @@ describe('TeamBuilderService -- Leaderauswahl-Regel 7 keys', () => {
             id_girl: 100 + i, rarity: 'mythic', element: 'stone',
             zodiac: 'Bélier', carac3: 3000 - i,
         }));
-        const r = TeamBuilderService.buildTeam([shieldNoTrait, shieldTrait, ...filler], 1, 100, 3)!;
+        const r = TeamBuilderService.buildTeam([shieldBalance, shieldBelier, ...filler], 1, 100, 3)!;
         expect(r.traitValue).toBe('Bélier');
-        expect(r.girls[0].id_girl).toBe(2);
+        expect(r.girls[0].element).toBe('stone');
+        expect(r.leaderTier5.name).toBe('Shield');
+        // Both equal-stat shields are fielded somewhere in the team.
+        const ids = r.girls.map(g => g.id_girl);
+        expect(ids).toContain(1);
+        expect(ids).toContain(2);
     });
 
     it('5: blessed vor unblessed', () => {

--- a/spec/fixtures/hh-bless-cluster-frank.json
+++ b/spec/fixtures/hh-bless-cluster-frank.json
@@ -1,0 +1,17799 @@
+{
+ "_note": "Anonymized from HH - Frank75.json (2026-05-26 dump). ids/names replaced with counters. Stats/traits/blessing_bonuses preserved. Reduced to eligible-only (Mythic + Legendary 5*); verified identical blessing detection and built team vs full pool.",
+ "hero": {
+  "class": 1,
+  "level": 0
+ },
+ "active_blessings": [
+  {
+   "title": "Semaine du Blond",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Couleur de cheveux Blond</span> obtiennent <span class=\"blessing-bonus\">+ 40%</span> de bonus sur tous les attributs.",
+   "remaining_time": 493429,
+   "starts_in": -111370
+  },
+  {
+   "title": "Semaine du Balance",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Signe astrologique Balance</span> obtiennent <span class=\"blessing-bonus\">+ 20%</span> de bonus sur tous les attributs.",
+   "remaining_time": 493429,
+   "starts_in": -111370
+  },
+  {
+   "title": "Semaine du Invocatrice de sperme",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Rôle Invocatrice de sperme</span> gagnent un bonus de <span class=\"blessing-bonus\">+ 30%</span> sur tous leurs attributs dans Labyrinthe de l’Amour.",
+   "remaining_time": 493429,
+   "starts_in": -111370
+  }
+ ],
+ "girls": [
+  {
+   "id_girl": 132,
+   "name": "Girl_132",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 9750,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 9750,
+    "carac3": 3562.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 144,
+   "name": "Girl_144",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 5775,
+   "carac3": 13650,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 5775,
+    "carac3": 13650
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 146,
+   "name": "Girl_146",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2625,
+   "carac2": 9937.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 2625,
+    "carac2": 9937.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 158,
+   "name": "Girl_158",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3000,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3000,
+    "carac3": 4875
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 198,
+   "name": "Girl_198",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9750,
+   "carac2": 3750,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 9750,
+    "carac2": 3750,
+    "carac3": 4312.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 250,
+   "name": "Girl_250",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4312.5,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4312.5,
+    "carac3": 9937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 253,
+   "name": "Girl_253",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 14175,
+   "carac3": 6037.5,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 14175,
+    "carac3": 6037.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 268,
+   "name": "Girl_268",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10125,
+   "carac2": 4312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10125,
+    "carac2": 4312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 300,
+   "name": "Girl_300",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 306,
+   "name": "Girl_306",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 3.99,
+   "carac2": 10.45,
+   "carac3": 4.56,
+   "caracs": {
+    "carac1": 3.99,
+    "carac2": 10.45,
+    "carac3": 4.56
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 307,
+   "name": "Girl_307",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 308,
+   "name": "Girl_308",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 3.12,
+   "carac2": 2.28,
+   "carac3": 6.6,
+   "caracs": {
+    "carac1": 3.12,
+    "carac2": 2.28,
+    "carac3": 6.6
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20,
+      30
+     ],
+     "carac2": [
+      20,
+      30
+     ],
+     "carac3": [
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 314,
+   "name": "Girl_314",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4875,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4875,
+    "carac3": 3562.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 315,
+   "name": "Girl_315",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1530,
+   "carac2": 4950,
+   "carac3": 2520,
+   "caracs": {
+    "carac1": 1530,
+    "carac2": 4950,
+    "carac3": 2520
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 322,
+   "name": "Girl_322",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 14437.5,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 14437.5,
+    "carac3": 7875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 325,
+   "name": "Girl_325",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4275,
+   "carac3": 5850,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4275,
+    "carac3": 5850
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 340,
+   "name": "Girl_340",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6.16,
+   "carac2": 15.4,
+   "carac3": 7,
+   "caracs": {
+    "carac1": 6.16,
+    "carac2": 15.4,
+    "carac3": 7
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 346,
+   "name": "Girl_346",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 10312.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 10312.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 352,
+   "name": "Girl_352",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6825,
+   "carac2": 13912.5,
+   "carac3": 4725,
+   "caracs": {
+    "carac1": 6825,
+    "carac2": 13912.5,
+    "carac3": 4725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 357,
+   "name": "Girl_357",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 5460,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 5460,
+    "carac3": 4620
+   },
+   "eye_color1": "F00",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 360,
+   "name": "Girl_360",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 2684.64,
+   "carac2": 8685.6,
+   "carac3": 4737.6,
+   "caracs": {
+    "carac1": 2684.64,
+    "carac2": 8685.6,
+    "carac3": 4737.6
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 365,
+   "name": "Girl_365",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 366,
+   "name": "Girl_366",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1377.5,
+   "carac2": 2612.5,
+   "carac3": 760,
+   "caracs": {
+    "carac1": 1377.5,
+    "carac2": 2612.5,
+    "carac3": 760
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 370,
+   "name": "Girl_370",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 5062.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 5062.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 372,
+   "name": "Girl_372",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3750,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3750,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 376,
+   "name": "Girl_376",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 2.6,
+   "carac3": 1.9,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 2.6,
+    "carac3": 1.9
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 379,
+   "name": "Girl_379",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2415,
+   "carac2": 2310,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 2415,
+    "carac2": 2310,
+    "carac3": 5775
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 389,
+   "name": "Girl_389",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 400,
+   "name": "Girl_400",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 401,
+   "name": "Girl_401",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3000,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3000,
+    "carac3": 10125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 402,
+   "name": "Girl_402",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1500,
+   "carac2": 4125,
+   "carac3": 1875,
+   "caracs": {
+    "carac1": 1500,
+    "carac2": 4125,
+    "carac3": 1875
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 403,
+   "name": "Girl_403",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4830,
+   "carac2": 5040,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 4830,
+    "carac2": 5040,
+    "carac3": 11550
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 404,
+   "name": "Girl_404",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 2250,
+   "carac3": 1125,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 2250,
+    "carac3": 1125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 425,
+   "name": "Girl_425",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 426,
+   "name": "Girl_426",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 427,
+   "name": "Girl_427",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7087.5,
+   "carac2": 4725,
+   "carac3": 13912.5,
+   "caracs": {
+    "carac1": 7087.5,
+    "carac2": 4725,
+    "carac3": 13912.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 432,
+   "name": "Girl_432",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1400,
+   "carac2": 2537.5,
+   "carac3": 4812.5,
+   "caracs": {
+    "carac1": 1400,
+    "carac2": 2537.5,
+    "carac3": 4812.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 433,
+   "name": "Girl_433",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 436,
+   "name": "Girl_436",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 442,
+   "name": "Girl_442",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3675,
+   "carac2": 14437.5,
+   "carac3": 8137.5,
+   "caracs": {
+    "carac1": 3675,
+    "carac2": 14437.5,
+    "carac3": 8137.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 444,
+   "name": "Girl_444",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 451,
+   "name": "Girl_451",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2100,
+   "carac2": 5775,
+   "carac3": 2625,
+   "caracs": {
+    "carac1": 2100,
+    "carac2": 5775,
+    "carac3": 2625
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 458,
+   "name": "Girl_458",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 10312.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 10312.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "EB8",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 469,
+   "name": "Girl_469",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 479,
+   "name": "Girl_479",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 484,
+   "name": "Girl_484",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 10312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 10312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 485,
+   "name": "Girl_485",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1155,
+   "carac2": 4235,
+   "carac3": 2310,
+   "caracs": {
+    "carac1": 1155,
+    "carac2": 4235,
+    "carac3": 2310
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 489,
+   "name": "Girl_489",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 490,
+   "name": "Girl_490",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 250,
+   "graded": 2,
+   "nb_grades": 5,
+   "carac1": 3080,
+   "carac2": 1176,
+   "carac3": 1344,
+   "caracs": {
+    "carac1": 3080,
+    "carac2": 1176,
+    "carac3": 1344
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 491,
+   "name": "Girl_491",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F90",
+   "hair_color1": "EB8",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 510,
+   "name": "Girl_510",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 513,
+   "name": "Girl_513",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4500,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4500,
+    "carac3": 5625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 523,
+   "name": "Girl_523",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 524,
+   "name": "Girl_524",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2,
+   "carac2": 5.5,
+   "carac3": 2.5,
+   "caracs": {
+    "carac1": 2,
+    "carac2": 5.5,
+    "carac3": 2.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 538,
+   "name": "Girl_538",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 539,
+   "name": "Girl_539",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F90",
+   "hair_color1": "CCC",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 540,
+   "name": "Girl_540",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 7875,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 7875,
+    "carac3": 3937.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 542,
+   "name": "Girl_542",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 178,
+   "graded": 2,
+   "nb_grades": 5,
+   "carac1": 768.96,
+   "carac2": 512.64,
+   "carac3": 1566.4,
+   "caracs": {
+    "carac1": 768.96,
+    "carac2": 512.64,
+    "carac3": 1566.4
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 544,
+   "name": "Girl_544",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4410,
+   "carac2": 5670,
+   "carac3": 11340,
+   "caracs": {
+    "carac1": 4410,
+    "carac2": 5670,
+    "carac3": 11340
+   },
+   "eye_color1": "00F",
+   "hair_color1": "XXX",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 546,
+   "name": "Girl_546",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "321",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 547,
+   "name": "Girl_547",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10360,
+   "carac2": 17635.8,
+   "carac3": 7472.5,
+   "caracs": {
+    "carac1": 10360,
+    "carac2": 17635.8,
+    "carac3": 7472.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 549,
+   "name": "Girl_549",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5215,
+   "carac2": 7577.5,
+   "carac3": 15015,
+   "caracs": {
+    "carac1": 5215,
+    "carac2": 7577.5,
+    "carac3": 15015
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 555,
+   "name": "Girl_555",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5037.5,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5037.5,
+    "carac3": 4100
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 562,
+   "name": "Girl_562",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 6300,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 6300,
+    "carac3": 14437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 571,
+   "name": "Girl_571",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 580,
+   "name": "Girl_580",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 2250,
+   "carac3": 1125,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 2250,
+    "carac3": 1125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 581,
+   "name": "Girl_581",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.3,
+   "carac2": 5.5,
+   "carac3": 2.2,
+   "caracs": {
+    "carac1": 2.3,
+    "carac2": 5.5,
+    "carac3": 2.2
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 583,
+   "name": "Girl_583",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 590,
+   "name": "Girl_590",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.6,
+   "carac2": 5.5,
+   "carac3": 1.9,
+   "caracs": {
+    "carac1": 2.6,
+    "carac2": 5.5,
+    "carac3": 1.9
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 593,
+   "name": "Girl_593",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3912.5,
+   "carac2": 10725,
+   "carac3": 5225,
+   "caracs": {
+    "carac1": 3912.5,
+    "carac2": 10725,
+    "carac3": 5225
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 599,
+   "name": "Girl_599",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 15015,
+   "carac2": 5477.5,
+   "carac3": 7315,
+   "caracs": {
+    "carac1": 15015,
+    "carac2": 5477.5,
+    "carac3": 7315
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 602,
+   "name": "Girl_602",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 4830,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 4830,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 604,
+   "name": "Girl_604",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4287.5,
+   "carac2": 4850,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4287.5,
+    "carac2": 4850,
+    "carac3": 10725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 611,
+   "name": "Girl_611",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5460,
+   "carac2": 11550,
+   "carac3": 4410,
+   "caracs": {
+    "carac1": 5460,
+    "carac2": 11550,
+    "carac3": 4410
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 612,
+   "name": "Girl_612",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3750,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3750,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 626,
+   "name": "Girl_626",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5037.5,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5037.5,
+    "carac3": 4100
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 627,
+   "name": "Girl_627",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4475,
+   "carac2": 4662.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4475,
+    "carac2": 4662.5,
+    "carac3": 10725
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 628,
+   "name": "Girl_628",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 6162.5,
+   "carac3": 2975,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 6162.5,
+    "carac3": 2975
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 630,
+   "name": "Girl_630",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5880,
+   "carac2": 4200,
+   "carac3": 11340,
+   "caracs": {
+    "carac1": 5880,
+    "carac2": 4200,
+    "carac3": 11340
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 641,
+   "name": "Girl_641",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 643,
+   "name": "Girl_643",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 644,
+   "name": "Girl_644",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 7.7,
+   "carac2": 4.2,
+   "carac3": 2.1,
+   "caracs": {
+    "carac1": 7.7,
+    "carac2": 4.2,
+    "carac3": 2.1
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 649,
+   "name": "Girl_649",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "EB8",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 655,
+   "name": "Girl_655",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3780,
+   "carac2": 11550,
+   "carac3": 6090,
+   "caracs": {
+    "carac1": 3780,
+    "carac2": 11550,
+    "carac3": 6090
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 661,
+   "name": "Girl_661",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3537.5,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3537.5,
+    "carac3": 5600
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 663,
+   "name": "Girl_663",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 858,
+   "carac2": 3630,
+   "carac3": 2112,
+   "caracs": {
+    "carac1": 858,
+    "carac2": 3630,
+    "carac3": 2112
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FD0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 665,
+   "name": "Girl_665",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 9937.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 9937.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 678,
+   "name": "Girl_678",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 682,
+   "name": "Girl_682",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 696,
+   "name": "Girl_696",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 700,
+   "name": "Girl_700",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 9937.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 9937.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "CCC",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 705,
+   "name": "Girl_705",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 5040,
+   "carac3": 5040,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 5040,
+    "carac3": 5040
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 706,
+   "name": "Girl_706",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 8365,
+   "carac2": 15015,
+   "carac3": 4427.5,
+   "caracs": {
+    "carac1": 8365,
+    "carac2": 15015,
+    "carac3": 4427.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 709,
+   "name": "Girl_709",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7735,
+   "carac2": 17635.8,
+   "carac3": 10097.5,
+   "caracs": {
+    "carac1": 7735,
+    "carac2": 17635.8,
+    "carac3": 10097.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 711,
+   "name": "Girl_711",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3537.5,
+   "carac2": 5600,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 3537.5,
+    "carac2": 5600,
+    "carac3": 10725
+   },
+   "eye_color1": "A55",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 713,
+   "name": "Girl_713",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4687.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4687.5,
+    "carac3": 3750
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 718,
+   "name": "Girl_718",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4850,
+   "carac3": 4287.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4850,
+    "carac3": 4287.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 724,
+   "name": "Girl_724",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.3,
+   "carac2": 2.2,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 2.3,
+    "carac2": 2.2,
+    "carac3": 5.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 734,
+   "name": "Girl_734",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4662.5,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4662.5,
+    "carac3": 4475
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FFF",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 742,
+   "name": "Girl_742",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 15015,
+   "carac2": 6002.5,
+   "carac3": 6790,
+   "caracs": {
+    "carac1": 15015,
+    "carac2": 6002.5,
+    "carac3": 6790
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 744,
+   "name": "Girl_744",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4662.5,
+   "carac2": 10725,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 4662.5,
+    "carac2": 10725,
+    "carac3": 4475
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 749,
+   "name": "Girl_749",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4462.5,
+   "carac2": 7350,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 4462.5,
+    "carac2": 7350,
+    "carac3": 14437.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 750,
+   "name": "Girl_750",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5600,
+   "carac2": 10725,
+   "carac3": 3537.5,
+   "caracs": {
+    "carac1": 5600,
+    "carac2": 10725,
+    "carac3": 3537.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 755,
+   "name": "Girl_755",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "00F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 756,
+   "name": "Girl_756",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 758,
+   "name": "Girl_758",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3162.5,
+   "carac2": 5975,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 3162.5,
+    "carac2": 5975,
+    "carac3": 10725
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 771,
+   "name": "Girl_771",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 4830,
+   "carac3": 5040,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 4830,
+    "carac3": 5040
+   },
+   "eye_color1": "F00",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 787,
+   "name": "Girl_787",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1875,
+   "carac2": 1500,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1875,
+    "carac2": 1500,
+    "carac3": 4125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 798,
+   "name": "Girl_798",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3162.5,
+   "carac2": 5787.5,
+   "carac3": 10335,
+   "caracs": {
+    "carac1": 3162.5,
+    "carac2": 5787.5,
+    "carac3": 10335
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 804,
+   "name": "Girl_804",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3162.5,
+   "carac3": 5975,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3162.5,
+    "carac3": 5975
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 811,
+   "name": "Girl_811",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 814,
+   "name": "Girl_814",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6300,
+   "carac2": 13860,
+   "carac3": 5544,
+   "caracs": {
+    "carac1": 6300,
+    "carac2": 13860,
+    "carac3": 5544
+   },
+   "eye_color1": "A55",
+   "hair_color1": "321",
+   "zodiac": "♎︎ Balance",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 819,
+   "name": "Girl_819",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.3,
+   "carac2": 2.2,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 2.3,
+    "carac2": 2.2,
+    "carac3": 5.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 831,
+   "name": "Girl_831",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5037.5,
+   "carac2": 10725,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 5037.5,
+    "carac2": 10725,
+    "carac3": 4100
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 844,
+   "name": "Girl_844",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5040,
+   "carac2": 11550,
+   "carac3": 4830,
+   "caracs": {
+    "carac1": 5040,
+    "carac2": 11550,
+    "carac3": 4830
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 849,
+   "name": "Girl_849",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8685.6,
+   "carac2": 3632.16,
+   "carac3": 3790.08,
+   "caracs": {
+    "carac1": 8685.6,
+    "carac2": 3632.16,
+    "carac3": 3790.08
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FD0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 851,
+   "name": "Girl_851",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 8148,
+   "carac2": 18018,
+   "carac3": 7203,
+   "caracs": {
+    "carac1": 8148,
+    "carac2": 18018,
+    "carac3": 7203
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20,
+      30
+     ],
+     "carac2": [
+      40,
+      20,
+      30
+     ],
+     "carac3": [
+      40,
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 856,
+   "name": "Girl_856",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3948,
+   "carac2": 8685.6,
+   "carac3": 3474.24,
+   "caracs": {
+    "carac1": 3948,
+    "carac2": 8685.6,
+    "carac3": 3474.24
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 858,
+   "name": "Girl_858",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 862,
+   "name": "Girl_862",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4695,
+   "carac2": 6270,
+   "carac3": 12870,
+   "caracs": {
+    "carac1": 4695,
+    "carac2": 6270,
+    "carac3": 12870
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 867,
+   "name": "Girl_867",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10415.625,
+   "carac2": 5681.25,
+   "carac3": 2840.625,
+   "caracs": {
+    "carac1": 10415.625,
+    "carac2": 5681.25,
+    "carac3": 2840.625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 868,
+   "name": "Girl_868",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5062.5,
+   "carac2": 10312.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 5062.5,
+    "carac2": 10312.5,
+    "carac3": 3375
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 875,
+   "name": "Girl_875",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11248.125,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 11248.125,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 879,
+   "name": "Girl_879",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "888",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 884,
+   "name": "Girl_884",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4500,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4500,
+    "carac3": 10125
+   },
+   "eye_color1": "B06",
+   "hair_color1": "888",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 886,
+   "name": "Girl_886",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 890,
+   "name": "Girl_890",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11.42,
+   "carac2": 4.37,
+   "carac3": 18.48,
+   "caracs": {
+    "carac1": 11.42,
+    "carac2": 4.37,
+    "carac3": 18.48
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 900,
+   "name": "Girl_900",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 825,
+   "carac2": 4125,
+   "carac3": 2550,
+   "caracs": {
+    "carac1": 825,
+    "carac2": 4125,
+    "carac3": 2550
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 903,
+   "name": "Girl_903",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5880,
+   "carac2": 16170,
+   "carac3": 7938,
+   "caracs": {
+    "carac1": 5880,
+    "carac2": 16170,
+    "carac3": 7938
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 904,
+   "name": "Girl_904",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 907,
+   "name": "Girl_907",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 19624.5,
+   "carac2": 12124,
+   "carac3": 7714,
+   "caracs": {
+    "carac1": 19624.5,
+    "carac2": 12124,
+    "carac3": 7714
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 909,
+   "name": "Girl_909",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 3.1,
+   "carac3": 1.4,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 3.1,
+    "carac3": 1.4
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 912,
+   "name": "Girl_912",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 10312.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 10312.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 914,
+   "name": "Girl_914",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 3.1,
+   "carac2": 1.4,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 3.1,
+    "carac2": 1.4,
+    "carac3": 5.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 918,
+   "name": "Girl_918",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 3990,
+   "carac3": 5880,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 3990,
+    "carac3": 5880
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 924,
+   "name": "Girl_924",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4875,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4875,
+    "carac3": 10125
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FD0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 928,
+   "name": "Girl_928",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3350,
+   "carac3": 5787.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3350,
+    "carac3": 5787.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 929,
+   "name": "Girl_929",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 934,
+   "name": "Girl_934",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5437.5,
+   "carac2": 3000,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5437.5,
+    "carac2": 3000,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 937,
+   "name": "Girl_937",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8685.6,
+   "carac2": 2684.64,
+   "carac3": 4737.6,
+   "caracs": {
+    "carac1": 8685.6,
+    "carac2": 2684.64,
+    "carac3": 4737.6
+   },
+   "eye_color1": "00F",
+   "hair_color1": "CCC",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 939,
+   "name": "Girl_939",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4287.5,
+   "carac3": 4850,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4287.5,
+    "carac3": 4850
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 945,
+   "name": "Girl_945",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5437.5,
+   "carac2": 3000,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5437.5,
+    "carac2": 3000,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 946,
+   "name": "Girl_946",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4579.68,
+   "carac2": 8685.6,
+   "carac3": 2842.56,
+   "caracs": {
+    "carac1": 4579.68,
+    "carac2": 8685.6,
+    "carac3": 2842.56
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 951,
+   "name": "Girl_951",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 13912.5,
+   "carac2": 3937.5,
+   "carac3": 7612.5,
+   "caracs": {
+    "carac1": 13912.5,
+    "carac2": 3937.5,
+    "carac3": 7612.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 954,
+   "name": "Girl_954",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6037.5,
+   "carac2": 5775,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 6037.5,
+    "carac2": 5775,
+    "carac3": 14437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 957,
+   "name": "Girl_957",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.6,
+   "carac2": 1.9,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 2.6,
+    "carac2": 1.9,
+    "carac3": 5.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 962,
+   "name": "Girl_962",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 9.07,
+   "carac2": 6.72,
+   "carac3": 18.48,
+   "caracs": {
+    "carac1": 9.07,
+    "carac2": 6.72,
+    "carac3": 18.48
+   },
+   "eye_color1": "A55",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 964,
+   "name": "Girl_964",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2437.5,
+   "carac2": 10125,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 2437.5,
+    "carac2": 10125,
+    "carac3": 5250
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 965,
+   "name": "Girl_965",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 52,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 468.83,
+   "carac2": 489.22,
+   "carac3": 1121.12,
+   "caracs": {
+    "carac1": 468.83,
+    "carac2": 489.22,
+    "carac3": 1121.12
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 966,
+   "name": "Girl_966",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 970,
+   "name": "Girl_970",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10125,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10125,
+    "carac3": 4875
+   },
+   "eye_color1": "F90",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 972,
+   "name": "Girl_972",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4830,
+   "carac2": 11340,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 4830,
+    "carac2": 11340,
+    "carac3": 5250
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 978,
+   "name": "Girl_978",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 982,
+   "name": "Girl_982",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5180,
+   "carac2": 12127.5,
+   "carac3": 5390,
+   "caracs": {
+    "carac1": 5180,
+    "carac2": 12127.5,
+    "carac3": 5390
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 990,
+   "name": "Girl_990",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6037.5,
+   "carac2": 14437.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 6037.5,
+    "carac2": 14437.5,
+    "carac3": 5775
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 999,
+   "name": "Girl_999",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 15.4,
+   "carac2": 10.36,
+   "carac3": 2.8,
+   "caracs": {
+    "carac1": 15.4,
+    "carac2": 10.36,
+    "carac3": 2.8
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1002,
+   "name": "Girl_1002",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4662.5,
+   "carac2": 10725,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 4662.5,
+    "carac2": 10725,
+    "carac3": 4475
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1004,
+   "name": "Girl_1004",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4287.5,
+   "carac3": 4850,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4287.5,
+    "carac3": 4850
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1005,
+   "name": "Girl_1005",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6495,
+   "carac2": 12870,
+   "carac3": 4470,
+   "caracs": {
+    "carac1": 6495,
+    "carac2": 12870,
+    "carac3": 4470
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20,
+      30
+     ],
+     "carac2": [
+      20,
+      30
+     ],
+     "carac3": [
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1012,
+   "name": "Girl_1012",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1275,
+   "carac2": 2100,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1275,
+    "carac2": 2100,
+    "carac3": 4125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1013,
+   "name": "Girl_1013",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 825,
+   "carac2": 4125,
+   "carac3": 2550,
+   "caracs": {
+    "carac1": 825,
+    "carac2": 4125,
+    "carac3": 2550
+   },
+   "eye_color1": "888",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1018,
+   "name": "Girl_1018",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1025,
+   "name": "Girl_1025",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 3657.5,
+   "carac2": 1729,
+   "carac3": 1263.5,
+   "caracs": {
+    "carac1": 3657.5,
+    "carac2": 1729,
+    "carac3": 1263.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1032,
+   "name": "Girl_1032",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1038,
+   "name": "Girl_1038",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5975,
+   "carac2": 2975,
+   "carac3": 10335,
+   "caracs": {
+    "carac1": 5975,
+    "carac2": 2975,
+    "carac3": 10335
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1047,
+   "name": "Girl_1047",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2275,
+   "carac2": 4812.5,
+   "carac3": 1662.5,
+   "caracs": {
+    "carac1": 2275,
+    "carac2": 4812.5,
+    "carac3": 1662.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1055,
+   "name": "Girl_1055",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "EB8",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1062,
+   "name": "Girl_1062",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 1,
+   "graded": 2,
+   "nb_grades": 5,
+   "carac1": 8.8,
+   "carac2": 3.52,
+   "carac3": 3.68,
+   "caracs": {
+    "carac1": 8.8,
+    "carac2": 3.52,
+    "carac3": 3.68
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1065,
+   "name": "Girl_1065",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1076,
+   "name": "Girl_1076",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3474.24,
+   "carac2": 8527.68,
+   "carac3": 4105.92,
+   "caracs": {
+    "carac1": 3474.24,
+    "carac2": 8527.68,
+    "carac3": 4105.92
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1084,
+   "name": "Girl_1084",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 3187.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 3187.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1094,
+   "name": "Girl_1094",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.96,
+   "carac2": 7.7,
+   "carac3": 4.34,
+   "caracs": {
+    "carac1": 1.96,
+    "carac2": 7.7,
+    "carac3": 4.34
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1098,
+   "name": "Girl_1098",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14175,
+   "carac2": 3937.5,
+   "carac3": 6825,
+   "caracs": {
+    "carac1": 14175,
+    "carac2": 3937.5,
+    "carac3": 6825
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1103,
+   "name": "Girl_1103",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "XXX",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1108,
+   "name": "Girl_1108",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1112,
+   "name": "Girl_1112",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4050,
+   "carac3": 6075,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4050,
+    "carac3": 6075
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1117,
+   "name": "Girl_1117",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3187.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3187.5,
+    "carac3": 5250
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1119,
+   "name": "Girl_1119",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 6.08,
+   "carac2": 2.47,
+   "carac3": 10.45,
+   "caracs": {
+    "carac1": 6.08,
+    "carac2": 2.47,
+    "carac3": 10.45
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1122,
+   "name": "Girl_1122",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 321,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 1797.6,
+   "carac2": 4853.52,
+   "carac3": 2516.64,
+   "caracs": {
+    "carac1": 1797.6,
+    "carac2": 4853.52,
+    "carac3": 2516.64
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1123,
+   "name": "Girl_1123",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1126,
+   "name": "Girl_1126",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 7700,
+   "carac3": 2870,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 7700,
+    "carac3": 2870
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1130,
+   "name": "Girl_1130",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3283.125,
+   "carac2": 5407.5,
+   "carac3": 10621.875,
+   "caracs": {
+    "carac1": 3283.125,
+    "carac2": 5407.5,
+    "carac3": 10621.875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1133,
+   "name": "Girl_1133",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12652.5,
+   "carac2": 6090,
+   "carac3": 3780,
+   "caracs": {
+    "carac1": 12652.5,
+    "carac2": 6090,
+    "carac3": 3780
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1134,
+   "name": "Girl_1134",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 14175,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 14175,
+    "carac3": 6300
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1137,
+   "name": "Girl_1137",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1144,
+   "name": "Girl_1144",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3465,
+   "carac2": 9075,
+   "carac3": 3960,
+   "caracs": {
+    "carac1": 3465,
+    "carac2": 9075,
+    "carac3": 3960
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1148,
+   "name": "Girl_1148",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6230,
+   "carac2": 4340,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 6230,
+    "carac2": 4340,
+    "carac3": 12127.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FFF",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1149,
+   "name": "Girl_1149",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1950,
+   "carac2": 1425,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1950,
+    "carac2": 1425,
+    "carac3": 4125
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1151,
+   "name": "Girl_1151",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 11248.125,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 11248.125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1153,
+   "name": "Girl_1153",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1157,
+   "name": "Girl_1157",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2187.5,
+   "carac2": 625,
+   "carac3": 3437.5,
+   "caracs": {
+    "carac1": 2187.5,
+    "carac2": 625,
+    "carac3": 3437.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1162,
+   "name": "Girl_1162",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4875,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4875,
+    "carac3": 3562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1170,
+   "name": "Girl_1170",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5400,
+   "carac2": 4725,
+   "carac3": 12375,
+   "caracs": {
+    "carac1": 5400,
+    "carac2": 4725,
+    "carac3": 12375
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1171,
+   "name": "Girl_1171",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5625,
+   "carac3": 2812.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5625,
+    "carac3": 2812.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1178,
+   "name": "Girl_1178",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 90,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 598.5,
+   "carac2": 171,
+   "carac3": 940.5,
+   "caracs": {
+    "carac1": 598.5,
+    "carac2": 171,
+    "carac3": 940.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "B06",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1183,
+   "name": "Girl_1183",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1186,
+   "name": "Girl_1186",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 250,
+   "graded": 2,
+   "nb_grades": 5,
+   "carac1": 920,
+   "carac2": 880,
+   "carac3": 2200,
+   "caracs": {
+    "carac1": 920,
+    "carac2": 880,
+    "carac3": 2200
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1199,
+   "name": "Girl_1199",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 7,
+   "carac2": 15.4,
+   "carac3": 6.16,
+   "caracs": {
+    "carac1": 7,
+    "carac2": 15.4,
+    "carac3": 6.16
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1204,
+   "name": "Girl_1204",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1209,
+   "name": "Girl_1209",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 11248.125,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 11248.125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1217,
+   "name": "Girl_1217",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 10312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 10312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1218,
+   "name": "Girl_1218",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3537.5,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3537.5,
+    "carac3": 5600
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1232,
+   "name": "Girl_1232",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1242,
+   "name": "Girl_1242",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5975,
+   "carac3": 3162.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5975,
+    "carac3": 3162.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1244,
+   "name": "Girl_1244",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 17089.8,
+   "carac2": 6947.5,
+   "carac3": 10360,
+   "caracs": {
+    "carac1": 17089.8,
+    "carac2": 6947.5,
+    "carac3": 10360
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1246,
+   "name": "Girl_1246",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1254,
+   "name": "Girl_1254",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.1,
+   "carac2": 5.5,
+   "carac3": 3.4,
+   "caracs": {
+    "carac1": 1.1,
+    "carac2": 5.5,
+    "carac3": 3.4
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1258,
+   "name": "Girl_1258",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1575,
+   "carac2": 1800,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1575,
+    "carac2": 1800,
+    "carac3": 4125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1265,
+   "name": "Girl_1265",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "F90",
+   "hair_color1": "A55",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1266,
+   "name": "Girl_1266",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 5625,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 5625,
+    "carac3": 9937.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1271,
+   "name": "Girl_1271",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 6037.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 6037.5,
+    "carac3": 5775
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1279,
+   "name": "Girl_1279",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 4410,
+   "carac3": 5670,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 4410,
+    "carac3": 5670
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1289,
+   "name": "Girl_1289",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4875,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4875,
+    "carac3": 3562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1297,
+   "name": "Girl_1297",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 3937.5,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 3937.5,
+    "carac3": 7875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1300,
+   "name": "Girl_1300",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3045,
+   "carac2": 1680,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 3045,
+    "carac2": 1680,
+    "carac3": 5775
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1307,
+   "name": "Girl_1307",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5600,
+   "carac2": 12127.5,
+   "carac3": 4970,
+   "caracs": {
+    "carac1": 5600,
+    "carac2": 12127.5,
+    "carac3": 4970
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1310,
+   "name": "Girl_1310",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4475,
+   "carac2": 10725,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4475,
+    "carac2": 10725,
+    "carac3": 4662.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1311,
+   "name": "Girl_1311",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.548,
+   "carac2": 7.775,
+   "carac3": 3.817,
+   "caracs": {
+    "carac1": 2.548,
+    "carac2": 7.775,
+    "carac3": 3.817
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1313,
+   "name": "Girl_1313",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 726,
+   "carac2": 3630,
+   "carac3": 2244,
+   "caracs": {
+    "carac1": 726,
+    "carac2": 3630,
+    "carac3": 2244
+   },
+   "eye_color1": "00F",
+   "hair_color1": "321",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1318,
+   "name": "Girl_1318",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8120,
+   "carac2": 2450,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 8120,
+    "carac2": 2450,
+    "carac3": 12127.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1319,
+   "name": "Girl_1319",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10125,
+   "carac2": 4125,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10125,
+    "carac2": 4125,
+    "carac3": 4500
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1327,
+   "name": "Girl_1327",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 4.37,
+   "carac2": 10.45,
+   "carac3": 4.18,
+   "caracs": {
+    "carac1": 4.37,
+    "carac2": 10.45,
+    "carac3": 4.18
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1328,
+   "name": "Girl_1328",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 10312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 10312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1331,
+   "name": "Girl_1331",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1333,
+   "name": "Girl_1333",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 10725,
+   "carac3": 4287.5,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 10725,
+    "carac3": 4287.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1334,
+   "name": "Girl_1334",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1812.5,
+   "carac2": 3437.5,
+   "carac3": 1000,
+   "caracs": {
+    "carac1": 1812.5,
+    "carac2": 3437.5,
+    "carac3": 1000
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1335,
+   "name": "Girl_1335",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1337,
+   "name": "Girl_1337",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1437.5,
+   "carac2": 1375,
+   "carac3": 3437.5,
+   "caracs": {
+    "carac1": 1437.5,
+    "carac2": 1375,
+    "carac3": 3437.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1338,
+   "name": "Girl_1338",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3162.5,
+   "carac2": 10725,
+   "carac3": 5975,
+   "caracs": {
+    "carac1": 3162.5,
+    "carac2": 10725,
+    "carac3": 5975
+   },
+   "eye_color1": "F99",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1339,
+   "name": "Girl_1339",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1349,
+   "name": "Girl_1349",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5062.5,
+   "carac2": 3375,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5062.5,
+    "carac2": 3375,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "00F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1353,
+   "name": "Girl_1353",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 4.2,
+   "carac2": 9.24,
+   "carac3": 3.36,
+   "caracs": {
+    "carac1": 4.2,
+    "carac2": 9.24,
+    "carac3": 3.36
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1355,
+   "name": "Girl_1355",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1361,
+   "name": "Girl_1361",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 4.62,
+   "carac2": 1.68,
+   "carac3": 7.7,
+   "caracs": {
+    "carac1": 4.62,
+    "carac2": 1.68,
+    "carac3": 7.7
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1362,
+   "name": "Girl_1362",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1080,
+   "carac2": 4950,
+   "carac3": 2970,
+   "caracs": {
+    "carac1": 1080,
+    "carac2": 4950,
+    "carac3": 2970
+   },
+   "eye_color1": "F99",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1369,
+   "name": "Girl_1369",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5062.5,
+   "carac2": 10312.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 5062.5,
+    "carac2": 10312.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1372,
+   "name": "Girl_1372",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4550,
+   "carac2": 6020,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 6020,
+    "carac3": 12127.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1383,
+   "name": "Girl_1383",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 5062.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 5062.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1393,
+   "name": "Girl_1393",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 4312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 4312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1397,
+   "name": "Girl_1397",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 70,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 385,
+   "carac2": 217,
+   "carac3": 98,
+   "caracs": {
+    "carac1": 385,
+    "carac2": 217,
+    "carac3": 98
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1399,
+   "name": "Girl_1399",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1487.5,
+   "carac2": 2450,
+   "carac3": 4812.5,
+   "caracs": {
+    "carac1": 1487.5,
+    "carac2": 2450,
+    "carac3": 4812.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1403,
+   "name": "Girl_1403",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1417,
+   "name": "Girl_1417",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 3.1,
+   "carac3": 1.4,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 3.1,
+    "carac3": 1.4
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1422,
+   "name": "Girl_1422",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 14437.5,
+   "carac3": 6562.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 14437.5,
+    "carac3": 6562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1423,
+   "name": "Girl_1423",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 6720,
+   "carac3": 3150,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 6720,
+    "carac3": 3150
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1424,
+   "name": "Girl_1424",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1432,
+   "name": "Girl_1432",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 10312.5,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 10312.5,
+    "carac3": 3562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1434,
+   "name": "Girl_1434",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1448,
+   "name": "Girl_1448",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 3750,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 3750,
+    "carac3": 9937.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1460,
+   "name": "Girl_1460",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1465,
+   "name": "Girl_1465",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.96,
+   "carac2": 7.7,
+   "carac3": 4.34,
+   "caracs": {
+    "carac1": 1.96,
+    "carac2": 7.7,
+    "carac3": 4.34
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1470,
+   "name": "Girl_1470",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1472,
+   "name": "Girl_1472",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4812.5,
+   "carac2": 2012.5,
+   "carac3": 1925,
+   "caracs": {
+    "carac1": 4812.5,
+    "carac2": 2012.5,
+    "carac3": 1925
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1475,
+   "name": "Girl_1475",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16170,
+   "carac2": 7644,
+   "carac3": 6174,
+   "caracs": {
+    "carac1": 16170,
+    "carac2": 7644,
+    "carac3": 6174
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1480,
+   "name": "Girl_1480",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1890,
+   "carac2": 2835,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 1890,
+    "carac2": 2835,
+    "carac3": 5775
+   },
+   "eye_color1": "B06",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1483,
+   "name": "Girl_1483",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3187.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3187.5,
+    "carac3": 5250
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1485,
+   "name": "Girl_1485",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4.48,
+   "carac2": 15.4,
+   "carac3": 8.68,
+   "caracs": {
+    "carac1": 4.48,
+    "carac2": 15.4,
+    "carac3": 8.68
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "B62",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1501,
+   "name": "Girl_1501",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2,
+   "carac2": 5.5,
+   "carac3": 2.5,
+   "caracs": {
+    "carac1": 2,
+    "carac2": 5.5,
+    "carac3": 2.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1503,
+   "name": "Girl_1503",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1504,
+   "name": "Girl_1504",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5544,
+   "carac2": 6552,
+   "carac3": 13608,
+   "caracs": {
+    "carac1": 5544,
+    "carac2": 6552,
+    "carac3": 13608
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1510,
+   "name": "Girl_1510",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1523,
+   "name": "Girl_1523",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 3937.5,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 3937.5,
+    "carac3": 7875
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1525,
+   "name": "Girl_1525",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3948,
+   "carac2": 3474.24,
+   "carac3": 8685.6,
+   "caracs": {
+    "carac1": 3948,
+    "carac2": 3474.24,
+    "carac3": 8685.6
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1527,
+   "name": "Girl_1527",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 1.8,
+   "carac3": 2.7,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 1.8,
+    "carac3": 2.7
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1528,
+   "name": "Girl_1528",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3377.5,
+   "carac2": 9415,
+   "carac3": 15015,
+   "caracs": {
+    "carac1": 3377.5,
+    "carac2": 9415,
+    "carac3": 15015
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1529,
+   "name": "Girl_1529",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1533,
+   "name": "Girl_1533",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2112,
+   "carac2": 858,
+   "carac3": 3630,
+   "caracs": {
+    "carac1": 2112,
+    "carac2": 858,
+    "carac3": 3630
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1535,
+   "name": "Girl_1535",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "D83",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1537,
+   "name": "Girl_1537",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2297.75,
+   "carac2": 1679.125,
+   "carac3": 4860.625,
+   "caracs": {
+    "carac1": 2297.75,
+    "carac2": 1679.125,
+    "carac3": 4860.625
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1540,
+   "name": "Girl_1540",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 6300,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 6300,
+    "carac3": 14437.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1543,
+   "name": "Girl_1543",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5180,
+   "carac2": 5390,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 5180,
+    "carac2": 5390,
+    "carac3": 12127.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1555,
+   "name": "Girl_1555",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 6562.5,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 6562.5,
+    "carac3": 14437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1557,
+   "name": "Girl_1557",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 15.4,
+   "carac2": 9.24,
+   "carac3": 3.92,
+   "caracs": {
+    "carac1": 15.4,
+    "carac2": 9.24,
+    "carac3": 3.92
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1561,
+   "name": "Girl_1561",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1562,
+   "name": "Girl_1562",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 10948,
+   "carac2": 8890,
+   "carac3": 19624.5,
+   "caracs": {
+    "carac1": 10948,
+    "carac2": 8890,
+    "carac3": 19624.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1565,
+   "name": "Girl_1565",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1566,
+   "name": "Girl_1566",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 7612.5,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 7612.5,
+    "carac3": 4200
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1586,
+   "name": "Girl_1586",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 935,
+   "carac3": 1540,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 935,
+    "carac3": 1540
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1600,
+   "name": "Girl_1600",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 687.5,
+   "carac2": 3437.5,
+   "carac3": 2125,
+   "caracs": {
+    "carac1": 687.5,
+    "carac2": 3437.5,
+    "carac3": 2125
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1602,
+   "name": "Girl_1602",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3080,
+   "carac2": 12127.5,
+   "carac3": 7490,
+   "caracs": {
+    "carac1": 3080,
+    "carac2": 12127.5,
+    "carac3": 7490
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1604,
+   "name": "Girl_1604",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 5250,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 5250,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1609,
+   "name": "Girl_1609",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 268,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3685,
+   "carac2": 1072,
+   "carac3": 1943,
+   "caracs": {
+    "carac1": 3685,
+    "carac2": 1072,
+    "carac3": 1943
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1610,
+   "name": "Girl_1610",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 12375,
+   "carac3": 5400,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 12375,
+    "carac3": 5400
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1618,
+   "name": "Girl_1618",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "888",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1620,
+   "name": "Girl_1620",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 3.12,
+   "carac2": 2.28,
+   "carac3": 6.6,
+   "caracs": {
+    "carac1": 3.12,
+    "carac2": 2.28,
+    "carac3": 6.6
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1625,
+   "name": "Girl_1625",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.9,
+   "carac2": 2.6,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 1.9,
+    "carac2": 2.6,
+    "carac3": 5.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1626,
+   "name": "Girl_1626",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1140,
+   "carac2": 2612.5,
+   "carac3": 997.5,
+   "caracs": {
+    "carac1": 1140,
+    "carac2": 2612.5,
+    "carac3": 997.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1638,
+   "name": "Girl_1638",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3158.4,
+   "carac2": 8685.6,
+   "carac3": 4263.84,
+   "caracs": {
+    "carac1": 3158.4,
+    "carac2": 8685.6,
+    "carac3": 4263.84
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1646,
+   "name": "Girl_1646",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6162.5,
+   "carac2": 2975,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 6162.5,
+    "carac2": 2975,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1651,
+   "name": "Girl_1651",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 5037.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 5037.5,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1653,
+   "name": "Girl_1653",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1282.5,
+   "carac2": 2612.5,
+   "carac3": 855,
+   "caracs": {
+    "carac1": 1282.5,
+    "carac2": 2612.5,
+    "carac3": 855
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1654,
+   "name": "Girl_1654",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1848,
+   "carac2": 4235,
+   "carac3": 1617,
+   "caracs": {
+    "carac1": 1848,
+    "carac2": 4235,
+    "carac3": 1617
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1663,
+   "name": "Girl_1663",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 1155,
+   "carac3": 1320,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 1155,
+    "carac3": 1320
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1665,
+   "name": "Girl_1665",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3725,
+   "carac3": 5412.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3725,
+    "carac3": 5412.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1667,
+   "name": "Girl_1667",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6090,
+   "carac2": 3780,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 6090,
+    "carac2": 3780,
+    "carac3": 11550
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1675,
+   "name": "Girl_1675",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 1785,
+   "carac3": 2940,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 1785,
+    "carac3": 2940
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1679,
+   "name": "Girl_1679",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4830,
+   "carac2": 12652.5,
+   "carac3": 5040,
+   "caracs": {
+    "carac1": 4830,
+    "carac2": 12652.5,
+    "carac3": 5040
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1694,
+   "name": "Girl_1694",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6230,
+   "carac2": 4340,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 6230,
+    "carac2": 4340,
+    "carac3": 12127.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1698,
+   "name": "Girl_1698",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2325,
+   "carac2": 1050,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 2325,
+    "carac2": 1050,
+    "carac3": 4125
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1701,
+   "name": "Girl_1701",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1100,
+   "carac2": 1375,
+   "carac3": 3025,
+   "caracs": {
+    "carac1": 1100,
+    "carac2": 1375,
+    "carac3": 3025
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1702,
+   "name": "Girl_1702",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 935,
+   "carac3": 1540,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 935,
+    "carac3": 1540
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1705,
+   "name": "Girl_1705",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 303,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2757.3,
+   "carac2": 2014.95,
+   "carac3": 5832.75,
+   "caracs": {
+    "carac1": 2757.3,
+    "carac2": 2014.95,
+    "carac3": 5832.75
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1717,
+   "name": "Girl_1717",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1718,
+   "name": "Girl_1718",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5635,
+   "carac2": 12197.5,
+   "carac3": 17635.8,
+   "caracs": {
+    "carac1": 5635,
+    "carac2": 12197.5,
+    "carac3": 17635.8
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1727,
+   "name": "Girl_1727",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 5390,
+   "carac3": 5180,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 5390,
+    "carac3": 5180
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1729,
+   "name": "Girl_1729",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1746,
+   "name": "Girl_1746",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1749,
+   "name": "Girl_1749",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♌︎ Lion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1754,
+   "name": "Girl_1754",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 1.5,
+   "carac3": 3,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 1.5,
+    "carac3": 3
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1755,
+   "name": "Girl_1755",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6562.5,
+   "carac2": 14437.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 6562.5,
+    "carac2": 14437.5,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1758,
+   "name": "Girl_1758",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1772,
+   "name": "Girl_1772",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1788,
+   "name": "Girl_1788",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 213,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 1729.56,
+   "carac2": 3280.2,
+   "carac3": 1073.52,
+   "caracs": {
+    "carac1": 1729.56,
+    "carac2": 3280.2,
+    "carac3": 1073.52
+   },
+   "eye_color1": "F99",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1802,
+   "name": "Girl_1802",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 6300,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 6300,
+    "carac3": 14437.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1806,
+   "name": "Girl_1806",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 4287.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 4287.5,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1829,
+   "name": "Girl_1829",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 9898,
+   "carac2": 4900,
+   "carac3": 16978.5,
+   "caracs": {
+    "carac1": 9898,
+    "carac2": 4900,
+    "carac3": 16978.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1830,
+   "name": "Girl_1830",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 251,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3037.1,
+   "carac2": 1214.84,
+   "carac3": 1270.06,
+   "caracs": {
+    "carac1": 3037.1,
+    "carac2": 1214.84,
+    "carac3": 1270.06
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1833,
+   "name": "Girl_1833",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 14437.5,
+   "carac3": 7612.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 14437.5,
+    "carac3": 7612.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1837,
+   "name": "Girl_1837",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6300,
+   "carac2": 17325,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 6300,
+    "carac2": 17325,
+    "carac3": 7875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20,
+      30
+     ],
+     "carac2": [
+      40,
+      20,
+      30
+     ],
+     "carac3": [
+      40,
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1840,
+   "name": "Girl_1840",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1843,
+   "name": "Girl_1843",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 2475,
+   "carac3": 900,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 2475,
+    "carac3": 900
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1849,
+   "name": "Girl_1849",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1725,
+   "carac2": 1650,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1725,
+    "carac2": 1650,
+    "carac3": 4125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1855,
+   "name": "Girl_1855",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "765",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1859,
+   "name": "Girl_1859",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1860,
+   "name": "Girl_1860",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16170,
+   "carac2": 10290,
+   "carac3": 3528,
+   "caracs": {
+    "carac1": 16170,
+    "carac2": 10290,
+    "carac3": 3528
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1864,
+   "name": "Girl_1864",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 1595,
+   "carac3": 880,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 1595,
+    "carac3": 880
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1871,
+   "name": "Girl_1871",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 1350,
+   "carac3": 2025,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 1350,
+    "carac3": 2025
+   },
+   "eye_color1": "000",
+   "hair_color1": "CCC",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1887,
+   "name": "Girl_1887",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "321",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1892,
+   "name": "Girl_1892",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 250,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3850,
+   "carac2": 2450,
+   "carac3": 840,
+   "caracs": {
+    "carac1": 3850,
+    "carac2": 2450,
+    "carac3": 840
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1898,
+   "name": "Girl_1898",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1902,
+   "name": "Girl_1902",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 2025,
+   "carac3": 1350,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 2025,
+    "carac3": 1350
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "321",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1903,
+   "name": "Girl_1903",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1916,
+   "name": "Girl_1916",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1917,
+   "name": "Girl_1917",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1425,
+   "carac2": 1950,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1425,
+    "carac2": 1950,
+    "carac3": 4125
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FFF",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1918,
+   "name": "Girl_1918",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.9,
+   "carac2": 2.6,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 1.9,
+    "carac2": 2.6,
+    "carac3": 5.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1920,
+   "name": "Girl_1920",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1922,
+   "name": "Girl_1922",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1425,
+   "carac2": 4125,
+   "carac3": 1950,
+   "caracs": {
+    "carac1": 1425,
+    "carac2": 4125,
+    "carac3": 1950
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1926,
+   "name": "Girl_1926",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16170,
+   "carac2": 8820,
+   "carac3": 4998,
+   "caracs": {
+    "carac1": 16170,
+    "carac2": 8820,
+    "carac3": 4998
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1928,
+   "name": "Girl_1928",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3000,
+   "carac2": 10312.5,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 3000,
+    "carac2": 10312.5,
+    "carac3": 5437.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1930,
+   "name": "Girl_1930",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1933,
+   "name": "Girl_1933",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1940,
+   "name": "Girl_1940",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1944,
+   "name": "Girl_1944",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 1485,
+   "carac3": 990,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 1485,
+    "carac3": 990
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1945,
+   "name": "Girl_1945",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9450,
+   "carac2": 4725,
+   "carac3": 17325,
+   "caracs": {
+    "carac1": 9450,
+    "carac2": 4725,
+    "carac3": 17325
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1952,
+   "name": "Girl_1952",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1953,
+   "name": "Girl_1953",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1965,
+   "name": "Girl_1965",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 726,
+   "carac2": 3630,
+   "carac3": 2244,
+   "caracs": {
+    "carac1": 726,
+    "carac2": 3630,
+    "carac3": 2244
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1968,
+   "name": "Girl_1968",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1972,
+   "name": "Girl_1972",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1973,
+   "name": "Girl_1973",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1979,
+   "name": "Girl_1979",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1990,
+   "name": "Girl_1990",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3948,
+   "carac2": 3474.24,
+   "carac3": 8685.6,
+   "caracs": {
+    "carac1": 3948,
+    "carac2": 3474.24,
+    "carac3": 8685.6
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2002,
+   "name": "Girl_2002",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3630,
+   "carac2": 1452,
+   "carac3": 1518,
+   "caracs": {
+    "carac1": 3630,
+    "carac2": 1452,
+    "carac3": 1518
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2004,
+   "name": "Girl_2004",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "FFF",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2010,
+   "name": "Girl_2010",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 1045,
+   "carac3": 1430,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 1045,
+    "carac3": 1430
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2011,
+   "name": "Girl_2011",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 251,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 3147.54,
+   "carac2": 1774.0700000000002,
+   "carac3": 801.1899999999999,
+   "caracs": {
+    "carac1": 3147.54,
+    "carac2": 1774.0700000000002,
+    "carac3": 801.1899999999999
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2012,
+   "name": "Girl_2012",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 14437.5,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 14437.5,
+    "carac3": 6300
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2024,
+   "name": "Girl_2024",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2034,
+   "name": "Girl_2034",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 6037.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 6037.5,
+    "carac3": 5775
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2035,
+   "name": "Girl_2035",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2036,
+   "name": "Girl_2036",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2039,
+   "name": "Girl_2039",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 10335,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 10335,
+    "carac3": 4662.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2044,
+   "name": "Girl_2044",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4620,
+   "carac2": 5460,
+   "carac3": 11340,
+   "caracs": {
+    "carac1": 4620,
+    "carac2": 5460,
+    "carac3": 11340
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2045,
+   "name": "Girl_2045",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 2.1,
+   "carac2": 2.4,
+   "carac3": 5.5,
+   "caracs": {
+    "carac1": 2.1,
+    "carac2": 2.4,
+    "carac3": 5.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2054,
+   "name": "Girl_2054",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2065,
+   "name": "Girl_2065",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2066,
+   "name": "Girl_2066",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 10312.5,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 10312.5,
+    "carac3": 3562.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2071,
+   "name": "Girl_2071",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 3.61,
+   "carac2": 4.94,
+   "carac3": 10.45,
+   "caracs": {
+    "carac1": 3.61,
+    "carac2": 4.94,
+    "carac3": 10.45
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2074,
+   "name": "Girl_2074",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7560,
+   "carac2": 17325,
+   "carac3": 6615,
+   "caracs": {
+    "carac1": 7560,
+    "carac2": 17325,
+    "carac3": 6615
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2079,
+   "name": "Girl_2079",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2082,
+   "name": "Girl_2082",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3000,
+   "carac2": 5437.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3000,
+    "carac2": 5437.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♌︎ Lion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2085,
+   "name": "Girl_2085",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 545,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7493.75,
+   "carac2": 2861.25,
+   "carac3": 3270,
+   "caracs": {
+    "carac1": 7493.75,
+    "carac2": 2861.25,
+    "carac3": 3270
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2086,
+   "name": "Girl_2086",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 5175,
+   "carac3": 4950,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 5175,
+    "carac3": 4950
+   },
+   "eye_color1": "A55",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2091,
+   "name": "Girl_2091",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1425,
+   "carac2": 4125,
+   "carac3": 1950,
+   "caracs": {
+    "carac1": 1425,
+    "carac2": 4125,
+    "carac3": 1950
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2094,
+   "name": "Girl_2094",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7612.5,
+   "carac2": 14437.5,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 7612.5,
+    "carac2": 14437.5,
+    "carac3": 4200
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2099,
+   "name": "Girl_2099",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2102,
+   "name": "Girl_2102",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11907,
+   "carac2": 4550,
+   "carac3": 6230,
+   "caracs": {
+    "carac1": 11907,
+    "carac2": 4550,
+    "carac3": 6230
+   },
+   "eye_color1": "F00",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2105,
+   "name": "Girl_2105",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 3,
+   "carac3": 1.5,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 3,
+    "carac3": 1.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2115,
+   "name": "Girl_2115",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2117,
+   "name": "Girl_2117",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "000",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2119,
+   "name": "Girl_2119",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1662.5,
+   "carac2": 2275,
+   "carac3": 4812.5,
+   "caracs": {
+    "carac1": 1662.5,
+    "carac2": 2275,
+    "carac3": 4812.5
+   },
+   "eye_color1": "B06",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2120,
+   "name": "Girl_2120",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 400,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5500,
+   "carac2": 2300,
+   "carac3": 2200,
+   "caracs": {
+    "carac1": 5500,
+    "carac2": 2300,
+    "carac3": 2200
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2121,
+   "name": "Girl_2121",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 9937.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 9937.5,
+    "carac3": 3750
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2125,
+   "name": "Girl_2125",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2126,
+   "name": "Girl_2126",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4.76,
+   "carac2": 15.4,
+   "carac3": 8.4,
+   "caracs": {
+    "carac1": 4.76,
+    "carac2": 15.4,
+    "carac3": 8.4
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2128,
+   "name": "Girl_2128",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3408.75,
+   "carac2": 10415.625,
+   "carac3": 5113.125,
+   "caracs": {
+    "carac1": 3408.75,
+    "carac2": 10415.625,
+    "carac3": 5113.125
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2135,
+   "name": "Girl_2135",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2155,
+   "name": "Girl_2155",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2625,
+   "carac2": 1312.5,
+   "carac3": 4812.5,
+   "caracs": {
+    "carac1": 2625,
+    "carac2": 1312.5,
+    "carac3": 4812.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2158,
+   "name": "Girl_2158",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 5037.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 5037.5,
+    "carac3": 10725
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2165,
+   "name": "Girl_2165",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 1950,
+   "carac3": 1425,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 1950,
+    "carac3": 1425
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2170,
+   "name": "Girl_2170",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 251,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3037.1,
+   "carac2": 938.74,
+   "carac3": 1546.16,
+   "caracs": {
+    "carac1": 3037.1,
+    "carac2": 938.74,
+    "carac3": 1546.16
+   },
+   "eye_color1": "00F",
+   "hair_color1": "CCC",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2177,
+   "name": "Girl_2177",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5412.5,
+   "carac2": 3725,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 5412.5,
+    "carac2": 3725,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2186,
+   "name": "Girl_2186",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 5775,
+   "carac3": 6037.5,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 5775,
+    "carac3": 6037.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2194,
+   "name": "Girl_2194",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 14437.5,
+   "carac3": 7087.5,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 14437.5,
+    "carac3": 7087.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2197,
+   "name": "Girl_2197",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1500,
+   "carac2": 1875,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 1500,
+    "carac2": 1875,
+    "carac3": 4125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2199,
+   "name": "Girl_2199",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3,
+   "carac2": 13.75,
+   "carac3": 8.25,
+   "caracs": {
+    "carac1": 3,
+    "carac2": 13.75,
+    "carac3": 8.25
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2204,
+   "name": "Girl_2204",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2208,
+   "name": "Girl_2208",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 9937.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 9937.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2212,
+   "name": "Girl_2212",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3780,
+   "carac2": 6090,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 3780,
+    "carac2": 6090,
+    "carac3": 11550
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2215,
+   "name": "Girl_2215",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 257,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1464.9,
+   "carac2": 4240.5,
+   "carac3": 2004.6,
+   "caracs": {
+    "carac1": 1464.9,
+    "carac2": 4240.5,
+    "carac3": 2004.6
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2226,
+   "name": "Girl_2226",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2228,
+   "name": "Girl_2228",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2231,
+   "name": "Girl_2231",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 350,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1750,
+   "carac2": 2187.5,
+   "carac3": 4812.5,
+   "caracs": {
+    "carac1": 1750,
+    "carac2": 2187.5,
+    "carac3": 4812.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2236,
+   "name": "Girl_2236",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 564,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8685.6,
+   "carac2": 4421.76,
+   "carac3": 3000.48,
+   "caracs": {
+    "carac1": 8685.6,
+    "carac2": 4421.76,
+    "carac3": 3000.48
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2237,
+   "name": "Girl_2237",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 4687.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 4687.5,
+    "carac3": 3750
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2239,
+   "name": "Girl_2239",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11248.125,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 11248.125,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "A55",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2243,
+   "name": "Girl_2243",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4200,
+   "carac2": 11340,
+   "carac3": 5880,
+   "caracs": {
+    "carac1": 4200,
+    "carac2": 11340,
+    "carac3": 5880
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2246,
+   "name": "Girl_2246",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2205,
+   "carac2": 5775,
+   "carac3": 2520,
+   "caracs": {
+    "carac1": 2205,
+    "carac2": 5775,
+    "carac3": 2520
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2250,
+   "name": "Girl_2250",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2258,
+   "name": "Girl_2258",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 5400,
+   "carac3": 12375,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 5400,
+    "carac3": 12375
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F90",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2260,
+   "name": "Girl_2260",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 15015,
+   "carac2": 5477.5,
+   "carac3": 7315,
+   "caracs": {
+    "carac1": 15015,
+    "carac2": 5477.5,
+    "carac3": 7315
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2270,
+   "name": "Girl_2270",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 880,
+   "carac2": 1595,
+   "carac3": 3025,
+   "caracs": {
+    "carac1": 880,
+    "carac2": 1595,
+    "carac3": 3025
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FD0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2271,
+   "name": "Girl_2271",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 11550,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 11550,
+    "carac3": 4620
+   },
+   "eye_color1": "F00",
+   "hair_color1": "EB8",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2272,
+   "name": "Girl_2272",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2274,
+   "name": "Girl_2274",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2290,
+   "name": "Girl_2290",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4760,
+   "carac2": 6020,
+   "carac3": 11907,
+   "caracs": {
+    "carac1": 4760,
+    "carac2": 6020,
+    "carac3": 11907
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2291,
+   "name": "Girl_2291",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2306,
+   "name": "Girl_2306",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2307,
+   "name": "Girl_2307",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 5625,
+   "carac3": 12375,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 5625,
+    "carac3": 12375
+   },
+   "eye_color1": "F90",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2309,
+   "name": "Girl_2309",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8.4,
+   "carac2": 4.76,
+   "carac3": 15.4,
+   "caracs": {
+    "carac1": 8.4,
+    "carac2": 4.76,
+    "carac3": 15.4
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2310,
+   "name": "Girl_2310",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2326,
+   "name": "Girl_2326",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 5670,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 5670,
+    "carac3": 4200
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2337,
+   "name": "Girl_2337",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.54,
+   "carac2": 7.7,
+   "carac3": 4.76,
+   "caracs": {
+    "carac1": 1.54,
+    "carac2": 7.7,
+    "carac3": 4.76
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2340,
+   "name": "Girl_2340",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2344,
+   "name": "Girl_2344",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5625,
+   "carac2": 10312.5,
+   "carac3": 2812.5,
+   "caracs": {
+    "carac1": 5625,
+    "carac2": 10312.5,
+    "carac3": 2812.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2345,
+   "name": "Girl_2345",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2351,
+   "name": "Girl_2351",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11172,
+   "carac2": 10227,
+   "carac3": 21162.96,
+   "caracs": {
+    "carac1": 11172,
+    "carac2": 10227,
+    "carac3": 21162.96
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2353,
+   "name": "Girl_2353",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1200,
+   "carac2": 4125,
+   "carac3": 2175,
+   "caracs": {
+    "carac1": 1200,
+    "carac2": 4125,
+    "carac3": 2175
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2359,
+   "name": "Girl_2359",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2362,
+   "name": "Girl_2362",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 5250,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 5250,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2364,
+   "name": "Girl_2364",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2369,
+   "name": "Girl_2369",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2375,
+   "name": "Girl_2375",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 300,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1425,
+   "carac2": 4125,
+   "carac3": 1950,
+   "caracs": {
+    "carac1": 1425,
+    "carac2": 4125,
+    "carac3": 1950
+   },
+   "eye_color1": "888",
+   "hair_color1": "A55",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  }
+ ]
+}

--- a/spec/fixtures/hh-bless-cluster-julien.json
+++ b/spec/fixtures/hh-bless-cluster-julien.json
@@ -1,0 +1,20355 @@
+{
+ "_note": "Anonymized from HH - Julien.json (2026-05-26 dump). ids/names replaced with counters. Stats/traits/blessing_bonuses preserved. Reduced to eligible-only (Mythic + Legendary 5*); verified identical blessing detection and built team vs full pool.",
+ "hero": {
+  "class": 1,
+  "level": 0
+ },
+ "active_blessings": [
+  {
+   "title": "Semaine du Blond",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Couleur de cheveux Blond</span> obtiennent <span class=\"blessing-bonus\">+ 40%</span> de bonus sur tous les attributs.",
+   "remaining_time": 494682,
+   "starts_in": -110117
+  },
+  {
+   "title": "Semaine du Balance",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Signe astrologique Balance</span> obtiennent <span class=\"blessing-bonus\">+ 20%</span> de bonus sur tous les attributs.",
+   "remaining_time": 494682,
+   "starts_in": -110117
+  },
+  {
+   "title": "Semaine du Invocatrice de sperme",
+   "description": "Toutes les filles avec <span class=\"blessing-condition\">Rôle Invocatrice de sperme</span> gagnent un bonus de <span class=\"blessing-bonus\">+ 30%</span> sur tous leurs attributs dans Labyrinthe de l’Amour.",
+   "remaining_time": 494682,
+   "starts_in": -110117
+  }
+ ],
+ "girls": [
+  {
+   "id_girl": 132,
+   "name": "Girl_132",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 9750,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 9750,
+    "carac3": 3562.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 144,
+   "name": "Girl_144",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 5775,
+   "carac3": 13650,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 5775,
+    "carac3": 13650
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 146,
+   "name": "Girl_146",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2625,
+   "carac2": 9937.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 2625,
+    "carac2": 9937.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 158,
+   "name": "Girl_158",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3000,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3000,
+    "carac3": 4875
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 198,
+   "name": "Girl_198",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9750,
+   "carac2": 3750,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 9750,
+    "carac2": 3750,
+    "carac3": 4312.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 250,
+   "name": "Girl_250",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 5512.5,
+   "carac3": 13912.5,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 5512.5,
+    "carac3": 13912.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 251,
+   "name": "Girl_251",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4312.5,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4312.5,
+    "carac3": 9937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 254,
+   "name": "Girl_254",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 14175,
+   "carac3": 6037.5,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 14175,
+    "carac3": 6037.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 269,
+   "name": "Girl_269",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10125,
+   "carac2": 4312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10125,
+    "carac2": 4312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 302,
+   "name": "Girl_302",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 304,
+   "name": "Girl_304",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 14.629999999999999,
+   "carac2": 6.12,
+   "carac3": 5.85,
+   "caracs": {
+    "carac1": 14.629999999999999,
+    "carac2": 6.12,
+    "carac3": 5.85
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 309,
+   "name": "Girl_309",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 310,
+   "name": "Girl_310",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 311,
+   "name": "Girl_311",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 5.930000000000001,
+   "carac2": 4.33,
+   "carac3": 12.54,
+   "caracs": {
+    "carac1": 5.930000000000001,
+    "carac2": 4.33,
+    "carac3": 12.54
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20,
+      30
+     ],
+     "carac2": [
+      20,
+      30
+     ],
+     "carac3": [
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 315,
+   "name": "Girl_315",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 318,
+   "name": "Girl_318",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4875,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4875,
+    "carac3": 3562.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 319,
+   "name": "Girl_319",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3825,
+   "carac2": 12375,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 3825,
+    "carac2": 12375,
+    "carac3": 6300
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 325,
+   "name": "Girl_325",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FD0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 328,
+   "name": "Girl_328",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 14437.5,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 14437.5,
+    "carac3": 7875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 331,
+   "name": "Girl_331",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4275,
+   "carac3": 5850,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4275,
+    "carac3": 5850
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 338,
+   "name": "Girl_338",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 348,
+   "name": "Girl_348",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 745,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4589.2,
+   "carac2": 11473,
+   "carac3": 5215,
+   "caracs": {
+    "carac1": 4589.2,
+    "carac2": 11473,
+    "carac3": 5215
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 355,
+   "name": "Girl_355",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 10312.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 10312.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 361,
+   "name": "Girl_361",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6825,
+   "carac2": 13912.5,
+   "carac3": 4725,
+   "caracs": {
+    "carac1": 6825,
+    "carac2": 13912.5,
+    "carac3": 4725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 365,
+   "name": "Girl_365",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 5460,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 5460,
+    "carac3": 4620
+   },
+   "eye_color1": "F00",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 368,
+   "name": "Girl_368",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 749,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3565.24,
+   "carac2": 11534.6,
+   "carac3": 6291.6,
+   "caracs": {
+    "carac1": 3565.24,
+    "carac2": 11534.6,
+    "carac3": 6291.6
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 373,
+   "name": "Girl_373",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 374,
+   "name": "Girl_374",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5437.5,
+   "carac2": 10312.5,
+   "carac3": 3000,
+   "caracs": {
+    "carac1": 5437.5,
+    "carac2": 10312.5,
+    "carac3": 3000
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 378,
+   "name": "Girl_378",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 5062.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 5062.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 380,
+   "name": "Girl_380",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3750,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3750,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 384,
+   "name": "Girl_384",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 12.1,
+   "carac2": 5.72,
+   "carac3": 4.18,
+   "caracs": {
+    "carac1": 12.1,
+    "carac2": 5.72,
+    "carac3": 4.18
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 387,
+   "name": "Girl_387",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4604.6,
+   "carac2": 4404.4,
+   "carac3": 11011,
+   "caracs": {
+    "carac1": 4604.6,
+    "carac2": 4404.4,
+    "carac3": 11011
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 397,
+   "name": "Girl_397",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 408,
+   "name": "Girl_408",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 409,
+   "name": "Girl_409",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3000,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3000,
+    "carac3": 10125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 410,
+   "name": "Girl_410",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 411,
+   "name": "Girl_411",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4830,
+   "carac2": 5040,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 4830,
+    "carac2": 5040,
+    "carac3": 11550
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 412,
+   "name": "Girl_412",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5625,
+   "carac3": 2812.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5625,
+    "carac3": 2812.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 433,
+   "name": "Girl_433",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 434,
+   "name": "Girl_434",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 435,
+   "name": "Girl_435",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7087.5,
+   "carac2": 4725,
+   "carac3": 13912.5,
+   "caracs": {
+    "carac1": 7087.5,
+    "carac2": 4725,
+    "carac3": 13912.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 440,
+   "name": "Girl_440",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3000,
+   "carac2": 5437.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3000,
+    "carac2": 5437.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 441,
+   "name": "Girl_441",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 444,
+   "name": "Girl_444",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 450,
+   "name": "Girl_450",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3675,
+   "carac2": 14437.5,
+   "carac3": 8137.5,
+   "caracs": {
+    "carac1": 3675,
+    "carac2": 14437.5,
+    "carac3": 8137.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 451,
+   "name": "Girl_451",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3000,
+   "carac2": 10312.5,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 3000,
+    "carac2": 10312.5,
+    "carac3": 5437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 453,
+   "name": "Girl_453",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 460,
+   "name": "Girl_460",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 12375,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 12375,
+    "carac3": 5625
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 467,
+   "name": "Girl_467",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 10312.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 10312.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "EB8",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 478,
+   "name": "Girl_478",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 488,
+   "name": "Girl_488",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 493,
+   "name": "Girl_493",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 10312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 10312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 494,
+   "name": "Girl_494",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3234,
+   "carac2": 11858,
+   "carac3": 6468,
+   "caracs": {
+    "carac1": 3234,
+    "carac2": 11858,
+    "carac3": 6468
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 498,
+   "name": "Girl_498",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 499,
+   "name": "Girl_499",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 10241,
+   "carac2": 3910.2,
+   "carac3": 4468.8,
+   "caracs": {
+    "carac1": 10241,
+    "carac2": 3910.2,
+    "carac3": 4468.8
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 500,
+   "name": "Girl_500",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F90",
+   "hair_color1": "EB8",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 519,
+   "name": "Girl_519",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 523,
+   "name": "Girl_523",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4500,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4500,
+    "carac3": 5625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 526,
+   "name": "Girl_526",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 10312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 10312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 534,
+   "name": "Girl_534",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3375,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3375,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 535,
+   "name": "Girl_535",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 88,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 334.4,
+   "carac2": 919.6,
+   "carac3": 418,
+   "caracs": {
+    "carac1": 334.4,
+    "carac2": 919.6,
+    "carac3": 418
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 549,
+   "name": "Girl_549",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 550,
+   "name": "Girl_550",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F90",
+   "hair_color1": "CCC",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 551,
+   "name": "Girl_551",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 7875,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 7875,
+    "carac3": 3937.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 553,
+   "name": "Girl_553",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4387.5,
+   "carac2": 2925,
+   "carac3": 8937.5,
+   "caracs": {
+    "carac1": 4387.5,
+    "carac2": 2925,
+    "carac3": 8937.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 554,
+   "name": "Girl_554",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4410,
+   "carac2": 5670,
+   "carac3": 11340,
+   "caracs": {
+    "carac1": 4410,
+    "carac2": 5670,
+    "carac3": 11340
+   },
+   "eye_color1": "00F",
+   "hair_color1": "XXX",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 556,
+   "name": "Girl_556",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 557,
+   "name": "Girl_557",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "321",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 558,
+   "name": "Girl_558",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9870,
+   "carac2": 16957.5,
+   "carac3": 6982.5,
+   "caracs": {
+    "carac1": 9870,
+    "carac2": 16957.5,
+    "carac3": 6982.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 560,
+   "name": "Girl_560",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5215,
+   "carac2": 7577.5,
+   "carac3": 15015,
+   "caracs": {
+    "carac1": 5215,
+    "carac2": 7577.5,
+    "carac3": 15015
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 566,
+   "name": "Girl_566",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4687.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4687.5,
+    "carac3": 3750
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 573,
+   "name": "Girl_573",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5145,
+   "carac2": 5880,
+   "carac3": 13475,
+   "caracs": {
+    "carac1": 5145,
+    "carac2": 5880,
+    "carac3": 13475
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 582,
+   "name": "Girl_582",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 591,
+   "name": "Girl_591",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10832.25,
+   "carac2": 6034.75,
+   "carac3": 3194.125,
+   "caracs": {
+    "carac1": 10832.25,
+    "carac2": 6034.75,
+    "carac3": 3194.125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 592,
+   "name": "Girl_592",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4709.125,
+   "carac2": 10832.25,
+   "carac3": 4519.75,
+   "caracs": {
+    "carac1": 4709.125,
+    "carac2": 10832.25,
+    "carac3": 4519.75
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 594,
+   "name": "Girl_594",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 601,
+   "name": "Girl_601",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4550,
+   "carac2": 9625,
+   "carac3": 3325,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 9625,
+    "carac3": 3325
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 604,
+   "name": "Girl_604",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3485,
+   "carac2": 9438,
+   "carac3": 4640,
+   "caracs": {
+    "carac1": 3485,
+    "carac2": 9438,
+    "carac3": 4640
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 610,
+   "name": "Girl_610",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14014,
+   "carac2": 5145,
+   "carac3": 6860,
+   "caracs": {
+    "carac1": 14014,
+    "carac2": 5145,
+    "carac3": 6860
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 613,
+   "name": "Girl_613",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 4830,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 4830,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 615,
+   "name": "Girl_615",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4287.5,
+   "carac2": 4850,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4287.5,
+    "carac2": 4850,
+    "carac3": 10725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 619,
+   "name": "Girl_619",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4475,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4475,
+    "carac3": 4662.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "XXX",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 622,
+   "name": "Girl_622",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5460,
+   "carac2": 11550,
+   "carac3": 4410,
+   "caracs": {
+    "carac1": 5460,
+    "carac2": 11550,
+    "carac3": 4410
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 623,
+   "name": "Girl_623",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 3750,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 3750,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 637,
+   "name": "Girl_637",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5037.5,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5037.5,
+    "carac3": 4100
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 638,
+   "name": "Girl_638",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 640,
+   "name": "Girl_640",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 6162.5,
+   "carac3": 2975,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 6162.5,
+    "carac3": 2975
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 642,
+   "name": "Girl_642",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6292.3,
+   "carac2": 4595.5,
+   "carac3": 12026.07,
+   "caracs": {
+    "carac1": 6292.3,
+    "carac2": 4595.5,
+    "carac3": 12026.07
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 653,
+   "name": "Girl_653",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 655,
+   "name": "Girl_655",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 656,
+   "name": "Girl_656",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 7.7,
+   "carac2": 4.2,
+   "carac3": 2.1,
+   "caracs": {
+    "carac1": 7.7,
+    "carac2": 4.2,
+    "carac3": 2.1
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 661,
+   "name": "Girl_661",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "EB8",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 667,
+   "name": "Girl_667",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4130,
+   "carac2": 12127.5,
+   "carac3": 6440,
+   "caracs": {
+    "carac1": 4130,
+    "carac2": 12127.5,
+    "carac3": 6440
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 673,
+   "name": "Girl_673",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3537.5,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3537.5,
+    "carac3": 5600
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 675,
+   "name": "Girl_675",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2112.5,
+   "carac2": 8937.5,
+   "carac3": 5200,
+   "caracs": {
+    "carac1": 2112.5,
+    "carac2": 8937.5,
+    "carac3": 5200
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FD0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 677,
+   "name": "Girl_677",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 9937.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 9937.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 691,
+   "name": "Girl_691",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 695,
+   "name": "Girl_695",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 700,
+   "name": "Girl_700",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 11248.125,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 11248.125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 710,
+   "name": "Girl_710",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 714,
+   "name": "Girl_714",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 9937.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 9937.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "CCC",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 719,
+   "name": "Girl_719",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12026.07,
+   "carac2": 5443.9,
+   "carac3": 5443.9,
+   "caracs": {
+    "carac1": 12026.07,
+    "carac2": 5443.9,
+    "carac3": 5443.9
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 720,
+   "name": "Girl_720",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7875,
+   "carac2": 14437.5,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 7875,
+    "carac2": 14437.5,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 724,
+   "name": "Girl_724",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7735,
+   "carac2": 17635.8,
+   "carac3": 10097.5,
+   "caracs": {
+    "carac1": 7735,
+    "carac2": 17635.8,
+    "carac3": 10097.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 726,
+   "name": "Girl_726",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2975,
+   "carac2": 9625,
+   "carac3": 4900,
+   "caracs": {
+    "carac1": 2975,
+    "carac2": 9625,
+    "carac3": 4900
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 728,
+   "name": "Girl_728",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3537.5,
+   "carac2": 5600,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 3537.5,
+    "carac2": 5600,
+    "carac3": 10725
+   },
+   "eye_color1": "A55",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 730,
+   "name": "Girl_730",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4687.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4687.5,
+    "carac3": 3750
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 736,
+   "name": "Girl_736",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 742,
+   "name": "Girl_742",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1092.5,
+   "carac2": 1045,
+   "carac3": 2612.5,
+   "caracs": {
+    "carac1": 1092.5,
+    "carac2": 1045,
+    "carac3": 2612.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 749,
+   "name": "Girl_749",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5302.5,
+   "carac2": 10415.625,
+   "carac3": 3219.375,
+   "caracs": {
+    "carac1": 5302.5,
+    "carac2": 10415.625,
+    "carac3": 3219.375
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 753,
+   "name": "Girl_753",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FFF",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 761,
+   "name": "Girl_761",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 5512.5,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 5512.5,
+    "carac3": 6300
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 763,
+   "name": "Girl_763",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4025,
+   "carac2": 9625,
+   "carac3": 3850,
+   "caracs": {
+    "carac1": 4025,
+    "carac2": 9625,
+    "carac3": 3850
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 768,
+   "name": "Girl_768",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4507.125,
+   "carac2": 7423.5,
+   "carac3": 14581.875,
+   "caracs": {
+    "carac1": 4507.125,
+    "carac2": 7423.5,
+    "carac3": 14581.875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 769,
+   "name": "Girl_769",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 10312.5,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 10312.5,
+    "carac3": 3187.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 774,
+   "name": "Girl_774",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3850,
+   "carac2": 4025,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 3850,
+    "carac2": 4025,
+    "carac3": 9625
+   },
+   "eye_color1": "F90",
+   "hair_color1": "00F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 775,
+   "name": "Girl_775",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 777,
+   "name": "Girl_777",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 5625,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 5625,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 790,
+   "name": "Girl_790",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12248.775,
+   "carac2": 5231.8,
+   "carac3": 5443.9,
+   "caracs": {
+    "carac1": 12248.775,
+    "carac2": 5231.8,
+    "carac3": 5443.9
+   },
+   "eye_color1": "F00",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 800,
+   "name": "Girl_800",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 937.5,
+   "carac2": 3437.5,
+   "carac3": 1875,
+   "caracs": {
+    "carac1": 937.5,
+    "carac2": 3437.5,
+    "carac3": 1875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 805,
+   "name": "Girl_805",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2772,
+   "carac2": 8470,
+   "carac3": 4158,
+   "caracs": {
+    "carac1": 2772,
+    "carac2": 8470,
+    "carac3": 4158
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 808,
+   "name": "Girl_808",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4734.375,
+   "carac2": 3787.5,
+   "carac3": 10415.625,
+   "caracs": {
+    "carac1": 4734.375,
+    "carac2": 3787.5,
+    "carac3": 10415.625
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 819,
+   "name": "Girl_819",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 5437.5,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 5437.5,
+    "carac3": 9937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 825,
+   "name": "Girl_825",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 832,
+   "name": "Girl_832",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 835,
+   "name": "Girl_835",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6720,
+   "carac2": 14553,
+   "carac3": 5964,
+   "caracs": {
+    "carac1": 6720,
+    "carac2": 14553,
+    "carac3": 5964
+   },
+   "eye_color1": "A55",
+   "hair_color1": "321",
+   "zodiac": "♎︎ Balance",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 840,
+   "name": "Girl_840",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4025,
+   "carac2": 3850,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4025,
+    "carac2": 3850,
+    "carac3": 9625
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 853,
+   "name": "Girl_853",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5037.5,
+   "carac2": 10725,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 5037.5,
+    "carac2": 10725,
+    "carac3": 4100
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 862,
+   "name": "Girl_862",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7350,
+   "carac2": 13475,
+   "carac3": 3675,
+   "caracs": {
+    "carac1": 7350,
+    "carac2": 13475,
+    "carac3": 3675
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 867,
+   "name": "Girl_867",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5040,
+   "carac2": 11550,
+   "carac3": 4830,
+   "caracs": {
+    "carac1": 5040,
+    "carac2": 11550,
+    "carac3": 4830
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 871,
+   "name": "Girl_871",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3162.5,
+   "carac2": 10725,
+   "carac3": 5975,
+   "caracs": {
+    "carac1": 3162.5,
+    "carac2": 10725,
+    "carac3": 5975
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 873,
+   "name": "Girl_873",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 4830,
+   "carac3": 5040,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 4830,
+    "carac3": 5040
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FD0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 874,
+   "name": "Girl_874",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4777.5,
+   "carac2": 12512.5,
+   "carac3": 5460,
+   "caracs": {
+    "carac1": 4777.5,
+    "carac2": 12512.5,
+    "carac3": 5460
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 876,
+   "name": "Girl_876",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 8148,
+   "carac2": 18018,
+   "carac3": 7203,
+   "caracs": {
+    "carac1": 8148,
+    "carac2": 18018,
+    "carac3": 7203
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20,
+      30
+     ],
+     "carac2": [
+      40,
+      20,
+      30
+     ],
+     "carac3": [
+      40,
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 881,
+   "name": "Girl_881",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 11550,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 11550,
+    "carac3": 4620
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 883,
+   "name": "Girl_883",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 887,
+   "name": "Girl_887",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4695,
+   "carac2": 6270,
+   "carac3": 12870,
+   "caracs": {
+    "carac1": 4695,
+    "carac2": 6270,
+    "carac3": 12870
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 892,
+   "name": "Girl_892",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10621.875,
+   "carac2": 5793.75,
+   "carac3": 2896.875,
+   "caracs": {
+    "carac1": 10621.875,
+    "carac2": 5793.75,
+    "carac3": 2896.875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 893,
+   "name": "Girl_893",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5412.5,
+   "carac2": 10725,
+   "carac3": 3725,
+   "caracs": {
+    "carac1": 5412.5,
+    "carac2": 10725,
+    "carac3": 3725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 896,
+   "name": "Girl_896",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3912.5,
+   "carac3": 5225,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3912.5,
+    "carac3": 5225
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "EB8",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 901,
+   "name": "Girl_901",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11248.125,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 11248.125,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 905,
+   "name": "Girl_905",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4550,
+   "carac2": 3325,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 3325,
+    "carac3": 9625
+   },
+   "eye_color1": "888",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 910,
+   "name": "Girl_910",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4500,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4500,
+    "carac3": 10125
+   },
+   "eye_color1": "B06",
+   "hair_color1": "888",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 912,
+   "name": "Girl_912",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 916,
+   "name": "Girl_916",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 571,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6523.1,
+   "carac2": 2494.13,
+   "carac3": 10552.08,
+   "caracs": {
+    "carac1": 6523.1,
+    "carac2": 2494.13,
+    "carac3": 10552.08
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 926,
+   "name": "Girl_926",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1694,
+   "carac2": 8470,
+   "carac3": 5236,
+   "caracs": {
+    "carac1": 1694,
+    "carac2": 8470,
+    "carac3": 5236
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 928,
+   "name": "Girl_928",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 450,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2925,
+   "carac2": 2137.5,
+   "carac3": 6187.5,
+   "caracs": {
+    "carac1": 2925,
+    "carac2": 2137.5,
+    "carac3": 6187.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "CCC",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 930,
+   "name": "Girl_930",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5880,
+   "carac2": 16170,
+   "carac3": 7938,
+   "caracs": {
+    "carac1": 5880,
+    "carac2": 16170,
+    "carac3": 7938
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 931,
+   "name": "Girl_931",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4287.5,
+   "carac3": 4850,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4287.5,
+    "carac3": 4850
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 934,
+   "name": "Girl_934",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 19624.5,
+   "carac2": 12124,
+   "carac3": 7714,
+   "caracs": {
+    "carac1": 19624.5,
+    "carac2": 12124,
+    "carac3": 7714
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 936,
+   "name": "Girl_936",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 88,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 919.6,
+   "carac2": 518.32,
+   "carac3": 234.08,
+   "caracs": {
+    "carac1": 919.6,
+    "carac2": 518.32,
+    "carac3": 234.08
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 939,
+   "name": "Girl_939",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 10725,
+   "carac3": 4287.5,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 10725,
+    "carac3": 4287.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 941,
+   "name": "Girl_941",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 55,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 426.25,
+   "carac2": 192.5,
+   "carac3": 756.25,
+   "caracs": {
+    "carac1": 426.25,
+    "carac2": 192.5,
+    "carac3": 756.25
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 945,
+   "name": "Girl_945",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 745,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11473,
+   "carac2": 3963.4,
+   "carac3": 5840.8,
+   "caracs": {
+    "carac1": 11473,
+    "carac2": 3963.4,
+    "carac3": 5840.8
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 951,
+   "name": "Girl_951",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4875,
+   "carac3": 10125,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4875,
+    "carac3": 10125
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FD0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 955,
+   "name": "Girl_955",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3350,
+   "carac3": 5787.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3350,
+    "carac3": 5787.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 956,
+   "name": "Girl_956",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 960,
+   "name": "Girl_960",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6537.5,
+   "carac2": 2600,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 6537.5,
+    "carac2": 2600,
+    "carac3": 10725
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FFF",
+   "zodiac": "♌︎ Lion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 962,
+   "name": "Girl_962",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5437.5,
+   "carac2": 3000,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5437.5,
+    "carac2": 3000,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 965,
+   "name": "Girl_965",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 3570,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 3570,
+    "carac3": 6300
+   },
+   "eye_color1": "00F",
+   "hair_color1": "CCC",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 967,
+   "name": "Girl_967",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4287.5,
+   "carac3": 4850,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4287.5,
+    "carac3": 4850
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 973,
+   "name": "Girl_973",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5437.5,
+   "carac2": 3000,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5437.5,
+    "carac2": 3000,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 974,
+   "name": "Girl_974",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6440,
+   "carac2": 12127.5,
+   "carac3": 4130,
+   "caracs": {
+    "carac1": 6440,
+    "carac2": 12127.5,
+    "carac3": 4130
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 976,
+   "name": "Girl_976",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 3500,
+   "carac3": 4375,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 3500,
+    "carac3": 4375
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 979,
+   "name": "Girl_979",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5600,
+   "carac3": 3537.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5600,
+    "carac3": 3537.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 981,
+   "name": "Girl_981",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 13912.5,
+   "carac2": 3937.5,
+   "carac3": 7612.5,
+   "caracs": {
+    "carac1": 13912.5,
+    "carac2": 3937.5,
+    "carac3": 7612.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 984,
+   "name": "Girl_984",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6037.5,
+   "carac2": 5775,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 6037.5,
+    "carac2": 5775,
+    "carac3": 14437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 987,
+   "name": "Girl_987",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4550,
+   "carac2": 3325,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 3325,
+    "carac3": 9625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 992,
+   "name": "Girl_992",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6872.04,
+   "carac2": 5090.4,
+   "carac3": 13998.6,
+   "caracs": {
+    "carac1": 6872.04,
+    "carac2": 5090.4,
+    "carac3": 13998.6
+   },
+   "eye_color1": "A55",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 994,
+   "name": "Girl_994",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2787.5,
+   "carac2": 10530,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 2787.5,
+    "carac2": 10530,
+    "carac3": 5600
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 995,
+   "name": "Girl_995",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6829.62,
+   "carac2": 7126.5599999999995,
+   "carac3": 16331.7,
+   "caracs": {
+    "carac1": 6829.62,
+    "carac2": 7126.5599999999995,
+    "carac3": 16331.7
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 996,
+   "name": "Girl_996",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5600,
+   "carac3": 3537.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5600,
+    "carac3": 3537.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1000,
+   "name": "Girl_1000",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10125,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10125,
+    "carac3": 4875
+   },
+   "eye_color1": "F90",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1002,
+   "name": "Girl_1002",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5231.8,
+   "carac2": 12026.07,
+   "carac3": 5656,
+   "caracs": {
+    "carac1": 5231.8,
+    "carac2": 12026.07,
+    "carac3": 5656
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1008,
+   "name": "Girl_1008",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 4287.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 4287.5,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1012,
+   "name": "Girl_1012",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5180,
+   "carac2": 12127.5,
+   "carac3": 5390,
+   "caracs": {
+    "carac1": 5180,
+    "carac2": 12127.5,
+    "carac3": 5390
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1021,
+   "name": "Girl_1021",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6037.5,
+   "carac2": 14437.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 6037.5,
+    "carac2": 14437.5,
+    "carac3": 5775
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1030,
+   "name": "Girl_1030",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 745,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11473,
+   "carac2": 7718.2,
+   "carac3": 2086,
+   "caracs": {
+    "carac1": 11473,
+    "carac2": 7718.2,
+    "carac3": 2086
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1033,
+   "name": "Girl_1033",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4802.375,
+   "carac2": 11046.75,
+   "carac3": 4609.25,
+   "caracs": {
+    "carac1": 4802.375,
+    "carac2": 11046.75,
+    "carac3": 4609.25
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1035,
+   "name": "Girl_1035",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4287.5,
+   "carac3": 4850,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4287.5,
+    "carac3": 4850
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1036,
+   "name": "Girl_1036",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6075,
+   "carac2": 12375,
+   "carac3": 4050,
+   "caracs": {
+    "carac1": 6075,
+    "carac2": 12375,
+    "carac3": 4050
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20,
+      30
+     ],
+     "carac2": [
+      20,
+      30
+     ],
+     "carac3": [
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1043,
+   "name": "Girl_1043",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2618,
+   "carac2": 4312,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 2618,
+    "carac2": 4312,
+    "carac3": 8470
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1044,
+   "name": "Girl_1044",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2062.5,
+   "carac2": 10312.5,
+   "carac3": 6375,
+   "caracs": {
+    "carac1": 2062.5,
+    "carac2": 10312.5,
+    "carac3": 6375
+   },
+   "eye_color1": "888",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1049,
+   "name": "Girl_1049",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1056,
+   "name": "Girl_1056",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 600,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11550,
+   "carac2": 5460,
+   "carac3": 3990,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 5460,
+    "carac3": 3990
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1063,
+   "name": "Girl_1063",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 10725,
+   "carac3": 5037.5,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 10725,
+    "carac3": 5037.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1069,
+   "name": "Girl_1069",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5975,
+   "carac2": 2975,
+   "carac3": 10335,
+   "caracs": {
+    "carac1": 5975,
+    "carac2": 2975,
+    "carac3": 10335
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1078,
+   "name": "Girl_1078",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4550,
+   "carac2": 9625,
+   "carac3": 3325,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 9625,
+    "carac3": 3325
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B62",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1086,
+   "name": "Girl_1086",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4287.5,
+   "carac2": 4850,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4287.5,
+    "carac2": 4850,
+    "carac3": 10725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "EB8",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1094,
+   "name": "Girl_1094",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3437.5,
+   "carac2": 1375,
+   "carac3": 1437.5,
+   "caracs": {
+    "carac1": 3437.5,
+    "carac2": 1375,
+    "carac3": 1437.5
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1097,
+   "name": "Girl_1097",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1098,
+   "name": "Girl_1098",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 2625,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 2625,
+    "carac3": 5250
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1109,
+   "name": "Girl_1109",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4620,
+   "carac2": 11340,
+   "carac3": 5460,
+   "caracs": {
+    "carac1": 4620,
+    "carac2": 11340,
+    "carac3": 5460
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1117,
+   "name": "Girl_1117",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 3187.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 3187.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1127,
+   "name": "Girl_1127",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 103,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 383.57000000000005,
+   "carac2": 1506.8899999999999,
+   "carac3": 849.3399999999999,
+   "caracs": {
+    "carac1": 383.57000000000005,
+    "carac2": 1506.8899999999999,
+    "carac3": 849.3399999999999
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1131,
+   "name": "Girl_1131",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14175,
+   "carac2": 3937.5,
+   "carac3": 6825,
+   "caracs": {
+    "carac1": 14175,
+    "carac2": 3937.5,
+    "carac3": 6825
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1136,
+   "name": "Girl_1136",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "XXX",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1141,
+   "name": "Girl_1141",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3675,
+   "carac2": 9625,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 3675,
+    "carac2": 9625,
+    "carac3": 4200
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1146,
+   "name": "Girl_1146",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 4050,
+   "carac3": 6075,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 4050,
+    "carac3": 6075
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1152,
+   "name": "Girl_1152",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11046.75,
+   "carac2": 3643.625,
+   "carac3": 5768,
+   "caracs": {
+    "carac1": 11046.75,
+    "carac2": 3643.625,
+    "carac3": 5768
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1154,
+   "name": "Girl_1154",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2112,
+   "carac2": 858,
+   "carac3": 3630,
+   "caracs": {
+    "carac1": 2112,
+    "carac2": 858,
+    "carac3": 3630
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1157,
+   "name": "Girl_1157",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4200,
+   "carac2": 11340,
+   "carac3": 5880,
+   "caracs": {
+    "carac1": 4200,
+    "carac2": 11340,
+    "carac3": 5880
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1158,
+   "name": "Girl_1158",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1161,
+   "name": "Girl_1161",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4576,
+   "carac2": 1859,
+   "carac3": 7865,
+   "caracs": {
+    "carac1": 4576,
+    "carac2": 1859,
+    "carac3": 7865
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1162,
+   "name": "Girl_1162",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 7700,
+   "carac3": 2870,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 7700,
+    "carac3": 2870
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1166,
+   "name": "Girl_1166",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3283.125,
+   "carac2": 5407.5,
+   "carac3": 10621.875,
+   "caracs": {
+    "carac1": 3283.125,
+    "carac2": 5407.5,
+    "carac3": 10621.875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1169,
+   "name": "Girl_1169",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 6440,
+   "carac3": 4130,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 6440,
+    "carac3": 4130
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1170,
+   "name": "Girl_1170",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5775,
+   "carac2": 14175,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 5775,
+    "carac2": 14175,
+    "carac3": 6300
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1173,
+   "name": "Girl_1173",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3912.5,
+   "carac2": 10725,
+   "carac3": 5225,
+   "caracs": {
+    "carac1": 3912.5,
+    "carac2": 10725,
+    "carac3": 5225
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1180,
+   "name": "Girl_1180",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3675,
+   "carac2": 9625,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 3675,
+    "carac2": 9625,
+    "carac3": 4200
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1184,
+   "name": "Girl_1184",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6230,
+   "carac2": 4340,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 6230,
+    "carac2": 4340,
+    "carac3": 12127.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FFF",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1185,
+   "name": "Girl_1185",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 600,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3900,
+   "carac2": 2850,
+   "carac3": 8250,
+   "caracs": {
+    "carac1": 3900,
+    "carac2": 2850,
+    "carac3": 8250
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1188,
+   "name": "Girl_1188",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1190,
+   "name": "Girl_1190",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3325,
+   "carac2": 9625,
+   "carac3": 4550,
+   "caracs": {
+    "carac1": 3325,
+    "carac2": 9625,
+    "carac3": 4550
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1194,
+   "name": "Girl_1194",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 5390,
+   "carac2": 1540,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 5390,
+    "carac2": 1540,
+    "carac3": 8470
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1199,
+   "name": "Girl_1199",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1207,
+   "name": "Girl_1207",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5820,
+   "carac2": 5145,
+   "carac3": 12870,
+   "caracs": {
+    "carac1": 5820,
+    "carac2": 5145,
+    "carac3": 12870
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1208,
+   "name": "Girl_1208",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5975,
+   "carac3": 3162.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5975,
+    "carac3": 3162.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1215,
+   "name": "Girl_1215",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 5390,
+   "carac2": 1540,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 5390,
+    "carac2": 1540,
+    "carac3": 8470
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "B06",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1220,
+   "name": "Girl_1220",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1223,
+   "name": "Girl_1223",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3542,
+   "carac2": 3388,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 3542,
+    "carac2": 3388,
+    "carac3": 8470
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1236,
+   "name": "Girl_1236",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 11550,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 11550,
+    "carac3": 4620
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1241,
+   "name": "Girl_1241",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1246,
+   "name": "Girl_1246",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 11248.125,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 11248.125
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1254,
+   "name": "Girl_1254",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 10312.5,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 10312.5,
+    "carac3": 4312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1255,
+   "name": "Girl_1255",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3187.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3187.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1262,
+   "name": "Girl_1262",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4004,
+   "carac2": 2926,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 4004,
+    "carac2": 2926,
+    "carac3": 8470
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1268,
+   "name": "Girl_1268",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4987.5,
+   "carac2": 6825,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 4987.5,
+    "carac2": 6825,
+    "carac3": 14437.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1271,
+   "name": "Girl_1271",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 10312.5,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 10312.5,
+    "carac3": 3187.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1272,
+   "name": "Girl_1272",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1282,
+   "name": "Girl_1282",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10832.25,
+   "carac2": 6034.75,
+   "carac3": 3194.125,
+   "caracs": {
+    "carac1": 10832.25,
+    "carac2": 6034.75,
+    "carac3": 3194.125
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1284,
+   "name": "Girl_1284",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 17089.8,
+   "carac2": 6947.5,
+   "carac3": 10360,
+   "caracs": {
+    "carac1": 17089.8,
+    "carac2": 6947.5,
+    "carac3": 10360
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1286,
+   "name": "Girl_1286",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1287,
+   "name": "Girl_1287",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3542,
+   "carac2": 3388,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 3542,
+    "carac2": 3388,
+    "carac3": 8470
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1296,
+   "name": "Girl_1296",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 1.1,
+   "carac2": 5.5,
+   "carac3": 3.4,
+   "caracs": {
+    "carac1": 1.1,
+    "carac2": 5.5,
+    "carac3": 3.4
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1300,
+   "name": "Girl_1300",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3234,
+   "carac2": 3696,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 3234,
+    "carac2": 3696,
+    "carac3": 8470
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1307,
+   "name": "Girl_1307",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "F90",
+   "hair_color1": "A55",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1308,
+   "name": "Girl_1308",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 5625,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 5625,
+    "carac3": 9937.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1313,
+   "name": "Girl_1313",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 6037.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 6037.5,
+    "carac3": 5775
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1321,
+   "name": "Girl_1321",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11340,
+   "carac2": 4410,
+   "carac3": 5670,
+   "caracs": {
+    "carac1": 11340,
+    "carac2": 4410,
+    "carac3": 5670
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1331,
+   "name": "Girl_1331",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1339,
+   "name": "Girl_1339",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 15015,
+   "carac2": 4427.5,
+   "carac3": 8365,
+   "caracs": {
+    "carac1": 15015,
+    "carac2": 4427.5,
+    "carac3": 8365
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1342,
+   "name": "Girl_1342",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 6252.4,
+   "carac2": 3449.6,
+   "carac3": 11858,
+   "caracs": {
+    "carac1": 6252.4,
+    "carac2": 3449.6,
+    "carac3": 11858
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1349,
+   "name": "Girl_1349",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5600,
+   "carac2": 12127.5,
+   "carac3": 4970,
+   "caracs": {
+    "carac1": 5600,
+    "carac2": 12127.5,
+    "carac3": 4970
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1352,
+   "name": "Girl_1352",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4475,
+   "carac2": 10725,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4475,
+    "carac2": 10725,
+    "carac3": 4662.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1353,
+   "name": "Girl_1353",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3880.8,
+   "carac2": 11858,
+   "carac3": 5821.2,
+   "caracs": {
+    "carac1": 3880.8,
+    "carac2": 11858,
+    "carac3": 5821.2
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1354,
+   "name": "Girl_1354",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4662.5,
+   "carac2": 10725,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 4662.5,
+    "carac2": 10725,
+    "carac3": 4475
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1356,
+   "name": "Girl_1356",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2310,
+   "carac2": 11550,
+   "carac3": 7140,
+   "caracs": {
+    "carac1": 2310,
+    "carac2": 11550,
+    "carac3": 7140
+   },
+   "eye_color1": "00F",
+   "hair_color1": "321",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1361,
+   "name": "Girl_1361",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 8120,
+   "carac2": 2450,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 8120,
+    "carac2": 2450,
+    "carac3": 12127.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1362,
+   "name": "Girl_1362",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10125,
+   "carac2": 4125,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10125,
+    "carac2": 4125,
+    "carac3": 4500
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1365,
+   "name": "Girl_1365",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5037.5,
+   "carac2": 10725,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 5037.5,
+    "carac2": 10725,
+    "carac3": 4100
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "B62",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1372,
+   "name": "Girl_1372",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4662.5,
+   "carac2": 10725,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 4662.5,
+    "carac2": 10725,
+    "carac3": 4475
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1373,
+   "name": "Girl_1373",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3850,
+   "carac2": 9625,
+   "carac3": 4025,
+   "caracs": {
+    "carac1": 3850,
+    "carac2": 9625,
+    "carac3": 4025
+   },
+   "eye_color1": "F00",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1377,
+   "name": "Girl_1377",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1378,
+   "name": "Girl_1378",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1380,
+   "name": "Girl_1380",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4898.5,
+   "carac2": 10832.25,
+   "carac3": 4330.375,
+   "caracs": {
+    "carac1": 4898.5,
+    "carac2": 10832.25,
+    "carac3": 4330.375
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1381,
+   "name": "Girl_1381",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5075,
+   "carac2": 9625,
+   "carac3": 2800,
+   "caracs": {
+    "carac1": 5075,
+    "carac2": 9625,
+    "carac3": 2800
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1382,
+   "name": "Girl_1382",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 4287.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 4287.5,
+    "carac3": 10725
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1384,
+   "name": "Girl_1384",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4025,
+   "carac2": 3850,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4025,
+    "carac2": 3850,
+    "carac3": 9625
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1385,
+   "name": "Girl_1385",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F99",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1386,
+   "name": "Girl_1386",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1396,
+   "name": "Girl_1396",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5062.5,
+   "carac2": 3375,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5062.5,
+    "carac2": 3375,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "00F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1400,
+   "name": "Girl_1400",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 4.2,
+   "carac2": 9.24,
+   "carac3": 3.36,
+   "caracs": {
+    "carac1": 4.2,
+    "carac2": 9.24,
+    "carac3": 3.36
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1402,
+   "name": "Girl_1402",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1408,
+   "name": "Girl_1408",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 250,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 2194.5,
+   "carac2": 798,
+   "carac3": 3657.5,
+   "caracs": {
+    "carac1": 2194.5,
+    "carac2": 798,
+    "carac3": 3657.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1409,
+   "name": "Girl_1409",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3633.75,
+   "carac2": 4972.5,
+   "carac3": 10518.75,
+   "caracs": {
+    "carac1": 3633.75,
+    "carac2": 4972.5,
+    "carac3": 10518.75
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "D83",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1411,
+   "name": "Girl_1411",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2217.6,
+   "carac2": 10164,
+   "carac3": 6098.4,
+   "caracs": {
+    "carac1": 2217.6,
+    "carac2": 10164,
+    "carac3": 6098.4
+   },
+   "eye_color1": "F99",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1418,
+   "name": "Girl_1418",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5062.5,
+   "carac2": 10312.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 5062.5,
+    "carac2": 10312.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1419,
+   "name": "Girl_1419",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 600,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3801.6,
+   "carac2": 3326.4,
+   "carac3": 8712,
+   "caracs": {
+    "carac1": 3801.6,
+    "carac2": 3326.4,
+    "carac3": 8712
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1420,
+   "name": "Girl_1420",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12870,
+   "carac2": 6270,
+   "carac3": 4695,
+   "caracs": {
+    "carac1": 12870,
+    "carac2": 6270,
+    "carac3": 4695
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1421,
+   "name": "Girl_1421",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3537.5,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3537.5,
+    "carac3": 5600
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1424,
+   "name": "Girl_1424",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4550,
+   "carac2": 6020,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 6020,
+    "carac3": 12127.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1430,
+   "name": "Girl_1430",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4900,
+   "carac2": 2975,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4900,
+    "carac2": 2975,
+    "carac3": 9625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1435,
+   "name": "Girl_1435",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 5062.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 5062.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1445,
+   "name": "Girl_1445",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 4312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 4312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1449,
+   "name": "Girl_1449",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5812.5,
+   "carac3": 2625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5812.5,
+    "carac3": 2625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1451,
+   "name": "Girl_1451",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2975,
+   "carac2": 4900,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 2975,
+    "carac2": 4900,
+    "carac3": 9625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1455,
+   "name": "Girl_1455",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1469,
+   "name": "Girl_1469",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 10.45,
+   "carac2": 5.89,
+   "carac3": 2.66,
+   "caracs": {
+    "carac1": 10.45,
+    "carac2": 5.89,
+    "carac3": 2.66
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1474,
+   "name": "Girl_1474",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 14437.5,
+   "carac3": 6562.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 14437.5,
+    "carac3": 6562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1475,
+   "name": "Girl_1475",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12248.775,
+   "carac2": 7140.7,
+   "carac3": 3535,
+   "caracs": {
+    "carac1": 12248.775,
+    "carac2": 7140.7,
+    "carac3": 3535
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1476,
+   "name": "Girl_1476",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4662.5,
+   "carac2": 4475,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4662.5,
+    "carac2": 4475,
+    "carac3": 10725
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1483,
+   "name": "Girl_1483",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 600,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2640,
+   "carac2": 7260,
+   "carac3": 3300,
+   "caracs": {
+    "carac1": 2640,
+    "carac2": 7260,
+    "carac3": 3300
+   },
+   "eye_color1": "F00",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1485,
+   "name": "Girl_1485",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 10312.5,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 10312.5,
+    "carac3": 3562.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1487,
+   "name": "Girl_1487",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1501,
+   "name": "Girl_1501",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 3750,
+   "carac3": 9937.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 3750,
+    "carac3": 9937.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1513,
+   "name": "Girl_1513",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1518,
+   "name": "Girl_1518",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4200,
+   "carac2": 3675,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4200,
+    "carac2": 3675,
+    "carac3": 9625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1519,
+   "name": "Girl_1519",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 3.72,
+   "carac2": 14.629999999999999,
+   "carac3": 8.25,
+   "caracs": {
+    "carac1": 3.72,
+    "carac2": 14.629999999999999,
+    "carac3": 8.25
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1524,
+   "name": "Girl_1524",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1526,
+   "name": "Girl_1526",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4312.5,
+   "carac3": 4125,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4312.5,
+    "carac3": 4125
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1529,
+   "name": "Girl_1529",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16978.5,
+   "carac2": 8134,
+   "carac3": 6664,
+   "caracs": {
+    "carac1": 16978.5,
+    "carac2": 8134,
+    "carac3": 6664
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1534,
+   "name": "Girl_1534",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 7087.5,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 7087.5,
+    "carac3": 14437.5
+   },
+   "eye_color1": "B06",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1537,
+   "name": "Girl_1537",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3187.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3187.5,
+    "carac3": 5250
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1539,
+   "name": "Girl_1539",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3360,
+   "carac2": 11550,
+   "carac3": 6510,
+   "caracs": {
+    "carac1": 3360,
+    "carac2": 11550,
+    "carac3": 6510
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "B62",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1551,
+   "name": "Girl_1551",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 550,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2420,
+   "carac2": 3025,
+   "carac3": 6655,
+   "caracs": {
+    "carac1": 2420,
+    "carac2": 3025,
+    "carac3": 6655
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1556,
+   "name": "Girl_1556",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 250,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 1250,
+   "carac2": 3437.5,
+   "carac3": 1562.5,
+   "caracs": {
+    "carac1": 1250,
+    "carac2": 3437.5,
+    "carac3": 1562.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "0F0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1558,
+   "name": "Girl_1558",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1559,
+   "name": "Girl_1559",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5964,
+   "carac2": 6972,
+   "carac3": 14288.4,
+   "caracs": {
+    "carac1": 5964,
+    "carac2": 6972,
+    "carac3": 14288.4
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1565,
+   "name": "Girl_1565",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "B06",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1578,
+   "name": "Girl_1578",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 3937.5,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 3937.5,
+    "carac3": 7875
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1580,
+   "name": "Girl_1580",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 4620,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 4620,
+    "carac3": 11550
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1582,
+   "name": "Girl_1582",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 250,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3025,
+   "carac2": 990,
+   "carac3": 1485,
+   "caracs": {
+    "carac1": 3025,
+    "carac2": 990,
+    "carac3": 1485
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1583,
+   "name": "Girl_1583",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3377.5,
+   "carac2": 9415,
+   "carac3": 15015,
+   "caracs": {
+    "carac1": 3377.5,
+    "carac2": 9415,
+    "carac3": 15015
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1584,
+   "name": "Girl_1584",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1588,
+   "name": "Girl_1588",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5600,
+   "carac2": 2275,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 5600,
+    "carac2": 2275,
+    "carac3": 9625
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1590,
+   "name": "Girl_1590",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "D83",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1592,
+   "name": "Girl_1592",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4923.75,
+   "carac2": 3598.125,
+   "carac3": 10415.625,
+   "caracs": {
+    "carac1": 4923.75,
+    "carac2": 3598.125,
+    "carac3": 10415.625
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1596,
+   "name": "Girl_1596",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 6300,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 6300,
+    "carac3": 14437.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1599,
+   "name": "Girl_1599",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5180,
+   "carac2": 5390,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 5180,
+    "carac2": 5390,
+    "carac3": 12127.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1611,
+   "name": "Girl_1611",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 6562.5,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 6562.5,
+    "carac3": 14437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1613,
+   "name": "Girl_1613",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 650,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 10010,
+   "carac2": 6006,
+   "carac3": 2548,
+   "caracs": {
+    "carac1": 10010,
+    "carac2": 6006,
+    "carac3": 2548
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1617,
+   "name": "Girl_1617",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1618,
+   "name": "Girl_1618",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 10948,
+   "carac2": 8890,
+   "carac3": 19624.5,
+   "caracs": {
+    "carac1": 10948,
+    "carac2": 8890,
+    "carac3": 19624.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1621,
+   "name": "Girl_1621",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5037.5,
+   "carac2": 4100,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 5037.5,
+    "carac2": 4100,
+    "carac3": 10725
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1622,
+   "name": "Girl_1622",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 15015,
+   "carac2": 8102.5,
+   "carac3": 4690,
+   "caracs": {
+    "carac1": 15015,
+    "carac2": 8102.5,
+    "carac3": 4690
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1642,
+   "name": "Girl_1642",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 8470,
+   "carac2": 2618,
+   "carac3": 4312,
+   "caracs": {
+    "carac1": 8470,
+    "carac2": 2618,
+    "carac3": 4312
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1648,
+   "name": "Girl_1648",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 103,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 528.39,
+   "carac2": 1076.35,
+   "carac3": 352.26,
+   "caracs": {
+    "carac1": 528.39,
+    "carac2": 1076.35,
+    "carac3": 352.26
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1656,
+   "name": "Girl_1656",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6037.5,
+   "carac2": 14437.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 6037.5,
+    "carac2": 14437.5,
+    "carac3": 5775
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1657,
+   "name": "Girl_1657",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1694,
+   "carac2": 8470,
+   "carac3": 5236,
+   "caracs": {
+    "carac1": 1694,
+    "carac2": 8470,
+    "carac3": 5236
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1659,
+   "name": "Girl_1659",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 3080,
+   "carac2": 12127.5,
+   "carac3": 7490,
+   "caracs": {
+    "carac1": 3080,
+    "carac2": 12127.5,
+    "carac3": 7490
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1661,
+   "name": "Girl_1661",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 5250,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 5250,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1666,
+   "name": "Girl_1666",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1667,
+   "name": "Girl_1667",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 12375,
+   "carac3": 5400,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 12375,
+    "carac3": 5400
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1675,
+   "name": "Girl_1675",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 10312.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 10312.5,
+    "carac3": 3750
+   },
+   "eye_color1": "888",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1677,
+   "name": "Girl_1677",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 1,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 6.859999999999999,
+   "carac2": 5.02,
+   "carac3": 14.52,
+   "caracs": {
+    "carac1": 6.859999999999999,
+    "carac2": 5.02,
+    "carac3": 14.52
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1682,
+   "name": "Girl_1682",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1683,
+   "name": "Girl_1683",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3696,
+   "carac2": 8470,
+   "carac3": 3234,
+   "caracs": {
+    "carac1": 3696,
+    "carac2": 8470,
+    "carac3": 3234
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1691,
+   "name": "Girl_1691",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4475,
+   "carac2": 10725,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4475,
+    "carac2": 10725,
+    "carac3": 4662.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1696,
+   "name": "Girl_1696",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4200,
+   "carac2": 11550,
+   "carac3": 5670,
+   "caracs": {
+    "carac1": 4200,
+    "carac2": 11550,
+    "carac3": 5670
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1705,
+   "name": "Girl_1705",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6162.5,
+   "carac2": 2975,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 6162.5,
+    "carac2": 2975,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "000",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1709,
+   "name": "Girl_1709",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 5037.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 5037.5,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1712,
+   "name": "Girl_1712",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 9625,
+   "carac3": 3150,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 9625,
+    "carac3": 3150
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FFF",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1713,
+   "name": "Girl_1713",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 550,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4065.6,
+   "carac2": 9317,
+   "carac3": 3557.4,
+   "caracs": {
+    "carac1": 4065.6,
+    "carac2": 9317,
+    "carac3": 3557.4
+   },
+   "eye_color1": "F90",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1722,
+   "name": "Girl_1722",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 600,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 6270,
+   "carac2": 2394,
+   "carac3": 2736,
+   "caracs": {
+    "carac1": 6270,
+    "carac2": 2394,
+    "carac3": 2736
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1724,
+   "name": "Girl_1724",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3725,
+   "carac3": 5412.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3725,
+    "carac3": 5412.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1726,
+   "name": "Girl_1726",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6440,
+   "carac2": 4130,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 6440,
+    "carac2": 4130,
+    "carac3": 12127.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1735,
+   "name": "Girl_1735",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 4462.5,
+   "carac3": 7350,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 4462.5,
+    "carac3": 7350
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♌︎ Lion",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1739,
+   "name": "Girl_1739",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5180,
+   "carac2": 12127.5,
+   "carac3": 5390,
+   "caracs": {
+    "carac1": 5180,
+    "carac2": 12127.5,
+    "carac3": 5390
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1754,
+   "name": "Girl_1754",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6230,
+   "carac2": 4340,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 6230,
+    "carac2": 4340,
+    "carac3": 12127.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1757,
+   "name": "Girl_1757",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 3562.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 3562.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1759,
+   "name": "Girl_1759",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5812.5,
+   "carac2": 2625,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 5812.5,
+    "carac2": 2625,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1762,
+   "name": "Girl_1762",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3300,
+   "carac2": 4125,
+   "carac3": 9075,
+   "caracs": {
+    "carac1": 3300,
+    "carac2": 4125,
+    "carac3": 9075
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1763,
+   "name": "Girl_1763",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3537.5,
+   "carac3": 5600,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3537.5,
+    "carac3": 5600
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1766,
+   "name": "Girl_1766",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 6006,
+   "carac2": 4389,
+   "carac3": 12705,
+   "caracs": {
+    "carac1": 6006,
+    "carac2": 4389,
+    "carac3": 12705
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1778,
+   "name": "Girl_1778",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F00",
+   "hair_color1": "00F",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1779,
+   "name": "Girl_1779",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5635,
+   "carac2": 12197.5,
+   "carac3": 17635.8,
+   "caracs": {
+    "carac1": 5635,
+    "carac2": 12197.5,
+    "carac3": 17635.8
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1781,
+   "name": "Girl_1781",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 10312.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 10312.5,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1782,
+   "name": "Girl_1782",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 4375,
+   "carac3": 3500,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 4375,
+    "carac3": 3500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1790,
+   "name": "Girl_1790",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 5390,
+   "carac3": 5180,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 5390,
+    "carac3": 5180
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1792,
+   "name": "Girl_1792",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1809,
+   "name": "Girl_1809",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1812,
+   "name": "Girl_1812",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 4025,
+   "carac3": 3850,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 4025,
+    "carac3": 3850
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♌︎ Lion",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1817,
+   "name": "Girl_1817",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1818,
+   "name": "Girl_1818",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6562.5,
+   "carac2": 14437.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 6562.5,
+    "carac2": 14437.5,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1821,
+   "name": "Girl_1821",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4125,
+   "carac2": 4312.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4125,
+    "carac2": 4312.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1835,
+   "name": "Girl_1835",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1839,
+   "name": "Girl_1839",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 600,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 7260,
+   "carac2": 3696,
+   "carac3": 2244,
+   "caracs": {
+    "carac1": 7260,
+    "carac2": 3696,
+    "carac3": 2244
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1852,
+   "name": "Girl_1852",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 6090,
+   "carac2": 11550,
+   "carac3": 3780,
+   "caracs": {
+    "carac1": 6090,
+    "carac2": 11550,
+    "carac3": 3780
+   },
+   "eye_color1": "F99",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1866,
+   "name": "Girl_1866",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 6300,
+   "carac3": 14437.5,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 6300,
+    "carac3": 14437.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1870,
+   "name": "Girl_1870",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4850,
+   "carac2": 4287.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4850,
+    "carac2": 4287.5,
+    "carac3": 10725
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1893,
+   "name": "Girl_1893",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 9898,
+   "carac2": 4900,
+   "carac3": 16978.5,
+   "caracs": {
+    "carac1": 9898,
+    "carac2": 4900,
+    "carac3": 16978.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1894,
+   "name": "Girl_1894",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4475,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4475,
+    "carac3": 4662.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1897,
+   "name": "Girl_1897",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 14437.5,
+   "carac3": 7612.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 14437.5,
+    "carac3": 7612.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1901,
+   "name": "Girl_1901",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 6300,
+   "carac2": 17325,
+   "carac3": 7875,
+   "caracs": {
+    "carac1": 6300,
+    "carac2": 17325,
+    "carac3": 7875
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20,
+      30
+     ],
+     "carac2": [
+      40,
+      20,
+      30
+     ],
+     "carac3": [
+      40,
+      20,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1904,
+   "name": "Girl_1904",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1907,
+   "name": "Girl_1907",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 5775,
+   "carac3": 2100,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 5775,
+    "carac3": 2100
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1913,
+   "name": "Girl_1913",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4312.5,
+   "carac2": 4125,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4312.5,
+    "carac2": 4125,
+    "carac3": 10312.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1916,
+   "name": "Girl_1916",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12870,
+   "carac2": 6945,
+   "carac3": 4020,
+   "caracs": {
+    "carac1": 12870,
+    "carac2": 6945,
+    "carac3": 4020
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♎︎ Balance",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1920,
+   "name": "Girl_1920",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5062.5,
+   "carac3": 3375,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5062.5,
+    "carac3": 3375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "765",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1921,
+   "name": "Girl_1921",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 2625,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 2625,
+    "carac3": 5250
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1925,
+   "name": "Girl_1925",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1926,
+   "name": "Girl_1926",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16170,
+   "carac2": 10290,
+   "carac3": 3528,
+   "caracs": {
+    "carac1": 16170,
+    "carac2": 10290,
+    "carac3": 3528
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1930,
+   "name": "Girl_1930",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 500,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 6050,
+   "carac2": 3190,
+   "carac3": 1760,
+   "caracs": {
+    "carac1": 6050,
+    "carac2": 3190,
+    "carac3": 1760
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1937,
+   "name": "Girl_1937",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10415.625,
+   "carac2": 3408.75,
+   "carac3": 5113.125,
+   "caracs": {
+    "carac1": 10415.625,
+    "carac2": 3408.75,
+    "carac3": 5113.125
+   },
+   "eye_color1": "000",
+   "hair_color1": "CCC",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1947,
+   "name": "Girl_1947",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 88,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 451.44,
+   "carac2": 300.96,
+   "carac3": 919.6,
+   "caracs": {
+    "carac1": 451.44,
+    "carac2": 300.96,
+    "carac3": 919.6
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1954,
+   "name": "Girl_1954",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "321",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1959,
+   "name": "Girl_1959",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 490,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 7546,
+   "carac2": 4802,
+   "carac3": 1646.4,
+   "caracs": {
+    "carac1": 7546,
+    "carac2": 4802,
+    "carac3": 1646.4
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1965,
+   "name": "Girl_1965",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1967,
+   "name": "Girl_1967",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 300,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1584,
+   "carac2": 1386,
+   "carac3": 3630,
+   "caracs": {
+    "carac1": 1584,
+    "carac2": 1386,
+    "carac3": 3630
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1970,
+   "name": "Girl_1970",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 8470,
+   "carac2": 4158,
+   "carac3": 2772,
+   "caracs": {
+    "carac1": 8470,
+    "carac2": 4158,
+    "carac3": 2772
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "321",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1971,
+   "name": "Girl_1971",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1975,
+   "name": "Girl_1975",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3162.5,
+   "carac2": 10725,
+   "carac3": 5975,
+   "caracs": {
+    "carac1": 3162.5,
+    "carac2": 10725,
+    "carac3": 5975
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1985,
+   "name": "Girl_1985",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1986,
+   "name": "Girl_1986",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FFF",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1987,
+   "name": "Girl_1987",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2926,
+   "carac2": 4004,
+   "carac3": 8470,
+   "caracs": {
+    "carac1": 2926,
+    "carac2": 4004,
+    "carac3": 8470
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F90",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1989,
+   "name": "Girl_1989",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4475,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4475,
+    "carac3": 4662.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1991,
+   "name": "Girl_1991",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3325,
+   "carac2": 9625,
+   "carac3": 4550,
+   "caracs": {
+    "carac1": 3325,
+    "carac2": 9625,
+    "carac3": 4550
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1995,
+   "name": "Girl_1995",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 16170,
+   "carac2": 8820,
+   "carac3": 4998,
+   "caracs": {
+    "carac1": 16170,
+    "carac2": 8820,
+    "carac3": 4998
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 1997,
+   "name": "Girl_1997",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3000,
+   "carac2": 10312.5,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 3000,
+    "carac2": 10312.5,
+    "carac3": 5437.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 1999,
+   "name": "Girl_1999",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2002,
+   "name": "Girl_2002",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4125,
+   "carac3": 4312.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4125,
+    "carac3": 4312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "000",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2009,
+   "name": "Girl_2009",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4025,
+   "carac2": 3850,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4025,
+    "carac2": 3850,
+    "carac3": 9625
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2013,
+   "name": "Girl_2013",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 8937.5,
+   "carac2": 4387.5,
+   "carac3": 2925,
+   "caracs": {
+    "carac1": 8937.5,
+    "carac2": 4387.5,
+    "carac3": 2925
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2014,
+   "name": "Girl_2014",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9450,
+   "carac2": 4725,
+   "carac3": 17325,
+   "caracs": {
+    "carac1": 9450,
+    "carac2": 4725,
+    "carac3": 17325
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♎︎ Balance",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2021,
+   "name": "Girl_2021",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2812.5,
+   "carac2": 10312.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 2812.5,
+    "carac2": 10312.5,
+    "carac3": 5625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2022,
+   "name": "Girl_2022",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10415.625,
+   "carac2": 3598.125,
+   "carac3": 4923.75,
+   "caracs": {
+    "carac1": 10415.625,
+    "carac2": 3598.125,
+    "carac3": 4923.75
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2035,
+   "name": "Girl_2035",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 650,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1573,
+   "carac2": 7865,
+   "carac3": 4862,
+   "caracs": {
+    "carac1": 1573,
+    "carac2": 7865,
+    "carac3": 4862
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2038,
+   "name": "Girl_2038",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 2625,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 2625,
+    "carac3": 5250
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2042,
+   "name": "Girl_2042",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2043,
+   "name": "Girl_2043",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2049,
+   "name": "Girl_2049",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 5425,
+   "carac3": 2450,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 5425,
+    "carac3": 2450
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2050,
+   "name": "Girl_2050",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3000,
+   "carac3": 5437.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3000,
+    "carac3": 5437.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2061,
+   "name": "Girl_2061",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 625,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4537.5,
+   "carac2": 1650,
+   "carac3": 7562.5,
+   "caracs": {
+    "carac1": 4537.5,
+    "carac2": 1650,
+    "carac3": 7562.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2062,
+   "name": "Girl_2062",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 4620,
+   "carac3": 11550,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 4620,
+    "carac3": 11550
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2074,
+   "name": "Girl_2074",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 8937.5,
+   "carac2": 3575,
+   "carac3": 3737.5,
+   "caracs": {
+    "carac1": 8937.5,
+    "carac2": 3575,
+    "carac3": 3737.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2076,
+   "name": "Girl_2076",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 5250,
+   "carac3": 3187.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 5250,
+    "carac3": 3187.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "FFF",
+   "zodiac": "♌︎ Lion",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2077,
+   "name": "Girl_2077",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2310,
+   "carac2": 8470,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 2310,
+    "carac2": 8470,
+    "carac3": 4620
+   },
+   "eye_color1": "F90",
+   "hair_color1": "CCC",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2082,
+   "name": "Girl_2082",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3562.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3562.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2083,
+   "name": "Girl_2083",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 6045,
+   "carac3": 2730,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 6045,
+    "carac3": 2730
+   },
+   "eye_color1": "00F",
+   "hair_color1": "0F0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2084,
+   "name": "Girl_2084",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5512.5,
+   "carac2": 14437.5,
+   "carac3": 6300,
+   "caracs": {
+    "carac1": 5512.5,
+    "carac2": 14437.5,
+    "carac3": 6300
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FF0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2096,
+   "name": "Girl_2096",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9625,
+   "carac2": 2625,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 9625,
+    "carac2": 2625,
+    "carac3": 5250
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "F99",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2106,
+   "name": "Girl_2106",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 6037.5,
+   "carac3": 5775,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 6037.5,
+    "carac3": 5775
+   },
+   "eye_color1": "F00",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2107,
+   "name": "Girl_2107",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2108,
+   "name": "Girl_2108",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2110,
+   "name": "Girl_2110",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 400,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1292,
+   "carac2": 2128,
+   "carac3": 4180,
+   "caracs": {
+    "carac1": 1292,
+    "carac2": 2128,
+    "carac3": 4180
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2112,
+   "name": "Girl_2112",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 10335,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 10335,
+    "carac3": 4662.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2113,
+   "name": "Girl_2113",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 550,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 5747.5,
+   "carac2": 2612.5,
+   "carac3": 2090,
+   "caracs": {
+    "carac1": 5747.5,
+    "carac2": 2612.5,
+    "carac3": 2090
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "3.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2118,
+   "name": "Girl_2118",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4620,
+   "carac2": 5460,
+   "carac3": 11340,
+   "caracs": {
+    "carac1": 4620,
+    "carac2": 5460,
+    "carac3": 11340
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "888",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2119,
+   "name": "Girl_2119",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 1,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5.25,
+   "carac2": 6,
+   "carac3": 13.75,
+   "caracs": {
+    "carac1": 5.25,
+    "carac2": 6,
+    "carac3": 13.75
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2128,
+   "name": "Girl_2128",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 3912.5,
+   "carac3": 5225,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 3912.5,
+    "carac3": 5225
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "FFF",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2137,
+   "name": "Girl_2137",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3150,
+   "carac2": 4725,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 3150,
+    "carac2": 4725,
+    "carac3": 9625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2140,
+   "name": "Girl_2140",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4550,
+   "carac2": 3325,
+   "carac3": 9625,
+   "caracs": {
+    "carac1": 4550,
+    "carac2": 3325,
+    "carac3": 9625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2141,
+   "name": "Girl_2141",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4875,
+   "carac2": 10312.5,
+   "carac3": 3562.5,
+   "caracs": {
+    "carac1": 4875,
+    "carac2": 10312.5,
+    "carac3": 3562.5
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2146,
+   "name": "Girl_2146",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "CCC",
+   "hair_color1": "CCC",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2149,
+   "name": "Girl_2149",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7560,
+   "carac2": 17325,
+   "carac3": 6615,
+   "caracs": {
+    "carac1": 7560,
+    "carac2": 17325,
+    "carac3": 6615
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "7.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2154,
+   "name": "Girl_2154",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2157,
+   "name": "Girl_2157",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3350,
+   "carac2": 5787.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 3350,
+    "carac2": 5787.5,
+    "carac3": 10725
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♌︎ Lion",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2160,
+   "name": "Girl_2160",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "2.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2161,
+   "name": "Girl_2161",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 12375,
+   "carac2": 5175,
+   "carac3": 4950,
+   "caracs": {
+    "carac1": 12375,
+    "carac2": 5175,
+    "carac3": 4950
+   },
+   "eye_color1": "A55",
+   "hair_color1": "CCC",
+   "zodiac": "♎︎ Balance",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2166,
+   "name": "Girl_2166",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2170,
+   "name": "Girl_2170",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 7612.5,
+   "carac2": 14437.5,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 7612.5,
+    "carac2": 14437.5,
+    "carac3": 4200
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2175,
+   "name": "Girl_2175",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2178,
+   "name": "Girl_2178",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11453.4,
+   "carac2": 4242,
+   "carac3": 5938.8,
+   "caracs": {
+    "carac1": 11453.4,
+    "carac2": 4242,
+    "carac3": 5938.8
+   },
+   "eye_color1": "F00",
+   "hair_color1": "CCC",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2181,
+   "name": "Girl_2181",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 1,
+   "graded": 0,
+   "nb_grades": 5,
+   "carac1": 5.5,
+   "carac2": 3,
+   "carac3": 1.5,
+   "caracs": {
+    "carac1": 5.5,
+    "carac2": 3,
+    "carac3": 1.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2188,
+   "name": "Girl_2188",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 650,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 1482,
+   "carac2": 6792.5,
+   "carac3": 4075.5,
+   "caracs": {
+    "carac1": 1482,
+    "carac2": 6792.5,
+    "carac3": 4075.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2192,
+   "name": "Girl_2192",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5037.5,
+   "carac2": 10725,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 5037.5,
+    "carac2": 10725,
+    "carac3": 4100
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2194,
+   "name": "Girl_2194",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 4500,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 4500,
+    "carac3": 10312.5
+   },
+   "eye_color1": "000",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2196,
+   "name": "Girl_2196",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 4875,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 4875,
+    "carac3": 10312.5
+   },
+   "eye_color1": "B06",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2197,
+   "name": "Girl_2197",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 4662.5,
+   "carac3": 4475,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 4662.5,
+    "carac3": 4475
+   },
+   "eye_color1": "F00",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2198,
+   "name": "Girl_2198",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 9937.5,
+   "carac3": 3750,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 9937.5,
+    "carac3": 3750
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FD0",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2202,
+   "name": "Girl_2202",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 4500,
+   "carac3": 3937.5,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 4500,
+    "carac3": 3937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2203,
+   "name": "Girl_2203",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 594,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 2827.44,
+   "carac2": 9147.6,
+   "carac3": 4989.6,
+   "caracs": {
+    "carac1": 2827.44,
+    "carac2": 9147.6,
+    "carac3": 4989.6
+   },
+   "eye_color1": "A55",
+   "hair_color1": "000",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2205,
+   "name": "Girl_2205",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3408.75,
+   "carac2": 10415.625,
+   "carac3": 5113.125,
+   "caracs": {
+    "carac1": 3408.75,
+    "carac2": 10415.625,
+    "carac3": 5113.125
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2212,
+   "name": "Girl_2212",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3937.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3937.5,
+    "carac3": 4500
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2219,
+   "name": "Girl_2219",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 450,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 5445,
+   "carac2": 2970,
+   "carac3": 1485,
+   "caracs": {
+    "carac1": 5445,
+    "carac2": 2970,
+    "carac3": 1485
+   },
+   "eye_color1": "F00",
+   "hair_color1": "000",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2233,
+   "name": "Girl_2233",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 706,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4659.6,
+   "carac2": 2329.8,
+   "carac3": 8542.6,
+   "caracs": {
+    "carac1": 4659.6,
+    "carac2": 2329.8,
+    "carac3": 8542.6
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2236,
+   "name": "Girl_2236",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4100,
+   "carac2": 5037.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 4100,
+    "carac2": 5037.5,
+    "carac3": 10725
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2243,
+   "name": "Girl_2243",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 13475,
+   "carac2": 3675,
+   "carac3": 7350,
+   "caracs": {
+    "carac1": 13475,
+    "carac2": 3675,
+    "carac3": 7350
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FF0",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2245,
+   "name": "Girl_2245",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 8470,
+   "carac2": 4004,
+   "carac3": 2926,
+   "caracs": {
+    "carac1": 8470,
+    "carac2": 4004,
+    "carac3": 2926
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2250,
+   "name": "Girl_2250",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 3187.5,
+   "carac3": 5250,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 3187.5,
+    "carac3": 5250
+   },
+   "eye_color1": "00F",
+   "hair_color1": "CCC",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "1.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2251,
+   "name": "Girl_2251",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2258,
+   "name": "Girl_2258",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5466.625,
+   "carac2": 3762.25,
+   "carac3": 10832.25,
+   "caracs": {
+    "carac1": 5466.625,
+    "carac2": 3762.25,
+    "carac3": 10832.25
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F00",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2267,
+   "name": "Girl_2267",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 5775,
+   "carac3": 6037.5,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 5775,
+    "carac3": 6037.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      30
+     ],
+     "carac2": [
+      40,
+      30
+     ],
+     "carac3": [
+      40,
+      30
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2268,
+   "name": "Girl_2268",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 8470,
+   "carac2": 4774,
+   "carac3": 2156,
+   "caracs": {
+    "carac1": 8470,
+    "carac2": 4774,
+    "carac3": 2156
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F00",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2269,
+   "name": "Girl_2269",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "F99",
+   "hair_color1": "A55",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2277,
+   "name": "Girl_2277",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5215,
+   "carac2": 15015,
+   "carac3": 7577.5,
+   "caracs": {
+    "carac1": 5215,
+    "carac2": 15015,
+    "carac3": 7577.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2280,
+   "name": "Girl_2280",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 650,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3250,
+   "carac2": 4062.5,
+   "carac3": 8937.5,
+   "caracs": {
+    "carac1": 3250,
+    "carac2": 4062.5,
+    "carac3": 8937.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "10.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2282,
+   "name": "Girl_2282",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 470,
+   "graded": 2,
+   "nb_grades": 5,
+   "carac1": 902.4,
+   "carac2": 4136,
+   "carac3": 2481.6,
+   "caracs": {
+    "carac1": 902.4,
+    "carac2": 4136,
+    "carac3": 2481.6
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2287,
+   "name": "Girl_2287",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3937.5,
+   "carac2": 10312.5,
+   "carac3": 4500,
+   "caracs": {
+    "carac1": 3937.5,
+    "carac2": 10312.5,
+    "carac3": 4500
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F90",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2291,
+   "name": "Girl_2291",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 9937.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 9937.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2295,
+   "name": "Girl_2295",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4130,
+   "carac2": 6440,
+   "carac3": 12127.5,
+   "caracs": {
+    "carac1": 4130,
+    "carac2": 6440,
+    "carac3": 12127.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2298,
+   "name": "Girl_2298",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 3511.2,
+   "carac2": 10164,
+   "carac3": 4804.8,
+   "caracs": {
+    "carac1": 3511.2,
+    "carac2": 10164,
+    "carac3": 4804.8
+   },
+   "eye_color1": "A55",
+   "hair_color1": "A55",
+   "zodiac": "♎︎ Balance",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2309,
+   "name": "Girl_2309",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "00F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "9.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2311,
+   "name": "Girl_2311",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3675,
+   "carac2": 9625,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 3675,
+    "carac2": 9625,
+    "carac3": 4200
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2314,
+   "name": "Girl_2314",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 4687.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 4687.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "F0F",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "12.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2319,
+   "name": "Girl_2319",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 12127.5,
+   "carac2": 6230,
+   "carac3": 4340,
+   "caracs": {
+    "carac1": 12127.5,
+    "carac2": 6230,
+    "carac3": 4340
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F90",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2320,
+   "name": "Girl_2320",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10335,
+   "carac2": 5037.5,
+   "carac3": 4100,
+   "caracs": {
+    "carac1": 10335,
+    "carac2": 5037.5,
+    "carac3": 4100
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "000",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2322,
+   "name": "Girl_2322",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10312.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 10312.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "A55",
+   "hair_color1": "0F0",
+   "zodiac": "♑︎ Capricorne",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2326,
+   "name": "Girl_2326",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4200,
+   "carac2": 11340,
+   "carac3": 5880,
+   "caracs": {
+    "carac1": 4200,
+    "carac2": 11340,
+    "carac3": 5880
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♌︎ Lion",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2329,
+   "name": "Girl_2329",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 4527.6,
+   "carac2": 11858,
+   "carac3": 5174.4,
+   "caracs": {
+    "carac1": 4527.6,
+    "carac2": 11858,
+    "carac3": 5174.4
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FF0",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2333,
+   "name": "Girl_2333",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "CCC",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2339,
+   "name": "Girl_2339",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4475,
+   "carac2": 10725,
+   "carac3": 4662.5,
+   "caracs": {
+    "carac1": 4475,
+    "carac2": 10725,
+    "carac3": 4662.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2342,
+   "name": "Girl_2342",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4725,
+   "carac2": 5400,
+   "carac3": 12375,
+   "caracs": {
+    "carac1": 4725,
+    "carac2": 5400,
+    "carac3": 12375
+   },
+   "eye_color1": "F90",
+   "hair_color1": "F90",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2344,
+   "name": "Girl_2344",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 14437.5,
+   "carac2": 4987.5,
+   "carac3": 6825,
+   "caracs": {
+    "carac1": 14437.5,
+    "carac2": 4987.5,
+    "carac3": 6825
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "1.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2354,
+   "name": "Girl_2354",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 550,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 1936,
+   "carac2": 3509,
+   "carac3": 6655,
+   "caracs": {
+    "carac1": 1936,
+    "carac2": 3509,
+    "carac3": 6655
+   },
+   "eye_color1": "FD0",
+   "hair_color1": "FD0",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "10.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2355,
+   "name": "Girl_2355",
+   "class": 2,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 5250,
+   "carac2": 11550,
+   "carac3": 4620,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 11550,
+    "carac3": 4620
+   },
+   "eye_color1": "F00",
+   "hair_color1": "EB8",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2356,
+   "name": "Girl_2356",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 9937.5,
+   "carac2": 2812.5,
+   "carac3": 5625,
+   "caracs": {
+    "carac1": 9937.5,
+    "carac2": 2812.5,
+    "carac3": 5625
+   },
+   "eye_color1": "0F0",
+   "hair_color1": "F99",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "3.png",
+   "blessing_bonuses": {
+    "pvp_v4": {
+     "carac1": [
+      30
+     ],
+     "carac2": [
+      30
+     ],
+     "carac3": [
+      30
+     ]
+    }
+   },
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2358,
+   "name": "Girl_2358",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F99",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2374,
+   "name": "Girl_2374",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "stone",
+   "element_data": {
+    "type": "stone",
+    "weakness": "nature",
+    "domination": "sun",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Physical.png",
+    "flavor": "Physique"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4760,
+   "carac2": 6020,
+   "carac3": 11907,
+   "caracs": {
+    "carac1": 4760,
+    "carac2": 6020,
+    "carac3": 11907
+   },
+   "eye_color1": "A55",
+   "hair_color1": "F00",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2375,
+   "name": "Girl_2375",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 3937.5,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 3937.5,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "888",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2390,
+   "name": "Girl_2390",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "fire",
+   "element_data": {
+    "type": "fire",
+    "weakness": "water",
+    "domination": "nature",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Eccentric.png",
+    "flavor": "Excentrique"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3562.5,
+   "carac2": 10312.5,
+   "carac3": 4875,
+   "caracs": {
+    "carac1": 3562.5,
+    "carac2": 10312.5,
+    "carac3": 4875
+   },
+   "eye_color1": "F99",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2391,
+   "name": "Girl_2391",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4500,
+   "carac2": 5625,
+   "carac3": 12375,
+   "caracs": {
+    "carac1": 4500,
+    "carac2": 5625,
+    "carac3": 12375
+   },
+   "eye_color1": "F90",
+   "hair_color1": "000",
+   "zodiac": "♎︎ Balance",
+   "position_img": "12.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      20
+     ],
+     "carac2": [
+      20
+     ],
+     "carac3": [
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2393,
+   "name": "Girl_2393",
+   "class": 3,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 571,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 4796.4,
+   "carac2": 2717.96,
+   "carac3": 8793.4,
+   "caracs": {
+    "carac1": 4796.4,
+    "carac2": 2717.96,
+    "carac3": 8793.4
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "9.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2394,
+   "name": "Girl_2394",
+   "class": 1,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 10725,
+   "carac2": 5225,
+   "carac3": 3912.5,
+   "caracs": {
+    "carac1": 10725,
+    "carac2": 5225,
+    "carac3": 3912.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "2.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2410,
+   "name": "Girl_2410",
+   "class": 1,
+   "rarity": "mythic",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 6,
+   "nb_grades": 6,
+   "carac1": 11550,
+   "carac2": 5670,
+   "carac3": 4200,
+   "caracs": {
+    "carac1": 11550,
+    "carac2": 5670,
+    "carac3": 4200
+   },
+   "eye_color1": "F99",
+   "hair_color1": "F99",
+   "zodiac": "♓︎ Poissons",
+   "position_img": "4.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2421,
+   "name": "Girl_2421",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 1,
+   "graded": 3,
+   "nb_grades": 5,
+   "carac1": 2.9299999999999997,
+   "carac2": 14.629999999999999,
+   "carac3": 9.04,
+   "caracs": {
+    "carac1": 2.9299999999999997,
+    "carac2": 14.629999999999999,
+    "carac3": 9.04
+   },
+   "eye_color1": "F99",
+   "hair_color1": "FF0",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40
+     ],
+     "carac2": [
+      40
+     ],
+     "carac3": [
+      40
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2424,
+   "name": "Girl_2424",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "sun",
+   "element_data": {
+    "type": "sun",
+    "weakness": "stone",
+    "domination": "water",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Playful.png",
+    "flavor": "Joueuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 4687.5,
+   "carac2": 3750,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 4687.5,
+    "carac2": 3750,
+    "carac3": 10312.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "00F",
+   "zodiac": "♌︎ Lion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2428,
+   "name": "Girl_2428",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5250,
+   "carac2": 9625,
+   "carac3": 2625,
+   "caracs": {
+    "carac1": 5250,
+    "carac2": 9625,
+    "carac3": 2625
+   },
+   "eye_color1": "00F",
+   "hair_color1": "A55",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "5.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2429,
+   "name": "Girl_2429",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2975,
+   "carac2": 9625,
+   "carac3": 4900,
+   "caracs": {
+    "carac1": 2975,
+    "carac2": 9625,
+    "carac3": 4900
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "0F0",
+   "zodiac": "♍︎ Vierge",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2435,
+   "name": "Girl_2435",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 11172,
+   "carac2": 10227,
+   "carac3": 21162.96,
+   "caracs": {
+    "carac1": 11172,
+    "carac2": 10227,
+    "carac3": 21162.96
+   },
+   "eye_color1": "A55",
+   "hair_color1": "FF0",
+   "zodiac": "♎︎ Balance",
+   "position_img": "11.png",
+   "blessing_bonuses": {
+    "pvp_v3": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    },
+    "pvp_v4": {
+     "carac1": [
+      40,
+      20
+     ],
+     "carac2": [
+      40,
+      20
+     ],
+     "carac3": [
+      40,
+      20
+     ]
+    }
+   },
+   "can_be_blessed": true,
+   "can_be_blessed_pvp4": true
+  },
+  {
+   "id_girl": 2437,
+   "name": "Girl_2437",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 2800,
+   "carac2": 9625,
+   "carac3": 5075,
+   "caracs": {
+    "carac1": 2800,
+    "carac2": 9625,
+    "carac3": 5075
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♋︎ Cancer",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2443,
+   "name": "Girl_2443",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "light",
+   "element_data": {
+    "type": "light",
+    "weakness": "darkness",
+    "domination": "psychic",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Submissive.png",
+    "flavor": "Soumise"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3750,
+   "carac2": 10312.5,
+   "carac3": 4687.5,
+   "caracs": {
+    "carac1": 3750,
+    "carac2": 10312.5,
+    "carac3": 4687.5
+   },
+   "eye_color1": "00F",
+   "hair_color1": "FFF",
+   "zodiac": "♈︎ Bélier",
+   "position_img": "8.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2446,
+   "name": "Girl_2446",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "psychic",
+   "element_data": {
+    "type": "psychic",
+    "weakness": "light",
+    "domination": "darkness",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Voyeurs.png",
+    "flavor": "Voyeuse"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3187.5,
+   "carac2": 5250,
+   "carac3": 10312.5,
+   "caracs": {
+    "carac1": 3187.5,
+    "carac2": 5250,
+    "carac3": 10312.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "00F",
+   "zodiac": "♊︎ Gémeaux",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2448,
+   "name": "Girl_2448",
+   "class": 3,
+   "rarity": "legendary",
+   "element": "darkness",
+   "element_data": {
+    "type": "darkness",
+    "weakness": "psychic",
+    "domination": "light",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Dominatrix.png",
+    "flavor": "Dominatrice"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 5225,
+   "carac2": 3912.5,
+   "carac3": 10725,
+   "caracs": {
+    "carac1": 5225,
+    "carac2": 3912.5,
+    "carac3": 10725
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♏︎ Scorpion",
+   "position_img": "11.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2449,
+   "name": "Girl_2449",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3500,
+   "carac2": 9625,
+   "carac3": 4375,
+   "caracs": {
+    "carac1": 3500,
+    "carac2": 9625,
+    "carac3": 4375
+   },
+   "eye_color1": "00F",
+   "hair_color1": "F0F",
+   "zodiac": "♒︎ Verseau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2454,
+   "name": "Girl_2454",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "water",
+   "element_data": {
+    "type": "water",
+    "weakness": "sun",
+    "domination": "fire",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Sensual.png",
+    "flavor": "Sensuelle"
+   },
+   "level": 750,
+   "graded": 5,
+   "nb_grades": 5,
+   "carac1": 3375,
+   "carac2": 10312.5,
+   "carac3": 5062.5,
+   "caracs": {
+    "carac1": 3375,
+    "carac2": 10312.5,
+    "carac3": 5062.5
+   },
+   "eye_color1": "F0F",
+   "hair_color1": "F0F",
+   "zodiac": "♐︎ Sagittaire",
+   "position_img": "7.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  },
+  {
+   "id_girl": 2460,
+   "name": "Girl_2460",
+   "class": 2,
+   "rarity": "legendary",
+   "element": "nature",
+   "element_data": {
+    "type": "nature",
+    "weakness": "fire",
+    "domination": "stone",
+    "domination_ego_bonus_percent": 10,
+    "domination_damage_bonus_percent": 10,
+    "domination_critical_chance_bonus_percent": 20,
+    "ico_url": "https://hh2.hh-content.com/pictures/girls_elements/Exhibitionist.png",
+    "flavor": "Exhibitionniste"
+   },
+   "level": 700,
+   "graded": 4,
+   "nb_grades": 5,
+   "carac1": 2926,
+   "carac2": 8470,
+   "carac3": 4004,
+   "caracs": {
+    "carac1": 2926,
+    "carac2": 8470,
+    "carac3": 4004
+   },
+   "eye_color1": "888",
+   "hair_color1": "A55",
+   "zodiac": "♉︎ Taureau",
+   "position_img": "6.png",
+   "blessing_bonuses": [],
+   "can_be_blessed": false,
+   "can_be_blessed_pvp4": false
+  }
+ ]
+}

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -116,14 +116,7 @@ export class TeamModule {
                     safeReload(randomInterval(200, 500));
                 }
             });
-        } 
-        // else if (getPage().match(/^\/characters\/\d+$/)) {
-        // TODO unequip from harem page
-        //     logHHAuto('Unequip from harem page');
-        //     if ($('#unequip_all').length > 0) {
-        //         $('#unequip_all').trigger('click');
-        //     }
-        // }
+        }
     }
 
     static manageSkillScrollTooltip() {
@@ -137,12 +130,6 @@ export class TeamModule {
     }
 
     static createSkillScrollTooltip(teamGirls: KKTeamGirl[]=null, displayTooltip: boolean=true): TeamData {
-        // if (!teamGirls || teamGirls.length != 7) {
-        //     teamGirls = TeamModule.getSelectedGirls();
-        //     if (teamGirls.length != 7) {
-        //         return;
-        //     }
-        // }
         const teamGirlWithoutMain = teamGirls.slice(1);
         const heroCurrencies = getHero().currencies;
         let scrollTooltipDetail = '';
@@ -193,11 +180,6 @@ export class TeamModule {
         return team;
     }
 
-    static stuffAllGirls() {
-        if (getPage() === ConfigHelper.getHHScriptVars("pagesIDBattleTeams")) {
-        }
-    }
-
     static buildStuffTeamSelectPopUp() {
         const teamGirls = TeamModule.getSelectedGirls();
         if (teamGirls.length == 0) {
@@ -215,7 +197,7 @@ export class TeamModule {
             <span>Needed: ${team['scrolls_' + rarity.toLowerCase()]}/Owned: ${heroCurrencies['scrolls_'+rarity.toLowerCase()]} <span><br/>`;
         };
 
-        const estimatedCost = 5 * (team.scrolls_mythic || 0 + team.scrolls_legendary || 0 + team.scrolls_epic || 0 + team.scrolls_rare || 0 + team.scrolls_common || 0);
+        const estimatedCost = 5 * ((team.scrolls_mythic || 0) + (team.scrolls_legendary || 0) + (team.scrolls_epic || 0) + (team.scrolls_rare || 0) + (team.scrolls_common || 0));
 
         let stuffTeamMenu = `<div style="padding:5px; display:flex;flex-direction:column;font-size:15px; max-width:550px" class="HHAutoScriptMenu">
             <div class="rowLine">
@@ -298,17 +280,6 @@ export class TeamModule {
             }
         });
     }
-
-    // static getSkillNeededScrollsOneGirl(girl: KKTeamGirl): number {
-    //     const rarity = girl.girl.rarity;
-    //     const nbGrades = girl.girl.nb_grades;
-    //     const skills: any[] = Object.values(girl.skill_tiers_info);
-    //     const usedScrolls = Number(skills.reduce((accumulator, skill) => accumulator + (skill.skill_points_used || 0), 0));
-
-    //     const fullNeededScrolls = HaremGirl.SCROLLS_NEED_5[rarity + '_' + nbGrades];
-    //     logHHAuto(`Total skill points used by ${girl.girl.name}: ${usedScrolls}/${fullNeededScrolls}`);
-    //     return fullNeededScrolls - usedScrolls;
-    // }
 
     static getSkillNeededScrolls(mainGirl: KKTeamGirl, teamGirls: KKTeamGirl[], rarity: string, nbGrades: number): number {
         const girls = teamGirls.filter(girl => girl.girl && girl.girl.rarity === rarity && girl.girl.nb_grades == nbGrades);
@@ -394,7 +365,7 @@ export class TeamModule {
         const selectedTeam = $('.team-slot-container.selected-team').attr('data-team-index');
         if (isNaN(Number(selectedTeam))) {
             logHHAuto('Error: can\'t get selected team index, cancel action');
-            return;
+            return [];
         }
         const girlIds = [...unsafeWindow.teams_data[selectedTeam].girls_ids];
         if (girlIds.length != 7) {
@@ -470,13 +441,19 @@ export class TeamModule {
         }
     }
 
-    private static setTopTeamV2(mode: ScoringMode, availableGirls: any[]) {
-        const playerLevel = Number(HeroHelper.getLevel());
-        const rawClass = Number(HeroHelper.getClass());
-        const playerClass: PlayerClass = (rawClass === 1 || rawClass === 2 || rawClass === 3) ? rawClass as PlayerClass : 1;
-
-        // Map availableGirls to GirlData interface
-        const girls: GirlData[] = availableGirls.map(g => ({
+    /**
+     * Map one raw availableGirls entry (game DOM/window data) onto the
+     * GirlData interface the team builder consumes. Extracted from
+     * setTopTeamV2 so the mapping is unit-testable in isolation (the rest
+     * of setTopTeamV2 is DOM/UI). Pure: no side effects, no DOM access.
+     *
+     * can_be_blessed / can_be_blessed_pvp4 are passed through as untyped
+     * bonus properties so BlessingService.detectActiveBlessings has an
+     * authoritative blessed-or-not flag (issue 1679 phase 2); the static
+     * type stays GirlData.
+     */
+    static mapAvailableGirl(g: any): GirlData {
+        return ({
             id_girl: Number(g.id_girl),
             name: g.name || '',
             carac1: Number(g.carac1 || 0),
@@ -500,13 +477,18 @@ export class TeamModule {
             eyeColor: g.eye_color1 || undefined,
             position: g.position_img ? String(g.position_img).replace('.png', '') : undefined,
             blessingBonuses: g.blessing_bonuses || undefined,
-            // Pass through can_be_blessed so detectActiveBlessings has
-            // an authoritative blessed-or-not flag (issue 1679 phase 2).
-            // The flag is added as a non-typed bonus property; the type
-            // signature stays GirlData.
             ...(typeof g.can_be_blessed === 'boolean' ? { can_be_blessed: g.can_be_blessed } : {}),
             ...(typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_pvp4: g.can_be_blessed_pvp4 } : {}),
-        }) as GirlData);
+        }) as GirlData;
+    }
+
+    private static setTopTeamV2(mode: ScoringMode, availableGirls: any[]) {
+        const playerLevel = Number(HeroHelper.getLevel());
+        const rawClass = Number(HeroHelper.getClass());
+        const playerClass: PlayerClass = (rawClass === 1 || rawClass === 2 || rawClass === 3) ? rawClass as PlayerClass : 1;
+
+        // Map availableGirls (raw game data) to the GirlData interface.
+        const girls: GirlData[] = availableGirls.map(g => TeamModule.mapAvailableGirl(g));
 
         // Build BOTH modes so we can detect when "Best Possible" produces
         // the same team as "Current Best" — this happens when the top 7

--- a/src/Service/BlessingService.ts
+++ b/src/Service/BlessingService.ts
@@ -326,6 +326,34 @@ export class BlessingService {
     }
 
     /**
+     * Resolve a girl's value for a blessing trait kind, accepting both
+     * raw API girls (snake_case: eye_color1, hair_color1, position_img)
+     * and GirlData (camelCase: eyeColor, hairColor, position). Single
+     * source of truth shared by detectActiveBlessings and the team
+     * builder's blessing matcher, so a future game field rename is a
+     * one-place change (see lesson mapping-fix-vollstaendig-pruefen).
+     * position is normalised (the '.png' suffix is stripped).
+     */
+    static resolveTraitField(
+        g: any,
+        kind: 'eyeColor' | 'hairColor' | 'zodiac' | 'position' | 'element' | 'rarity',
+    ): string | undefined {
+        switch (kind) {
+            case 'eyeColor':  return g.eye_color1 ?? g.eyeColor;
+            case 'hairColor': return g.hair_color1 ?? g.hairColor;
+            case 'zodiac':    return g.zodiac;
+            case 'position': {
+                const raw = g.position_img ?? g.position;
+                if (raw === undefined || raw === null) return undefined;
+                return String(raw).replace(/\.png$/i, '');
+            }
+            case 'element':   return g.element;
+            case 'rarity':    return g.rarity;
+            default:          return undefined;
+        }
+    }
+
+    /**
      * Detect active blessings DIRECTLY from the girls in the pool, without
      * relying on String-Parsing of the API description (which is locale-
      * dependent: 'eye color' / 'couleur des yeux' / 'augenfarbe' ...).
@@ -397,21 +425,8 @@ export class BlessingService {
 
         // Read a girl's value for a given trait kind, accepting both
         // snake_case (raw API) and camelCase (GirlData) forms.
-        const fieldOf = (g: any, kind: Cand['kind']): string | undefined => {
-            switch (kind) {
-                case 'eyeColor':  return g.eye_color1 ?? g.eyeColor;
-                case 'hairColor': return g.hair_color1 ?? g.hairColor;
-                case 'zodiac':    return g.zodiac;
-                case 'position': {
-                    // Raw position_img is '5.png', GirlData.position is '5'.
-                    const raw = g.position_img ?? g.position;
-                    if (raw === undefined || raw === null) return undefined;
-                    return String(raw).replace(/\.png$/i, '');
-                }
-                case 'element':   return g.element;
-                case 'rarity':    return g.rarity;
-            }
-        };
+        const fieldOf = (g: any, kind: Cand['kind']): string | undefined =>
+            BlessingService.resolveTraitField(g, kind);
 
         const kinds: Cand['kind'][] = ['eyeColor', 'hairColor', 'zodiac', 'position', 'element', 'rarity'];
 

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.59";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.60";
 
 /**
  * HTML content for the feature popup.

--- a/src/Service/TeamBuilderService.ts
+++ b/src/Service/TeamBuilderService.ts
@@ -88,7 +88,7 @@ export interface TeamResult {
     tier3Bonus: number;
     traitMatchCount: number;
     activeBlessings: BlessingSummary[];
-    poolUsed: 'bless1' | 'bless2' | 'default' | 'fallback';
+    poolUsed: 'bless1' | 'bless2' | 'bless1-flat' | 'bless2-flat' | 'default' | 'default-flat' | 'fallback';
     blessedGirlCount: number;
     fallbackReason?: string;
     playerClass: PlayerClass;
@@ -99,6 +99,11 @@ export interface TeamResult {
 
 const TEAM_SIZE = 7;
 const POS_2_TO_7 = 6;
+// Two candidate teams within this relative stat-sum margin are treated
+// as a near-tie; the higher Tier-5 leader skill (Shield > Stun > Execute
+// > Reflect) then decides. Keeps a Shield leader from being traded away
+// for a marginal stat gain the sum-only metric cannot otherwise see.
+const LEADER_TIEBREAK_MARGIN = 0.02;
 
 // Element pairs that share a Tier-3 category.
 const ELEMENT_PAIRS_BY_CATEGORY: Record<TraitCategory, ElementType[]> = {
@@ -120,7 +125,7 @@ interface TeamCluster {
 interface CandidateTeam {
     team: GirlData[];
     cluster: TeamCluster;
-    poolUsed: 'bless1' | 'bless2' | 'default';
+    poolUsed: 'bless1' | 'bless2' | 'bless1-flat' | 'bless2-flat' | 'default' | 'default-flat';
     score: number; // mode-aware caracs_sum across all 7 picks
 }
 
@@ -157,29 +162,49 @@ export class TeamBuilderService {
             kind: b.kind, value: b.value, percent: b.percent, pool_size: b.pool_size,
         }));
 
-        // Build up to three candidates in parallel.
+        // ---- Candidate matrix --------------------------------------
+        //
+        // For each pool (bless1, bless2, full eligible) we build a SET of
+        // candidate teams: one clustered candidate per trait category that
+        // forms a >= TEAM_SIZE element-pair group, plus one flat candidate
+        // (no cluster constraint). Every candidate is a fully-formed 7-girl
+        // team. The strongest by mode-aware stat-sum wins; on a near-tie
+        // (<= LEADER_TIEBREAK_MARGIN) the higher Tier-5 leader skill wins,
+        // so a Shield leader is never silently traded away for a marginal
+        // stat gain. Spreading the cluster axis into explicit candidates
+        // means the builder never has to guess whether to cluster on the
+        // blessed axis -- it simply tries them all and compares.
         const candidates: CandidateTeam[] = [];
         const bless1 = blessings[0];
         const bless2 = blessings[1];
 
+        const addCandidatesForPool = (
+            pool: GirlData[],
+            label: 'bless1' | 'bless2' | 'default',
+        ): void => {
+            if (pool.length < TEAM_SIZE) return;
+            // One clustered candidate per enumerable trait cluster.
+            for (const cluster of TeamBuilderService.enumerateClusters(pool)) {
+                const built = TeamBuilderService.buildWithCluster(pool, eligible, scoreMap, cluster);
+                if (built) candidates.push({ ...built, poolUsed: label });
+            }
+            // One flat candidate (no cluster constraint).
+            const flat = TeamBuilderService.buildFlat(pool, eligible, scoreMap);
+            if (flat) {
+                const flatLabel = (label === 'default' ? 'default-flat' : (label + '-flat')) as CandidateTeam['poolUsed'];
+                candidates.push({ ...flat, poolUsed: flatLabel });
+            }
+        };
+
         if (bless1) {
-            const pool = eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless1));
-            const built = TeamBuilderService.buildFromPool(pool, eligible, scoreMap);
-            if (built) candidates.push({ ...built, poolUsed: 'bless1' });
+            addCandidatesForPool(eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless1)), 'bless1');
         }
         if (bless2) {
-            const pool = eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless2));
-            const built = TeamBuilderService.buildFromPool(pool, eligible, scoreMap);
-            if (built) candidates.push({ ...built, poolUsed: 'bless2' });
+            addCandidatesForPool(eligible.filter(g => TeamBuilderService.matchesBlessing(g, bless2)), 'bless2');
         }
-        // Default team: full eligible pool, no Bless filter, cluster from
-        // the trait hierarchy.
-        {
-            const built = TeamBuilderService.buildFromPool(eligible, eligible, scoreMap);
-            if (built) candidates.push({ ...built, poolUsed: 'default' });
-        }
+        addCandidatesForPool(eligible, 'default');
 
-        // Score each candidate and pick the best by mode-aware sum.
+        // Score each candidate by mode-aware sum across all 7 picks.
         for (const c of candidates) {
             c.score = c.team.reduce(
                 (s, g) => s + (scoreMap.get(g.id_girl) ?? TeamScoringService.caracsSum(g)),
@@ -194,13 +219,7 @@ export class TeamBuilderService {
             );
         }
 
-        // Tiebreak: bless1 > bless2 > default. Stable sort already preserves
-        // this since we appended in that order. We just take the highest score.
-        // For ties, keep the first occurrence (already in priority order).
-        let best = candidates[0];
-        for (let i = 1; i < candidates.length; i++) {
-            if (candidates[i].score > best.score) best = candidates[i];
-        }
+        const best = TeamBuilderService.selectBestCandidate(candidates);
 
         return TeamBuilderService.buildResult(
             best.team, scoreMap, eligible, playerClass,
@@ -219,53 +238,30 @@ export class TeamBuilderService {
      */
     private static matchesBlessing(girl: GirlData, bless: BlessingSummary): boolean {
         if (BlessingService.getEffectiveMultiplier(girl as any) <= 1) return false;
-        const raw: any = girl;
-        const valueOf = (kind: string): string | undefined => {
-            switch (kind) {
-                case 'eyeColor':  return raw.eyeColor ?? raw.eye_color1;
-                case 'hairColor': return raw.hairColor ?? raw.hair_color1;
-                case 'zodiac':    return raw.zodiac;
-                case 'position': {
-                    const v = raw.position ?? raw.position_img;
-                    if (v === undefined || v === null) return undefined;
-                    return String(v).replace(/\.png$/i, '');
-                }
-                case 'element':   return raw.element;
-                case 'rarity':    return raw.rarity;
-                default:          return undefined;
-            }
-        };
-        return String(valueOf(bless.kind) ?? '') === bless.value;
+        // Field resolution is shared with BlessingService.detectActiveBlessings
+        // via resolveTraitField (single source of truth, lesson mapping-fix).
+        const value = BlessingService.resolveTraitField(girl as any, bless.kind as any);
+        return String(value ?? '') === bless.value;
     }
 
-    // ---- One pool -> one team ------------------------------------------
+    // ---- One pool + one cluster -> one team ----------------------------
 
     /**
-     * Build a single team from one pool (Spec step 2). Sequence:
-     *   A. Choose cluster from the trait hierarchy.
-     *   B. Pick leader from the FULL eligible pool (the leader does
-     *      not have to satisfy the bless filter, it just has to fit
-     *      the chosen cluster -- a strong Mythic Shield from outside
-     *      the bless pool wins over a weaker bless-pool mythic).
-     *   C. Fill positions 2..7 from the local pool, minus the leader.
-     * Returns null if the pool cannot fill 7 slots.
+     * Build a clustered candidate from a pool and a GIVEN cluster.
+     *   A. Leader from the FULL eligible pool via Leaderauswahl-Regel
+     *      against this cluster (a strong Mythic Shield from outside the
+     *      bless pool can lead -- spec rule).
+     *   B. Fill positions 2..7 from the pool, cluster-constrained.
+     * Returns null if the pool cannot fill 7 slots for this cluster.
      */
-    private static buildFromPool(
+    private static buildWithCluster(
         pool: GirlData[],
         eligibleAll: GirlData[],
         scoreMap: Map<number, number>,
+        cluster: TeamCluster,
     ): { team: GirlData[]; cluster: TeamCluster; score: number } | null {
         if (pool.length < TEAM_SIZE) return null;
 
-        const cluster = TeamBuilderService.chooseTeamCluster(pool);
-        if (!cluster) return null;
-
-        // Leader-Kandidaten = gesamter eligible Pool. Die 7-key sort
-        // (Mythic > Tier-5 > Element-Pair > Trait-Match > blessed >
-        // caracs_sum > Element-Coeff) bevorzugt automatisch eine
-        // Mythic Shield mit Trait-Match, faellt zu Mythic Shield ohne
-        // Trait-Match wenn keine vorhanden, und erst dann zu Mythic
-        // Stun/Execute/Reflect.
         const leader = TeamBuilderService.pickLeader(eligibleAll, cluster, scoreMap);
         if (!leader) return null;
 
@@ -276,14 +272,172 @@ export class TeamBuilderService {
         return { team: [leader, ...positions], cluster, score: 0 };
     }
 
+    // ---- Flat candidate (no cluster constraint) ------------------------
+
+    /**
+     * Build a flat candidate: a rule-leader plus the strongest remaining
+     * TEAM_SIZE-1 girls from `pool`, with NO cluster constraint. This is
+     * NOT guaranteed to be the absolute stat-sum maximum of the pool --
+     * the leader is chosen by the Leaderauswahl-Regel (Tier-5 / blessed
+     * before raw score), so a slightly lower-score leader can be fixed by
+     * design. Its purpose is to keep a fully-blessed, no-cluster-constraint
+     * team in the comparison so the blessing multiplier is never dropped
+     * on filler slots by over-constraining on a cluster.
+     *
+     * Leader is picked from the FULL eligible pool with a CLUSTER-NEUTRAL
+     * sentinel: an empty element set and an impossible trait value, so
+     * Leaderauswahl-Regel keys 3 (element-pair match) and 4 (trait match)
+     * never fire. The leader is therefore decided by keys 1 (Mythic),
+     * 2 (Tier-5 Shield priority), 5 (blessed before unblessed), 6
+     * (caracs_sum), 7 (element coeff). That makes the strongest blessed
+     * Mythic Shield lead when one exists (-> fully blessed team), and the
+     * strongest Mythic Shield overall otherwise. The display cluster is
+     * derived from the FINAL fielded team (not a pre-pick top-7), so the
+     * reported traitCategory/value actually describes the team.
+     * Returns null if the pool cannot fill 7 slots.
+     */
+    private static buildFlat(
+        pool: GirlData[],
+        eligibleAll: GirlData[],
+        scoreMap: Map<number, number>,
+    ): { team: GirlData[]; cluster: TeamCluster; score: number } | null {
+        if (pool.length < TEAM_SIZE) return null;
+
+        const scoreOf = (g: GirlData): number =>
+            scoreMap.get(g.id_girl) ?? TeamScoringService.caracsSum(g);
+
+        // Cluster-neutral sentinel: keys 3+4 of the leader rule cannot match.
+        const NEUTRAL_CLUSTER: TeamCluster = {
+            category: 'eyeColor',
+            value: '\u0000__none__',
+            elements: [],
+        };
+
+        // Leader from the full eligible pool (spec rule: a strong Mythic
+        // Shield can lead even from outside the pool). Cluster-neutral, so
+        // blessed-vs-unblessed (key 5) breaks Shield-vs-Shield ties in
+        // favour of the blessed Shield.
+        const leader = TeamBuilderService.pickLeader(eligibleAll, NEUTRAL_CLUSTER, scoreMap);
+        if (!leader) return null;
+
+        // Pos 2..7 = strongest pool girls by score, leader excluded.
+        const positions = [...pool]
+            .filter(g => g.id_girl !== leader.id_girl)
+            .sort((a, b) => {
+                const sa = scoreOf(a);
+                const sb = scoreOf(b);
+                if (sb !== sa) return sb - sa;
+                return TeamScoringService.getElementPowerCoeff(b.element)
+                     - TeamScoringService.getElementPowerCoeff(a.element);
+            })
+            .slice(0, POS_2_TO_7);
+        if (positions.length < POS_2_TO_7) return null;
+
+        const team = [leader, ...positions];
+        // Display cluster derived from the FINAL team (dominant element pair).
+        const cluster = TeamBuilderService.chooseTeamCluster(team) ?? NEUTRAL_CLUSTER;
+        return { team, cluster, score: 0 };
+    }
+
+    // ---- Cluster enumeration + choice ----------------------------------
+
+    /**
+     * Enumerate candidate clusters for a pool: one per trait category whose
+     * element-pair holds at least TEAM_SIZE girls, with the largest trait
+     * sub-group as the cluster value. This replaces the single hierarchy
+     * pick with an explicit set so the builder can try every meaningful
+     * cluster axis and compare the resulting teams. Always includes the
+     * hierarchy fallback (chooseTeamCluster) so a pool with no >= 7 pair
+     * still yields one cluster.
+     */
+    private static enumerateClusters(pool: GirlData[]): TeamCluster[] {
+        const clusters: TeamCluster[] = [];
+        const seen = new Set<string>();
+        const push = (c: TeamCluster | null) => {
+            if (!c) return;
+            const key = c.category + '=' + c.value;
+            if (seen.has(key)) return;
+            seen.add(key);
+            clusters.push(c);
+        };
+
+        for (const category of TRAIT_HIERARCHY) {
+            const pair = ELEMENT_PAIRS_BY_CATEGORY[category];
+            const subset = pool.filter(g => pair.includes(g.element));
+            if (subset.length < TEAM_SIZE) continue;
+            const buckets = new Map<string, number>();
+            for (const g of subset) {
+                const v = TeamScoringService.getTraitValue(g);
+                if (!v) continue;
+                buckets.set(v, (buckets.get(v) || 0) + 1);
+            }
+            if (buckets.size === 0) continue;
+            const [topVal, topCount] = [...buckets.entries()].sort((a, b) => b[1] - a[1])[0];
+            // The cluster value must itself be fillable: at least one full
+            // sub-group is not required (Pos 2-7 falls back across the
+            // element pair), but a topVal sub-group below a useful size
+            // would key Tier-3 on a near-empty trait. Keep clusters whose
+            // dominant trait has more than one carrier; degenerate
+            // single-carrier clusters are skipped (the flat candidate and
+            // other axes still cover the pool).
+            if (topCount < 2) continue;
+            push({ category, value: topVal, elements: pair });
+        }
+
+        // Guarantee at least one cluster (hierarchy fallback).
+        if (clusters.length === 0) push(TeamBuilderService.chooseTeamCluster(pool));
+        return clusters;
+    }
+
+    /**
+     * Pick the winning candidate with a TRANSITIVE, order-independent
+     * rule (two passes):
+     *   1. Find the global maximum mode-aware stat-sum.
+     *   2. Among all candidates within LEADER_TIEBREAK_MARGIN of that
+     *      global max, take the one with the highest Tier-5 leader skill
+     *      (Shield > Stun > Execute > Reflect); break further ties by
+     *      higher score, then by append order (candidate priority).
+     *
+     * Anchoring the near-tie window on the GLOBAL max (not a drifting
+     * running best) guarantees the winner is always within the margin of
+     * the strongest team -- the pairwise running-best variant was
+     * non-transitive and could drift several margins below the max.
+     */
+    private static selectBestCandidate(candidates: CandidateTeam[]): CandidateTeam {
+        // buildTeam guards candidates.length === 0 before calling this;
+        // the guard here keeps the method total in isolation.
+        if (candidates.length === 0) {
+            throw new Error('selectBestCandidate called with no candidates');
+        }
+        const tier5 = (c: CandidateTeam): number =>
+            TeamScoringService.getTier5Skill(c.team[0].element).priority;
+
+        const maxScore = candidates.reduce((m, c) => Math.max(m, c.score), -Infinity);
+        const denom = Math.abs(maxScore) || 1;
+        const contenders = candidates.filter(
+            c => (maxScore - c.score) / denom <= LEADER_TIEBREAK_MARGIN,
+        );
+
+        let best = contenders[0];
+        for (let i = 1; i < contenders.length; i++) {
+            const c = contenders[i];
+            const t5c = tier5(c);
+            const t5b = tier5(best);
+            if (t5c > t5b) best = c;
+            else if (t5c === t5b && c.score > best.score) best = c;
+        }
+        return best;
+    }
+
     // ---- Cluster choice ------------------------------------------------
 
     /**
-     * Walk the trait hierarchy eyes -> hair -> zodiac -> position. The
-     * first hierarchy step that yields any sub-group inside the matching
-     * element-pair wins. Within the step, the largest sub-group is the
-     * primary cluster value. Falls through to the dominant element with
-     * Element-Coeff tiebreak when no trait category resolves.
+     * Single-cluster pick: walk the trait hierarchy eyes -> hair -> zodiac
+     * -> position, first non-empty element-pair sub-group wins (largest
+     * sub-group = cluster value). Falls through to the dominant element
+     * with Element-Coeff tiebreak when no trait category resolves. Used as
+     * the display-cluster deriver (buildFlat) and the no->=7-pair fallback
+     * (enumerateClusters).
      */
     private static chooseTeamCluster(pool: GirlData[]): TeamCluster | null {
         if (pool.length === 0) return null;
@@ -306,6 +460,11 @@ export class TeamBuilderService {
             return { category, value: topVal, girls: topGirls };
         };
 
+        // Hierarchy fallback: first trait category with a non-empty
+        // sub-group wins. Only used by buildFlat's display-cluster
+        // derivation and as the >=7-pair-less fallback in
+        // enumerateClusters; the main candidate set comes from
+        // enumerateClusters, which tries every >= 7 trait axis explicitly.
         for (const category of TRAIT_HIERARCHY) {
             const dominant = dominantBucketFor(category);
             if (dominant && dominant.girls.length >= 1) {

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -128,7 +128,12 @@ export class TeamScoringService {
      */
     static scoreBestPossible(girl: GirlData, _playerClass?: PlayerClass): number {
         const current = TeamScoringService.caracsSum(girl);
-        const level = girl.level || 1;
+        // Clamp the level into [1, PROJECTION_LEVEL_CAP]. 750 is the hard
+        // girl cap (a girl can be developed to 750 regardless of player
+        // level), so level > 750 should not occur; the guard is pure
+        // game-drift defence -- without it a drifted level > 750 would
+        // make the factor < 1 and wrongly devalue a fully-developed girl.
+        const level = Math.min(Math.max(girl.level || 1, 1), PROJECTION_LEVEL_CAP);
         const currentGrades = girl.graded || 0;
         const maxGrades = girl.nb_grades || 0;
         return current


### PR DESCRIPTION
Step 6 of the refactor (team cluster: TeamModule, TeamBuilderService, TeamScoringService), squashed from the refactor staging branch.

Refs #1722