### PR TITLE
fix: prevent auto-pachinko orb over-consumption and won-girl popup hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.35.62 - pachinko orb over-consumption fix
+
+#### Fixed
+
+- **Auto-pachinko no longer spends more orbs than requested.** On fast runs the on-screen orb counter could lag behind the server, so the routine kept pulling after it had already reached the requested number and used up extra orbs. The stop count now follows the server's reported orb total, so a run of N stops exactly at N.
+
+#### Changed
+
+- The pachinko log now records the start of a run (selected type, target, available) and a clear finish line with the number of orbs spent, making runs easier to review afterwards.
+
 ### v7.35.59 - raid girl skin endless-fight fix
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.35.61
+// @version      7.35.62
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -16218,6 +16218,11 @@ class Pachinko {
         if (!Pachinko.ajaxBindingDone) {
             Pachinko.bindPachinkoAjaxReturn();
         }
+        // Reset per-run state so the run is self-contained: no stale server count
+        // from a previous run, and a fresh retry budget.
+        Pachinko.serverOrbsLeft = undefined;
+        Pachinko.retry = 0;
+        LogUtils_logHHAuto(`Pachinko run starting: ${selectedOption.text}, target ${Pachinko.orbsToGo}, available ${Pachinko.orbLeftOnAutoStart}.`);
         Pachinko.autoPachinkoRunning = true;
         setTimeout(Pachinko.playXPachinko_func, randomInterval(500, 1500));
     }
@@ -16242,6 +16247,7 @@ class Pachinko {
     }
     static playXPachinko_func() {
         return Pachinko_awaiter(this, void 0, void 0, function* () {
+            var _a;
             let buttonSelector = Pachinko.getSelectedOptionButtonSelector();
             const buttonContinueSelector = '.popup_buttons #play_again:visible';
             if (!isDisplayedHHPopUp()) {
@@ -16262,9 +16268,14 @@ class Pachinko {
                     return;
                 }
             }
-            const currentOrbsLeft = Pachinko.getNumberOfOrbsLeft(buttonSelector);
+            const domOrbsLeft = Pachinko.getNumberOfOrbsLeft(buttonSelector);
+            // Prefer the server-reported remaining count over the DOM. The DOM value
+            // (span[total_orbs]) can lag behind the server during fast runs, which made
+            // the run continue past orbsToGo and over-consume orbs (issue 1745).
+            const currentOrbsLeft = Pachinko.resolveStopOrbsLeft(Pachinko.serverOrbsLeft, domOrbsLeft);
             const spendedOrbs = Number(Pachinko.orbLeftOnAutoStart - currentOrbsLeft);
-            //if (debugEnabled) logHHAuto('orbsLeft: ' + Pachinko.orbLeftOnAutoStart + ", currentOrbsLeft: " + currentOrbsLeft + ', spendedOrbs: ' + spendedOrbs + '/orbsToGo: ' + orbsToGo);
+            if (Pachinko.debugEnabled)
+                LogUtils_logHHAuto(`Pachinko progress: spent ${spendedOrbs}/${Pachinko.orbsToGo} (orbsLeft server=${(_a = Pachinko.serverOrbsLeft) !== null && _a !== void 0 ? _a : 'n/a'} dom=${domOrbsLeft}).`);
             if (Pachinko.stopFirstGirlChecked && $('#rewards_popup #reward_holder .shards_wrapper:visible').length > 0) {
                 LogUtils_logHHAuto("Girl in reward, stopping...");
                 maskHHPopUp();
@@ -16279,10 +16290,12 @@ class Pachinko {
                     continuePachinkoSelectedButton.trigger('click');
                 }
                 else {
-                    if (RewardHelper.closeRewardPopupIfAny(false)) {
-                        yield TimeHelper.sleep(randomInterval(500, 1000));
-                        RewardHelper.closeGirlRewardPopupIfAny(true);
-                    }
+                    // Close any reward popup before the next pull. When a girl is won the
+                    // game shows a popup whose purple Claim button (#ok_button_pachinko)
+                    // can appear a moment after the popup opens. The previous single-shot
+                    // check raced that animation: if the button was not yet :visible the
+                    // popup stayed open and the run hung (issue 1745). Poll briefly instead.
+                    yield Pachinko.closePachinkoRewardPopup();
                     pachinkoSelectedButton.click();
                     Pachinko.failureTimeoutId = setTimeout(() => {
                         // Safe mode
@@ -16294,7 +16307,7 @@ class Pachinko {
             }
             else {
                 RewardHelper.closeRewardPopupIfAny(false);
-                LogUtils_logHHAuto("All spent, going back to Selector.");
+                LogUtils_logHHAuto(`Pachinko run finished: spent ${spendedOrbs}/${Pachinko.orbsToGo} orbs, ${currentOrbsLeft} left.`);
                 maskHHPopUp();
                 Pachinko.buildPachinkoSelectPopUp(spendedOrbs);
                 return;
@@ -16318,10 +16331,16 @@ class Pachinko {
                     Pachinko.stopXPachinkoFailure();
                     return;
                 }
-                if ((_b = (_a = response.rewards) === null || _a === void 0 ? void 0 : _a.heroChangesUpdate) === null || _b === void 0 ? void 0 : _b.orbs) {
-                    //const orbs = response.rewards?.heroChangesUpdate?.orbs;
-                    // o_g10 / o_g1 / o_eq2
-                    //const orbLeftFromResponse = orbs.o_g10;
+                const orbs = (_b = (_a = response.rewards) === null || _a === void 0 ? void 0 : _a.heroChangesUpdate) === null || _b === void 0 ? void 0 : _b.orbs;
+                if (orbs) {
+                    // The play-response carries the authoritative remaining count for
+                    // the selected orb type (e.g. orbs.o_g10). Capture it so the stop
+                    // logic no longer depends on the lag-prone DOM counter (issue 1745).
+                    const selectedOrbName = Pachinko.getSelectedOrbName();
+                    const remaining = orbs[selectedOrbName];
+                    if (typeof remaining === 'number') {
+                        Pachinko.serverOrbsLeft = remaining;
+                    }
                     if (Pachinko.failureTimeoutId)
                         clearTimeout(Pachinko.failureTimeoutId); // cancel safe mode
                     if (Pachinko.autoPachinkoRunning) {
@@ -16335,6 +16354,61 @@ class Pachinko {
                     Pachinko.stopXPachinkoFailure();
             }
         });
+    }
+    // Resolves the orb_name of the currently selected pachinko option (e.g. "o_g10").
+    // Used to read the matching remaining count from the server play-response.
+    static getSelectedOrbName() {
+        var _a;
+        try {
+            if (!Pachinko.pachinkoSelector)
+                return 'unknown';
+            const opt = Pachinko.pachinkoSelector.options[Pachinko.pachinkoSelector.selectedIndex];
+            return (_a = opt === null || opt === void 0 ? void 0 : opt.value) !== null && _a !== void 0 ? _a : 'unknown';
+        }
+        catch (e) {
+            return 'unknown';
+        }
+    }
+    // Closes any reward popup shown between pulls (a normal reward, or the
+    // popup shown after winning a girl). The won-girl popup exposes a blue
+    // "redirect-to-harem" button; the actual dismiss action is the purple Claim
+    // button (#ok_button_pachinko) inside #rewards_popup, which can become
+    // :visible a moment after the popup opens. RewardHelper.closeRewardPopupIfAny
+    // checks once and returns false while the button is still animating in, which
+    // left the run hanging (issue 1745). This retries for a short window: each
+    // iteration delegates to the shared close helpers, and only keeps waiting
+    // while a popup is actually open but not yet closeable.
+    static closePachinkoRewardPopup() {
+        return Pachinko_awaiter(this, arguments, void 0, function* (maxWaitMs = 3000) {
+            const popupButtonsVisible = () => $('#rewards_popup button.blue_button_L:visible, #rewards_popup button.purple_button_L:visible').length > 0;
+            const deadline = Date.now() + maxWaitMs;
+            while (true) {
+                if (RewardHelper.closeRewardPopupIfAny(false)) {
+                    // A reward (or the girl redirect) was handled. A girl popup can
+                    // follow a normal reward, so give it a moment and claim it too.
+                    yield TimeHelper.sleep(randomInterval(500, 1000));
+                    RewardHelper.closeGirlRewardPopupIfAny(true);
+                    return;
+                }
+                // Nothing was closeable this tick. Either there is no popup (the common
+                // case, proceed immediately) or a won-girl popup is still animating in
+                // and its purple Claim button is not :visible yet (the race).
+                if (!popupButtonsVisible() || Date.now() >= deadline) {
+                    return;
+                }
+                yield TimeHelper.sleep(randomInterval(150, 300));
+            }
+        });
+    }
+    // Chooses which remaining-orb count drives the stop decision. The server value
+    // (from the play-response) is authoritative and lag-free; the DOM value is only
+    // a fallback for the first tick (before any pull) or when the server key is
+    // missing. See issue 1745 for the over-consumption this prevents.
+    static resolveStopOrbsLeft(serverOrbsLeft, domOrbsLeft) {
+        if (typeof serverOrbsLeft === 'number' && serverOrbsLeft >= 0) {
+            return serverOrbsLeft;
+        }
+        return domOrbsLeft;
     }
     static getHumanPachinkoFromOrbName(orb_name) {
         switch (orb_name) {
@@ -16361,6 +16435,10 @@ Pachinko.autoPachinkoRunning = false;
 Pachinko.failureTimeoutId = undefined;
 Pachinko.pachinkoSelector = undefined;
 Pachinko.retry = 0;
+// Authoritative remaining orb count for the selected type, taken from the
+// server play-response. Preferred over the DOM counter, which can lag during
+// fast runs and cause over-consumption past the requested amount (issue 1745).
+Pachinko.serverOrbsLeft = undefined;
 
 ;// CONCATENATED MODULE: ./src/Module/Shop.ts
 // Shop.ts -- Automates the equipment shop: buys and sells equipment, manages
@@ -28354,7 +28432,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.61";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.62";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.35.61",
+  "version": "7.35.62",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Pachinko.spec.ts
+++ b/spec/Module/Pachinko.spec.ts
@@ -37,4 +37,21 @@ describe("Pachinko", function() {
       expect(Pachinko.getHumanPachinkoFromOrbName('o_g10')).toBe('10');
     });
   });
+
+  describe("resolveStopOrbsLeft", function() {
+    it("prefers the server count when it is a valid number", function() {
+      // Server is authoritative even when the DOM lags behind (issue 1745).
+      expect(Pachinko.resolveStopOrbsLeft(104, 109)).toBe(104);
+    });
+    it("accepts zero from the server", function() {
+      expect(Pachinko.resolveStopOrbsLeft(0, 5)).toBe(0);
+    });
+    it("falls back to the DOM when the server count is undefined", function() {
+      // First tick of a run, before any play-response has arrived.
+      expect(Pachinko.resolveStopOrbsLeft(undefined, 123)).toBe(123);
+    });
+    it("falls back to the DOM when the server count is negative", function() {
+      expect(Pachinko.resolveStopOrbsLeft(-1, 42)).toBe(42);
+    });
+  });
 });

--- a/src/Module/Pachinko.ts
+++ b/src/Module/Pachinko.ts
@@ -35,6 +35,10 @@ export class Pachinko {
     static stopFirstGirlChecked: boolean;
     static debugEnabled: boolean;
     static retry: number = 0;
+    // Authoritative remaining orb count for the selected type, taken from the
+    // server play-response. Preferred over the DOM counter, which can lag during
+    // fast runs and cause over-consumption past the requested amount (issue 1745).
+    static serverOrbsLeft: number | undefined = undefined;
 
     static getGreatPachinko(): Promise<boolean> {
         return Pachinko.getFreePachinko('great','nextPachinkoTime','great-timer');
@@ -293,6 +297,12 @@ export class Pachinko {
             Pachinko.bindPachinkoAjaxReturn();
         }
 
+        // Reset per-run state so the run is self-contained: no stale server count
+        // from a previous run, and a fresh retry budget.
+        Pachinko.serverOrbsLeft = undefined;
+        Pachinko.retry = 0;
+        logHHAuto(`Pachinko run starting: ${selectedOption.text}, target ${Pachinko.orbsToGo}, available ${Pachinko.orbLeftOnAutoStart}.`);
+
         Pachinko.autoPachinkoRunning = true;
         setTimeout(Pachinko.playXPachinko_func, randomInterval(500, 1500));
     }
@@ -338,9 +348,13 @@ export class Pachinko {
             }
         }
 
-        const currentOrbsLeft = Pachinko.getNumberOfOrbsLeft(buttonSelector);
+        const domOrbsLeft = Pachinko.getNumberOfOrbsLeft(buttonSelector);
+        // Prefer the server-reported remaining count over the DOM. The DOM value
+        // (span[total_orbs]) can lag behind the server during fast runs, which made
+        // the run continue past orbsToGo and over-consume orbs (issue 1745).
+        const currentOrbsLeft = Pachinko.resolveStopOrbsLeft(Pachinko.serverOrbsLeft, domOrbsLeft);
         const spendedOrbs = Number(Pachinko.orbLeftOnAutoStart - currentOrbsLeft);
-        //if (debugEnabled) logHHAuto('orbsLeft: ' + Pachinko.orbLeftOnAutoStart + ", currentOrbsLeft: " + currentOrbsLeft + ', spendedOrbs: ' + spendedOrbs + '/orbsToGo: ' + orbsToGo);
+        if (Pachinko.debugEnabled) logHHAuto(`Pachinko progress: spent ${spendedOrbs}/${Pachinko.orbsToGo} (orbsLeft server=${Pachinko.serverOrbsLeft ?? 'n/a'} dom=${domOrbsLeft}).`);
         if (Pachinko.stopFirstGirlChecked && $('#rewards_popup #reward_holder .shards_wrapper:visible').length > 0) {
             logHHAuto("Girl in reward, stopping...");
             maskHHPopUp();
@@ -355,10 +369,12 @@ export class Pachinko {
                 continuePachinkoSelectedButton.trigger('click');
             }
             else {
-                if(RewardHelper.closeRewardPopupIfAny(false)) {
-                    await TimeHelper.sleep(randomInterval(500, 1000));
-                    RewardHelper.closeGirlRewardPopupIfAny(true);
-                }
+                // Close any reward popup before the next pull. When a girl is won the
+                // game shows a popup whose purple Claim button (#ok_button_pachinko)
+                // can appear a moment after the popup opens. The previous single-shot
+                // check raced that animation: if the button was not yet :visible the
+                // popup stayed open and the run hung (issue 1745). Poll briefly instead.
+                await Pachinko.closePachinkoRewardPopup();
                 pachinkoSelectedButton.click();
 
                 Pachinko.failureTimeoutId = setTimeout(() => {
@@ -372,7 +388,7 @@ export class Pachinko {
         }
         else {
             RewardHelper.closeRewardPopupIfAny(false);
-            logHHAuto("All spent, going back to Selector.");
+            logHHAuto(`Pachinko run finished: spent ${spendedOrbs}/${Pachinko.orbsToGo} orbs, ${currentOrbsLeft} left.`);
             maskHHPopUp();
             Pachinko.buildPachinkoSelectPopUp(spendedOrbs);
             return;
@@ -396,10 +412,16 @@ export class Pachinko {
                     return;
                 }
 
-                if (response.rewards?.heroChangesUpdate?.orbs) {
-                    //const orbs = response.rewards?.heroChangesUpdate?.orbs;
-                    // o_g10 / o_g1 / o_eq2
-                    //const orbLeftFromResponse = orbs.o_g10;
+                const orbs = response.rewards?.heroChangesUpdate?.orbs;
+                if (orbs) {
+                    // The play-response carries the authoritative remaining count for
+                    // the selected orb type (e.g. orbs.o_g10). Capture it so the stop
+                    // logic no longer depends on the lag-prone DOM counter (issue 1745).
+                    const selectedOrbName = Pachinko.getSelectedOrbName();
+                    const remaining = orbs[selectedOrbName];
+                    if (typeof remaining === 'number') {
+                        Pachinko.serverOrbsLeft = remaining;
+                    }
                     if (Pachinko.failureTimeoutId) clearTimeout(Pachinko.failureTimeoutId); // cancel safe mode
                     if (Pachinko.autoPachinkoRunning) {
                         setTimeout(Pachinko.playXPachinko_func, randomInterval(200, 500));
@@ -410,6 +432,60 @@ export class Pachinko {
                 else Pachinko.stopXPachinkoFailure();
             }
         });
+    }
+
+    // Resolves the orb_name of the currently selected pachinko option (e.g. "o_g10").
+    // Used to read the matching remaining count from the server play-response.
+    static getSelectedOrbName(): string {
+        try {
+            if (!Pachinko.pachinkoSelector) return 'unknown';
+            const opt = Pachinko.pachinkoSelector.options[Pachinko.pachinkoSelector.selectedIndex];
+            return opt?.value ?? 'unknown';
+        } catch (e) {
+            return 'unknown';
+        }
+    }
+
+    // Closes any reward popup shown between pulls (a normal reward, or the
+    // popup shown after winning a girl). The won-girl popup exposes a blue
+    // "redirect-to-harem" button; the actual dismiss action is the purple Claim
+    // button (#ok_button_pachinko) inside #rewards_popup, which can become
+    // :visible a moment after the popup opens. RewardHelper.closeRewardPopupIfAny
+    // checks once and returns false while the button is still animating in, which
+    // left the run hanging (issue 1745). This retries for a short window: each
+    // iteration delegates to the shared close helpers, and only keeps waiting
+    // while a popup is actually open but not yet closeable.
+    static async closePachinkoRewardPopup(maxWaitMs: number = 3000): Promise<void> {
+        const popupButtonsVisible = () =>
+            $('#rewards_popup button.blue_button_L:visible, #rewards_popup button.purple_button_L:visible').length > 0;
+        const deadline = Date.now() + maxWaitMs;
+        while (true) {
+            if (RewardHelper.closeRewardPopupIfAny(false)) {
+                // A reward (or the girl redirect) was handled. A girl popup can
+                // follow a normal reward, so give it a moment and claim it too.
+                await TimeHelper.sleep(randomInterval(500, 1000));
+                RewardHelper.closeGirlRewardPopupIfAny(true);
+                return;
+            }
+            // Nothing was closeable this tick. Either there is no popup (the common
+            // case, proceed immediately) or a won-girl popup is still animating in
+            // and its purple Claim button is not :visible yet (the race).
+            if (!popupButtonsVisible() || Date.now() >= deadline) {
+                return;
+            }
+            await TimeHelper.sleep(randomInterval(150, 300));
+        }
+    }
+
+    // Chooses which remaining-orb count drives the stop decision. The server value
+    // (from the play-response) is authoritative and lag-free; the DOM value is only
+    // a fallback for the first tick (before any pull) or when the server key is
+    // missing. See issue 1745 for the over-consumption this prevents.
+    static resolveStopOrbsLeft(serverOrbsLeft: number | undefined, domOrbsLeft: number): number {
+        if (typeof serverOrbsLeft === 'number' && serverOrbsLeft >= 0) {
+            return serverOrbsLeft;
+        }
+        return domOrbsLeft;
     }
 
     static getHumanPachinkoFromOrbName(orb_name: string): string

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.35.61";
+const FEATURE_POPUP_TITLE = "HHAuto v7.35.62";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
Fixes two auto-pachinko problems reported for v7.35.60.

- Stop logic now uses the server-reported remaining orb count instead of the lag-prone DOM counter, so a run of N stops exactly at N instead of over-consuming.
- The won-girl reward popup is now closed reliably via short polling, instead of a single-shot check that could race the popup animation and stall the run.
- Run start/finish are logged (type, target, available, spent) for easier review.

Refs #1745