### PR TITLE
chore: raise debug log buffer to 5000 entries (v7.37.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.4 - longer debug log
+
+#### Changed
+
+- The debug log now keeps up to 5000 entries (was 500), so a Save Debug capture covers a much longer run for troubleshooting.
+
 ### v7.37.3 - timing tweaks
 
 #### Changed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.3
+// @version      7.37.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -24708,8 +24708,9 @@ function getBrowserData(nav) {
 
 
 
-/** Maximum number of log entries kept in storage before old ones are pruned. */
-const MAX_LINES = 500;
+/** Maximum number of log entries kept in storage before old ones are pruned.
+ * ~132 bytes/entry observed, so 5000 entries is roughly 0.65 MB in sessionStorage. */
+const MAX_LINES = 5000;
 /**
  * Wipe all existing log entries from storage and free up large temp
  * caches. Called from setStoredValue's quota-error catch path, so this
@@ -26266,7 +26267,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.3";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.4";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.3",
+  "version": "7.37.4",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.3";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.4";
 
 /**
  * HTML content for the feature popup.

--- a/src/Utils/LogUtils.ts
+++ b/src/Utils/LogUtils.ts
@@ -19,8 +19,9 @@ import { TK } from "../config/StorageKeys";
 import { getBrowserData } from "./BrowserUtils";
 import { safeJsonParse } from './Utils';
 
-/** Maximum number of log entries kept in storage before old ones are pruned. */
-const MAX_LINES = 500
+/** Maximum number of log entries kept in storage before old ones are pruned.
+ * ~132 bytes/entry observed, so 5000 entries is roughly 0.65 MB in sessionStorage. */
+const MAX_LINES = 5000
 
 /**
  * Wipe all existing log entries from storage and free up large temp


### PR DESCRIPTION
Raises the debug log buffer from 500 to 5000 entries (~0.65 MB) so a Save Debug capture covers a much longer run. The buffer is re-serialized per write, so 5000 balances coverage against per-write cost. No behaviour change beyond log retention.