### PR TITLE
fix: keep Season fighting instead of stalling after a few fights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.5 - Season no longer stops early
+
+#### Fixed
+
+- **Season** could stop after the first few fights and arm a ~30 minute timer even though more fights were still available, so it looked like only one fight ran. The auto-fighter now keeps going through your remaining Season energy as intended.
+
 ### v7.37.4 - longer debug log
 
 #### Changed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.4
+// @version      7.37.5
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -5726,6 +5726,15 @@ class Season {
                     LogUtils_logHHAuto(`Max tier reached (${Season.getTierLevel()} >= ${maxTier}) but "Stop if no event girl" enabled, will check for event girls.`);
                 }
                 var chosenID = yield Season.moduleSimSeasonBattle(true);
+                if (chosenID === undefined || chosenID === null) {
+                    // Defensive wall (issue #1722): moduleSimSeasonBattle must return a
+                    // number (opponent id, -1 or -2). A null/undefined result means the
+                    // simulation did not run (e.g. a poisoned callItOnce wrapper). Retry
+                    // shortly instead of arming the 30 min "no opponent" timer.
+                    LogUtils_logHHAuto("Season : opponent simulation returned no result, retrying shortly.");
+                    setTimer('nextSeasonTime', randomInterval(5, 10));
+                    return false;
+                }
                 if (chosenID === -2) {
                     //change opponents and reload
                     function refreshOpponents() {
@@ -19190,6 +19199,11 @@ var AutoLoopPageHandlers_awaiter = (undefined && undefined.__awaiter) || functio
 
 
 
+// Tracks whether the read-only Season-arena power-calc preview has already
+// been rendered on the current page load. Reset implicitly on every page
+// navigation (full reload re-initialises the module). Used instead of
+// wrapping Season.moduleSimSeasonBattle in callItOnce -- see issue #1722.
+let seasonArenaPreviewShown = false;
 function handlePageSpecific(ctx) {
     return AutoLoopPageHandlers_awaiter(this, void 0, void 0, function* () {
         switch (ctx.currentPage) {
@@ -19203,11 +19217,15 @@ function handlePageSpecific(ctx) {
                 break;
             case ConfigHelper.getHHScriptVars("pagesIDSeasonArena"):
                 if (getStoredValue(HHStoredVarPrefixKey + SK.showCalculatePower) === "true" && $("div.matchRatingNew img#powerLevelScouter").length < 3) {
-                    if (ctx.lastActionPerformed !== "season") {
-                        // Avoid double call when coming from Season.run()
-                        Season.stylesBattle = callItOnce(Season.stylesBattle);
+                    // Display-only power-calc preview. Do NOT wrap Season.stylesBattle or
+                    // Season.moduleSimSeasonBattle in callItOnce: Season.run() calls the very
+                    // same static methods, and a consumed once-wrapper makes run() receive
+                    // undefined from moduleSimSeasonBattle, which then arms a ~30 min timer and
+                    // stalls Season after a few fights (issue #1722). A module-scoped flag keeps
+                    // this preview to once per page load without poisoning the shared methods.
+                    if (ctx.lastActionPerformed !== "season" && !seasonArenaPreviewShown) {
+                        seasonArenaPreviewShown = true;
                         Season.stylesBattle();
-                        Season.moduleSimSeasonBattle = callItOnce(Season.moduleSimSeasonBattle);
                         Season.moduleSimSeasonBattle();
                     }
                 }
@@ -26267,7 +26285,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.4";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.5";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.4",
+  "version": "7.37.5",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Events/Season.spec.ts
+++ b/spec/Module/Events/Season.spec.ts
@@ -1,4 +1,4 @@
-import { setTimer } from "../../../src/Helper/TimerHelper";
+import { getSecondsLeft, setTimer } from "../../../src/Helper/TimerHelper";
 import { Booster } from '../../../src/Module/Booster';
 import { Season } from '../../../src/Module/Events/Season';
 import { ParanoiaService } from "../../../src/Service/ParanoiaService";
@@ -382,6 +382,29 @@ describe("Season event", function () {
             const result = Season.isTimeToFight();
 
             expect(result).toBeTruthy();
+        });
+    });
+
+    describe("run defensive wall (issue #1722)", function () {
+        beforeEach(() => {
+            MockHelper.mockHeroLevel(500);
+            MockHelper.mockPage('season_arena', '<div id="tier_indicator">1</div>');
+            localStorage.setItem(HHStoredVarPrefixKey + "Setting_autoSeasonMaxTier", "false");
+            setTimer('nextSeasonTime', -1);
+        });
+
+        it("retries shortly instead of arming the 30 min timer when the sim returns undefined", async () => {
+            jest.spyOn(Season, 'stylesBattle').mockImplementation(() => {});
+            jest.spyOn(Season, 'moduleSimSeasonBattle').mockResolvedValue(undefined as any);
+
+            const result = await Season.run();
+
+            expect(result).toBe(false);
+            const left = getSecondsLeft('nextSeasonTime');
+            expect(left).toBeGreaterThan(0);
+            expect(left).toBeLessThanOrEqual(11);
+
+            jest.restoreAllMocks();
         });
     });
 });

--- a/spec/Service/AutoLoopPageHandlers.spec.ts
+++ b/spec/Service/AutoLoopPageHandlers.spec.ts
@@ -1,0 +1,67 @@
+import { handlePageSpecific } from "../../src/Service/AutoLoopPageHandlers";
+import { AutoLoopContext } from "../../src/Service/AutoLoopContext";
+import { Season } from "../../src/Module/Events/Season";
+import { ConfigHelper } from "../../src/Helper/ConfigHelper";
+import { MockHelper } from "../testHelpers/MockHelpers";
+
+// Regression guard for issue #1722.
+//
+// The season_arena page handler used to do:
+//   Season.moduleSimSeasonBattle = callItOnce(Season.moduleSimSeasonBattle);
+//   Season.moduleSimSeasonBattle();
+// callItOnce REPLACED the shared static method. Season.run() calls the very
+// same method to pick an opponent; once the display preview had consumed the
+// single allowed call, run() received undefined, fell into the fight branch
+// with [data-opponent=undefined], found no fight link and armed a ~30 min
+// timer -- Season looked like it stopped after one fight.
+//
+// The handler must run the preview WITHOUT poisoning the shared method.
+
+function makeCtx(page: string, lastAction: string): AutoLoopContext {
+    return {
+        busy: false,
+        lastActionPerformed: lastAction,
+        currentPower: 0,
+        canCollectCompetitionActive: true,
+        eventIDs: [],
+        bossBangEventIDs: [],
+        currentPage: page,
+    };
+}
+
+describe("handlePageSpecific season_arena (issue #1722)", function () {
+
+    beforeEach(() => {
+        MockHelper.mockDomain();
+        MockHelper.mockPage("season_arena");
+        MockHelper.mockSetting("showCalculatePower", "true");
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("does not poison Season.moduleSimSeasonBattle: run() still gets a real result", async () => {
+        const simSpy = jest.spyOn(Season, "moduleSimSeasonBattle").mockResolvedValue(42 as any);
+        jest.spyOn(Season, "stylesBattle").mockImplementation(() => {});
+
+        const ctx = makeCtx(ConfigHelper.getHHScriptVars("pagesIDSeasonArena"), "none");
+        await handlePageSpecific(ctx); // display preview -> call #1
+
+        // Simulate Season.run() asking for the chosen opponent afterwards.
+        const result = await Season.moduleSimSeasonBattle(true); // call #2
+
+        expect(simSpy).toHaveBeenCalledTimes(2);
+        expect(result).toBe(42);
+    });
+
+    it("skips the preview when arriving straight from a Season fight", async () => {
+        const simSpy = jest.spyOn(Season, "moduleSimSeasonBattle").mockResolvedValue(7 as any);
+        jest.spyOn(Season, "stylesBattle").mockImplementation(() => {});
+
+        const ctx = makeCtx(ConfigHelper.getHHScriptVars("pagesIDSeasonArena"), "season");
+        await handlePageSpecific(ctx);
+
+        expect(simSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/Module/Events/Season.ts
+++ b/src/Module/Events/Season.ts
@@ -355,6 +355,16 @@ export class Season {
             }
 
             var chosenID = await Season.moduleSimSeasonBattle(true);
+            if (chosenID === undefined || chosenID === null)
+            {
+                // Defensive wall (issue #1722): moduleSimSeasonBattle must return a
+                // number (opponent id, -1 or -2). A null/undefined result means the
+                // simulation did not run (e.g. a poisoned callItOnce wrapper). Retry
+                // shortly instead of arming the 30 min "no opponent" timer.
+                logHHAuto("Season : opponent simulation returned no result, retrying shortly.");
+                setTimer('nextSeasonTime',randomInterval(5, 10));
+                return false;
+            }
             if (chosenID === -2 )
             {
                 //change opponents and reload

--- a/src/Service/AutoLoopPageHandlers.ts
+++ b/src/Service/AutoLoopPageHandlers.ts
@@ -52,6 +52,12 @@ import { HHStoredVarPrefixKey } from "../config/HHStoredVars";
 import { SK, TK } from "../config/StorageKeys";
 import { AdsService } from "./AdsService";
 
+// Tracks whether the read-only Season-arena power-calc preview has already
+// been rendered on the current page load. Reset implicitly on every page
+// navigation (full reload re-initialises the module). Used instead of
+// wrapping Season.moduleSimSeasonBattle in callItOnce -- see issue #1722.
+let seasonArenaPreviewShown = false;
+
 export async function handlePageSpecific(ctx: AutoLoopContext): Promise<void> {
     switch (ctx.currentPage)
     {
@@ -67,11 +73,15 @@ export async function handlePageSpecific(ctx: AutoLoopContext): Promise<void> {
         case ConfigHelper.getHHScriptVars("pagesIDSeasonArena"):
             if (getStoredValue(HHStoredVarPrefixKey+SK.showCalculatePower) === "true" && $("div.matchRatingNew img#powerLevelScouter").length < 3)
             {
-                if (ctx.lastActionPerformed !== "season") {
-                    // Avoid double call when coming from Season.run()
-                    Season.stylesBattle = callItOnce(Season.stylesBattle);
+                // Display-only power-calc preview. Do NOT wrap Season.stylesBattle or
+                // Season.moduleSimSeasonBattle in callItOnce: Season.run() calls the very
+                // same static methods, and a consumed once-wrapper makes run() receive
+                // undefined from moduleSimSeasonBattle, which then arms a ~30 min timer and
+                // stalls Season after a few fights (issue #1722). A module-scoped flag keeps
+                // this preview to once per page load without poisoning the shared methods.
+                if (ctx.lastActionPerformed !== "season" && !seasonArenaPreviewShown) {
+                    seasonArenaPreviewShown = true;
                     Season.stylesBattle();
-                    Season.moduleSimSeasonBattle = callItOnce(Season.moduleSimSeasonBattle);
                     Season.moduleSimSeasonBattle();
                 }
             }

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.4";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.5";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
## Summary

The season_arena page handler wrapped the shared static methods `Season.moduleSimSeasonBattle` and `Season.stylesBattle` in `callItOnce` to render the power-calc preview once per page. `callItOnce` permanently reassigns the method, and `Season.run()` calls the same method to choose an opponent. Once the preview consumed the single allowed call, `run()` received `undefined`, fell into the fight branch with an undefined opponent id, found no fight link and armed a ~30 min timer -- so Season looked like it stopped after one fight.

## Fix

- Render the preview via a module-scoped once-flag instead of poisoning the shared methods.
- Guard `Season.run()` against a null/undefined simulation result with a short retry instead of the 30 min timer.
- Version bump to 7.37.5 (package.json, FeaturePopupService, CHANGELOG, rebuilt bundle).

## Tested

- typecheck clean, eslint clean on changed files, full suite 1014 tests green.
- Two regression tests added.
- Live-tested on a real account with the power-calc display enabled (the trigger): 10 Season fights in a row across handleGenericBattle returns, no "Error getting opponent location", no 30 min stall.

Refs #1722
