### PR TITLE
chore: ignore docs-internal/_archive local notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ docs-internal/PENDING_*.md
 docs-internal/PROMPT_*.md
 docs-internal/SESSION_HANDOVER_*.md
 docs-internal/RELEASE_RUNBOOK_*.md
+# Lokales Archiv abgeschlossener Notizen (nicht syncen)
+docs-internal/_archive/


### PR DESCRIPTION
Ignores docs-internal/_archive, the local folder where completed module-review notes and old session handovers are now kept. Keeps the local archive out of the repo and out of git status. No code or behaviour change.