### PR TITLE
fix: map Pornstar Harem world 27 to Caty Campbell (v7.37.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.2 - Pornstar Harem boss mapping fix
+
+#### Fixed
+
+- **Caty Campbell (Pornstar Harem world 27)** is now recognised by the troll fighter. Her world had no ID mapping and resolved to the wrong opponent.
+
 ### v7.37.1 - new Pornstar Harem boss
 
 #### Added

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.1
+// @version      7.37.2
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -14052,7 +14052,7 @@ class PornstarHarem {
         envVariables.isEnabledSpreadsheets = false;
     }
 }
-PornstarHarem.trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 28: 19 }; // under 10 id as usual
+PornstarHarem.trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 27: 18, 28: 19 }; // under 10 id as usual
 PornstarHarem.lastQuestId = 16100; //  TODO update when new quest comes
 
 ;// CONCATENATED MODULE: ./src/config/game/TransPornstarHaremVars.ts
@@ -26266,7 +26266,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.1";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.2";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.1",
+  "version": "7.37.2",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.1";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.2";
 
 /**
  * HTML content for the feature popup.

--- a/src/config/game/PornstarHaremVars.ts
+++ b/src/config/game/PornstarHaremVars.ts
@@ -3,7 +3,7 @@
 // and quest data specific to the Pornstar Harem game variant.
 
 export class PornstarHarem {
-    static trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 28: 19 }; // under 10 id as usual
+    static trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 27: 18, 28: 19 }; // under 10 id as usual
     static lastQuestId = 16100; //  TODO update when new quest comes
     static getEnv() {
         return {


### PR DESCRIPTION
Adds the missing trollIdMapping entry for Pornstar Harem world 27 (Caty Campbell, troll index 18). Without it the troll fighter logged an error and resolved the wrong opponent on that world. Verified the full PSH world->troll->girls table against live data; all other entries already correct.

Refs #1744