### PR TITLE
feat: add Pornstar Harem boss Marie McCray (v7.37.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ docs-internal/HANDOVER_*.md
 # Lokale Live-Test-Tracking- und Prompt-Notizen (nicht syncen)
 docs-internal/PENDING_*.md
 docs-internal/PROMPT_*.md
+docs-internal/SESSION_HANDOVER_*.md
+docs-internal/RELEASE_RUNBOOK_*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.1 - new Pornstar Harem boss
+
+#### Added
+
+- **New boss "Marie McCray"** added to Pornstar Harem (world 28), including her three reward girls so the troll fighter recognises and tracks them.
+
 ### v7.37.0 - block-based pipeline + block reordering
 
 #### Added

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.0
+// @version      7.37.1
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -14015,7 +14015,8 @@ class PornstarHarem {
             'The Hooded Heroine',
             'EMPTY',
             'Monica Mattos',
-            'Caty Campbell'];
+            'Caty Campbell',
+            'Marie McCray'];
         switch (languageCode) {
             case "fr":
                 trollList[1] = 'Directrice Asa Akira';
@@ -14044,13 +14045,14 @@ class PornstarHarem {
             [[0], [0], [0]],
             [['409433993', '438706084', '673600948'], [0], [0]],
             [['248370930', '257485641', '381828319'], [0], [0]],
+            [['409136518', '330443174', '958834753'], [0], [0]], // Marie McCray (world 28)
         ];
     }
     static updateFeatures(envVariables) {
         envVariables.isEnabledSpreadsheets = false;
     }
 }
-PornstarHarem.trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17 }; // under 10 id as usual
+PornstarHarem.trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 28: 19 }; // under 10 id as usual
 PornstarHarem.lastQuestId = 16100; //  TODO update when new quest comes
 
 ;// CONCATENATED MODULE: ./src/config/game/TransPornstarHaremVars.ts
@@ -26264,7 +26266,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.0";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.1";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.0",
+  "version": "7.37.1",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.0";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.1";
 
 /**
  * HTML content for the feature popup.

--- a/src/config/game/PornstarHaremVars.ts
+++ b/src/config/game/PornstarHaremVars.ts
@@ -3,7 +3,7 @@
 // and quest data specific to the Pornstar Harem game variant.
 
 export class PornstarHarem {
-    static trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17 }; // under 10 id as usual
+    static trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 28: 19 }; // under 10 id as usual
     static lastQuestId = 16100; //  TODO update when new quest comes
     static getEnv() {
         return {
@@ -31,7 +31,8 @@ export class PornstarHarem {
                     'The Hooded Heroine',
                     'EMPTY',
                     'Monica Mattos',
-                    'Caty Campbell'];
+                    'Caty Campbell',
+                    'Marie McCray'];
 
         switch (languageCode) {
             case "fr":
@@ -62,6 +63,7 @@ export class PornstarHarem {
             [[0], [0], [0]],
             [['409433993', '438706084', '673600948'], [0], [0]],
             [['248370930', '257485641', '381828319'], [0], [0]],
+            [['409136518', '330443174', '958834753'], [0], [0]],   // Marie McCray (world 28)
         ];
     }
 


### PR DESCRIPTION
Adds the new Pornstar Harem boss "Marie McCray" (world 28, troll index 19) with her three reward girls, and the matching trollIdMapping entry so the troll fighter resolves world 28.

Refs #1744