### PR TITLE
chore: gitignore local pending and prompt notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ docs-internal/REVIEW_*.md
 # Webpack bundle analyzer stats
 stats.json
 docs-internal/HANDOVER_*.md
+# Lokale Live-Test-Tracking- und Prompt-Notizen (nicht syncen)
+docs-internal/PENDING_*.md
+docs-internal/PROMPT_*.md


### PR DESCRIPTION
Local-only working notes, same as REVIEW_*/HANDOVER_*.