### PR TITLE
feat: tune Penta Drill / Stuff Team / booster delays (v7.37.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.3 - timing tweaks
+
+#### Changed
+
+- **Penta Drill** now waits longer after starting a fight, avoiding the occasional blank screen when the next step was clicked before the server had responded.
+- **Stuff Team** paces the equipment clicks more slowly (about half a second between clicks) for steadier, more human-like equipping.
+- **Auto-equip boosters** re-check on a tighter randomized schedule (15-45 minutes) instead of up to 2 hours.
+
 ### v7.37.2 - Pornstar Harem boss mapping fix
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.2
+// @version      7.37.3
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -5063,15 +5063,15 @@ class Booster {
         return Math.max(0, Math.floor(longest));
     }
     /**
-     * Generates a random delay between 5 minutes and 2 hours (in seconds).
+     * Generates a random delay between 15 and 45 minutes (in seconds).
      * Added to booster expiry time to make auto-equip timing look human.
      */
     static getRandomEquipDelay() {
-        return randomInterval(5 * 60, 2 * 60 * 60);
+        return randomInterval(15 * 60, 45 * 60);
     }
     /**
      * Schedules the next auto-equip check based on the longest-running active booster
-     * plus a random delay (5 min - 2 h). If no boosters are active, schedules immediately
+     * plus a random delay (15-45 min). If no boosters are active, schedules immediately
      * with just the random delay.
      */
     static scheduleNextEquipCheck() {
@@ -7808,7 +7808,7 @@ class HaremGirl {
                 const slot = equipmentSlots.eq(i);
                 slot.trigger('click');
                 // Short wait so the game kicks off its inventory request for this slot
-                yield TimeHelper.sleep(randomInterval(100, 200));
+                yield TimeHelper.sleep(randomInterval(500, 700));
                 // Force game to render all lazy-loaded inventory items into the DOM
                 yield HaremGirl.forceLoadAllInventoryItems();
                 const equippedEl = slot.find('.slot[data-d]');
@@ -7912,7 +7912,7 @@ class HaremGirl {
                         else {
                             bestInventory.el.trigger('click');
                         }
-                        yield TimeHelper.sleep(randomInterval(100, 200));
+                        yield TimeHelper.sleep(randomInterval(500, 700));
                         // Click the Equip confirm button (revealed after item selection)
                         let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
                         // Wait up to ~500ms for the button to become enabled
@@ -7927,7 +7927,7 @@ class HaremGirl {
                                 btnRaw.click();
                             else
                                 $equipBtn.trigger('click');
-                            yield TimeHelper.sleep(randomInterval(200, 300));
+                            yield TimeHelper.sleep(randomInterval(500, 700));
                             LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         }
                         else {
@@ -11752,7 +11752,7 @@ class PentaDrill {
                 performButton.trigger('click');
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 LogUtils_logHHAuto("setting autoloop to false");
-                yield TimeHelper.sleep(randomInterval(5000, 8000));
+                yield TimeHelper.sleep(randomInterval(6000, 9000));
                 //setTimer('nextPentaDrillTime',10);
                 return true;
             }
@@ -26266,7 +26266,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.2";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.3";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.2",
+  "version": "7.37.3",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Module/Booster.ts
+++ b/src/Module/Booster.ts
@@ -455,16 +455,16 @@ export class Booster {
     }
 
     /**
-     * Generates a random delay between 5 minutes and 2 hours (in seconds).
+     * Generates a random delay between 15 and 45 minutes (in seconds).
      * Added to booster expiry time to make auto-equip timing look human.
      */
     static getRandomEquipDelay(): number {
-        return randomInterval(5 * 60, 2 * 60 * 60);
+        return randomInterval(15 * 60, 45 * 60);
     }
 
     /**
      * Schedules the next auto-equip check based on the longest-running active booster
-     * plus a random delay (5 min - 2 h). If no boosters are active, schedules immediately
+     * plus a random delay (15-45 min). If no boosters are active, schedules immediately
      * with just the random delay.
      */
     static scheduleNextEquipCheck(): void {

--- a/src/Module/PentaDrill.ts
+++ b/src/Module/PentaDrill.ts
@@ -168,7 +168,7 @@ export class PentaDrill {
             performButton.trigger('click');
             setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "false");
             logHHAuto("setting autoloop to false");
-            await TimeHelper.sleep(randomInterval(5000, 8000));
+            await TimeHelper.sleep(randomInterval(6000, 9000));
             //setTimer('nextPentaDrillTime',10);
             return true;
         }

--- a/src/Module/harem/HaremGirl.ts
+++ b/src/Module/harem/HaremGirl.ts
@@ -910,7 +910,7 @@ export class HaremGirl {
             const slot = equipmentSlots.eq(i);
             slot.trigger('click');
             // Short wait so the game kicks off its inventory request for this slot
-            await TimeHelper.sleep(randomInterval(100, 200));
+            await TimeHelper.sleep(randomInterval(500, 700));
 
             // Force game to render all lazy-loaded inventory items into the DOM
             await HaremGirl.forceLoadAllInventoryItems();
@@ -1013,7 +1013,7 @@ export class HaremGirl {
                     } else {
                         bestInventory.el.trigger('click');
                     }
-                    await TimeHelper.sleep(randomInterval(100, 200));
+                    await TimeHelper.sleep(randomInterval(500, 700));
 
                     // Click the Equip confirm button (revealed after item selection)
                     let $equipBtn = $('#girl-equipment-equip').removeClass('hidden').removeAttr('hidden');
@@ -1028,7 +1028,7 @@ export class HaremGirl {
                         const btnRaw = $equipBtn.get(0) as HTMLElement | undefined;
                         if (btnRaw && typeof btnRaw.click === 'function') btnRaw.click();
                         else $equipBtn.trigger('click');
-                        await TimeHelper.sleep(randomInterval(200, 300));
+                        await TimeHelper.sleep(randomInterval(500, 700));
                         logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                     } else {
                         logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.2";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.3";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
Tunes three action delays from reporter feedback:

- Penta Drill waits longer after starting a fight (5-8s -> 6-9s) to avoid the blank screen when the next step fired before the server responded.
- Stuff Team paces the three equipment clicks ~0.5s apart for steadier, more human-like equipping.
- Auto-equip booster re-check schedule shortened from up to 2h to a randomized 15-45min.

Constant-only changes, no logic change.

Refs #1593, #1679, #1718