### PR TITLE
fix: stop the no-progress watchdog from counting idle time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v7.37.12 - Champions no longer auto-disable after the script idles
+
+#### Fixed
+
+- **Champions stop auto-disabling on their own.** A long stretch where the script was not actively running (a backgrounded or frozen browser tab, the computer asleep, or a manual mouse pause) was wrongly counted as the champion run "making no progress". After enough of those false counts the champion handler disabled itself, showing "ERROR - re-activate" with a no-progress-timeout note. The progress check now ignores idle time and only counts time the script was actually working, so healthy runs survive long idle periods. The same fix protects other multi-step handlers (e.g. Places of Power).
+
 ### v7.37.11 - Startup no longer hangs on the non-game frame
 
 #### Fixed

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      7.37.11
+// @version      7.37.12
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -26457,7 +26457,7 @@ const FEATURE_POPUP_VERSION = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.11";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.12";
 /**
  * HTML content for the feature popup.
  * Update this each time you activate the popup for a new version.
@@ -27913,6 +27913,7 @@ const DEFAULT_CONFIG = {
     failureThreshold: 3,
     noProgressMs: 300000, // 5 min without any step progress -> treat as hung
     cooldownMs: 60000,
+    dormantGapMs: 30000, // 30s gap (>>1s cadence) = scheduler was dormant
 };
 /** Short signature of a failure reason for the per-signature failure counter. */
 function shortSig(reason) {
@@ -27926,6 +27927,7 @@ class BlockScheduler {
         this.run = null;
         this.restoredFromStore = false;
         this.tickCount = 0; // R6.3 correlation: incremented once per tick()
+        this.lastTickAt = 0; // wall-clock of the previous tick(); 0 = no tick yet
         this.cfg = Object.assign(Object.assign({}, DEFAULT_CONFIG), cfg);
         // Restore a run that survived a reload (R4.4) and reconcile version-gated
         // auto-disable (R5.5: one retry after a script update).
@@ -27977,6 +27979,16 @@ class BlockScheduler {
     tick(ctx) {
         return BlockScheduler_awaiter(this, void 0, void 0, function* () {
             this.tickCount++;
+            const now = this.ports.now();
+            // Dormant-gap rebasing: autoLoop reschedules itself via setTimeout(~1s). When
+            // the gap since the previous tick is far larger than that cadence, the
+            // scheduler was dormant (mouse pause holds blockTick, a frozen/backgrounded
+            // tab suspends the timer, the OS slept) -- the wall-clock advanced while no
+            // ticking happened. That gap is not no-progress of the active run. Push the
+            // active run's anchor forward by the gap so the no-progress watchdog measures
+            // only contiguous active ticking time, not dormant wall-clock.
+            const gap = this.lastTickAt === 0 ? 0 : now - this.lastTickAt;
+            this.lastTickAt = now;
             // 1. Stop-check: master/autoLoop off -> discard run, NO home routing (R4 / design).
             if (this.ports.isMasterOff() || this.ports.isAutoLoopOff()) {
                 if (this.run) {
@@ -27989,6 +28001,11 @@ class BlockScheduler {
             if (!this.run)
                 this.run = this.ports.loadRun();
             if (this.run) {
+                if (gap > this.cfg.dormantGapMs) {
+                    this.run.stepStartedAt += gap;
+                    this.ports.saveRun(this.run);
+                    this.emit({ ev: "rebase", block: this.run.blockId, detail: "dormant-gap:" + gap });
+                }
                 yield this.continueRun(ctx);
                 return;
             }
@@ -28006,14 +28023,6 @@ class BlockScheduler {
             const block = this.registry[run.blockId];
             if (!block) {
                 yield this.abort(run, "block-missing");
-                return;
-            }
-            // No-progress watchdog: abort only if the run has made NO progress (no step
-            // advance/repeat resets stepStartedAt) for noProgressMs. A working block keeps
-            // resetting stepStartedAt, so it never times out; only a genuinely stuck run
-            // (re-entered across ticks without advancing) is aborted + routed home.
-            if (this.ports.now() - run.stepStartedAt > this.cfg.noProgressMs) {
-                yield this.abort(run, "no-progress-timeout");
                 return;
             }
             // First handling after a reload: resume validation + at-most-once (R4.6/R4.9).
@@ -28049,6 +28058,21 @@ class BlockScheduler {
                     this.ports.saveRun(run);
                     this.emit({ ev: "resume", block: block.id, step: next === null || next === void 0 ? void 0 : next.name, detail: "valid" });
                 }
+            }
+            // No-progress watchdog (checked AFTER the restore-resume handling above): a
+            // valid resume after a reload IS progress and resets stepStartedAt, so the
+            // watchdog must run after it -- otherwise the first tick after a reload that
+            // followed a long dormant period (frozen/backgrounded tab, OS sleep) would
+            // abort a healthy reload-based run on its stale persisted anchor before the
+            // resume reset could refresh it. That false abort, repeated failureThreshold
+            // times for the same signature, auto-disables the block (observed live as
+            // "ERROR - Champion re-activate", tooltip no-progress-timeout). A working
+            // block keeps resetting stepStartedAt (resume/advance/repeat), so it never
+            // times out; only a genuinely stuck run (re-entered across ticks without
+            // advancing) is aborted + routed home.
+            if (this.ports.now() - run.stepStartedAt > this.cfg.noProgressMs) {
+                yield this.abort(run, "no-progress-timeout");
+                return;
             }
             // gate-hold-return (ADR-002): a held run continues only while the block
             // still WANTS to run. Re-check the precondition on every continuation; once

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "7.37.11",
+  "version": "7.37.12",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Service/BlockScheduler.spec.ts
+++ b/spec/Service/BlockScheduler.spec.ts
@@ -170,6 +170,52 @@ describe("BlockScheduler -- abort/watchdog", () => {
     });
 });
 
+describe("BlockScheduler -- dormant-gap rebasing & reload-resume watchdog (no-progress false-positive fix)", () => {
+    it("does NOT abort when the gap since the last tick exceeds the dormant threshold (scheduler paused/frozen)", async () => {
+        // Healthy run, but the scheduler was dormant (mouse pause holds blockTick,
+        // a frozen/backgrounded tab suspends setTimeout) longer than noProgressMs
+        // between two ticks. The dormant gap is not no-progress: the anchor is
+        // rebased by the gap so the run survives instead of being aborted.
+        const h = makePorts();
+        const A = block("A", [step("loop", { ok: true, repeat: true })]);
+        const s = new BlockScheduler(reg(A), ["A"], h.ports, { noProgressMs: 5000, dormantGapMs: 3000 });
+        await s.tick(CTX);                  // t=1000: start, repeat, stepStartedAt=1000, lastTickAt=1000
+        h.ctl.time = 1000 + 10000;          // 10s gap (> dormantGapMs 3s AND > noProgressMs 5s)
+        await s.tick(CTX);
+        expect(s.getActiveRun()).not.toBeNull();   // rebased -> not aborted
+        expect(h.routeHome).not.toHaveBeenCalled();
+    });
+
+    it("still aborts a stuck run when ticking continuously (gap below the dormant threshold)", async () => {
+        // Contrast: the scheduler keeps ticking (small inter-tick gap), so no
+        // rebase happens and the watchdog still fires once stepStartedAt is older
+        // than noProgressMs. Pins the dormantGapMs boundary.
+        const h = makePorts();
+        const A = block("A", [step("loop", { ok: true, repeat: true })]);
+        const s = new BlockScheduler(reg(A), ["A"], h.ports, { noProgressMs: 5000, dormantGapMs: 30000 });
+        await s.tick(CTX);                  // t=1000, stepStartedAt=1000
+        h.ctl.time = 1000 + 6000;           // 6s gap < dormantGapMs 30s, but > noProgressMs 5s
+        await s.tick(CTX);
+        expect(s.getActiveRun()).toBeNull();
+        expect(h.routeHome).toHaveBeenCalled();
+    });
+
+    it("does NOT abort a reload-restored run with a stale anchor (valid resume resets before the watchdog)", async () => {
+        // Champion/PoP reload-based case: the run was persisted with stepStartedAt
+        // far in the past (tab frozen/backgrounded across the reload). On the first
+        // tick after the reload the valid resume must reset the anchor BEFORE the
+        // watchdog runs, otherwise the healthy run is aborted on its stale anchor
+        // (3x same signature -> auto-disable, the "ERROR - Champion re-activate").
+        const h = makePorts({ blockId: "A", stepIdx: 0, startedAt: 900, stepStartedAt: 1000 });
+        const A = block("A", [step("loop", { ok: true, repeat: true })]);
+        h.ctl.time = 1000 + 400000;         // 400s since the persisted anchor (> noProgressMs 300s default)
+        const s = new BlockScheduler(reg(A), ["A"], h.ports);  // restores run -> valid resume on first tick
+        await s.tick(CTX);
+        expect(s.getActiveRun()).not.toBeNull();   // resume reset the anchor first -> not aborted
+        expect(h.routeHome).not.toHaveBeenCalled();
+    });
+});
+
 describe("BlockScheduler -- resume / at-most-once", () => {
     it("aborts when resume validation fails after reload", async () => {
         const h = makePorts({ blockId: "A", stepIdx: 0, startedAt: 900, stepStartedAt: 900 });

--- a/src/Service/BlockScheduler.ts
+++ b/src/Service/BlockScheduler.ts
@@ -51,12 +51,20 @@ export interface SchedulerConfig {
   // reload (user-accepted).
   noProgressMs: number;
   cooldownMs: number;           // R4.10/R5.2 abort cool-down
+  // Dormant-gap threshold: a gap between two ticks larger than this means the
+  // scheduler was not running (mouse pause, frozen/backgrounded tab, OS sleep),
+  // not that the active run made no progress. Used to rebase the no-progress
+  // anchor so the watchdog measures only contiguous active ticking time. Set
+  // well above the normal autoLoop cadence (~1s) so a healthy busy run is never
+  // rebased; only real dormancy crosses it.
+  dormantGapMs: number;
 }
 
 const DEFAULT_CONFIG: SchedulerConfig = {
   failureThreshold: 3,
   noProgressMs: 300_000,   // 5 min without any step progress -> treat as hung
   cooldownMs: 60_000,
+  dormantGapMs: 30_000,    // 30s gap (>>1s cadence) = scheduler was dormant
 };
 
 /** Short signature of a failure reason for the per-signature failure counter. */
@@ -68,6 +76,7 @@ export class BlockScheduler {
   private run: BlockRun | null = null;
   private restoredFromStore = false;
   private tickCount = 0;  // R6.3 correlation: incremented once per tick()
+  private lastTickAt = 0; // wall-clock of the previous tick(); 0 = no tick yet
   private readonly cfg: SchedulerConfig;
 
   constructor(
@@ -127,6 +136,16 @@ export class BlockScheduler {
 
   async tick(ctx: AutoLoopContext): Promise<void> {
     this.tickCount++;
+    const now = this.ports.now();
+    // Dormant-gap rebasing: autoLoop reschedules itself via setTimeout(~1s). When
+    // the gap since the previous tick is far larger than that cadence, the
+    // scheduler was dormant (mouse pause holds blockTick, a frozen/backgrounded
+    // tab suspends the timer, the OS slept) -- the wall-clock advanced while no
+    // ticking happened. That gap is not no-progress of the active run. Push the
+    // active run's anchor forward by the gap so the no-progress watchdog measures
+    // only contiguous active ticking time, not dormant wall-clock.
+    const gap = this.lastTickAt === 0 ? 0 : now - this.lastTickAt;
+    this.lastTickAt = now;
     // 1. Stop-check: master/autoLoop off -> discard run, NO home routing (R4 / design).
     if (this.ports.isMasterOff() || this.ports.isAutoLoopOff()) {
       if (this.run) {
@@ -140,6 +159,11 @@ export class BlockScheduler {
     if (!this.run) this.run = this.ports.loadRun();
 
     if (this.run) {
+      if (gap > this.cfg.dormantGapMs) {
+        this.run.stepStartedAt += gap;
+        this.ports.saveRun(this.run);
+        this.emit({ ev: "rebase", block: this.run.blockId, detail: "dormant-gap:" + gap });
+      }
       await this.continueRun(ctx);
       return;
     }
@@ -155,14 +179,6 @@ export class BlockScheduler {
     const run = this.run!;
     const block = this.registry[run.blockId];
     if (!block) { await this.abort(run, "block-missing"); return; }
-
-    // No-progress watchdog: abort only if the run has made NO progress (no step
-    // advance/repeat resets stepStartedAt) for noProgressMs. A working block keeps
-    // resetting stepStartedAt, so it never times out; only a genuinely stuck run
-    // (re-entered across ticks without advancing) is aborted + routed home.
-    if (this.ports.now() - run.stepStartedAt > this.cfg.noProgressMs) {
-      await this.abort(run, "no-progress-timeout"); return;
-    }
 
     // First handling after a reload: resume validation + at-most-once (R4.6/R4.9).
     if (this.restoredFromStore) {
@@ -192,6 +208,21 @@ export class BlockScheduler {
         this.ports.saveRun(run);
         this.emit({ ev: "resume", block: block.id, step: next?.name, detail: "valid" });
       }
+    }
+
+    // No-progress watchdog (checked AFTER the restore-resume handling above): a
+    // valid resume after a reload IS progress and resets stepStartedAt, so the
+    // watchdog must run after it -- otherwise the first tick after a reload that
+    // followed a long dormant period (frozen/backgrounded tab, OS sleep) would
+    // abort a healthy reload-based run on its stale persisted anchor before the
+    // resume reset could refresh it. That false abort, repeated failureThreshold
+    // times for the same signature, auto-disables the block (observed live as
+    // "ERROR - Champion re-activate", tooltip no-progress-timeout). A working
+    // block keeps resetting stepStartedAt (resume/advance/repeat), so it never
+    // times out; only a genuinely stuck run (re-entered across ticks without
+    // advancing) is aborted + routed home.
+    if (this.ports.now() - run.stepStartedAt > this.cfg.noProgressMs) {
+      await this.abort(run, "no-progress-timeout"); return;
     }
 
     // gate-hold-return (ADR-002): a held run continues only while the block

--- a/src/Service/FeaturePopupService.ts
+++ b/src/Service/FeaturePopupService.ts
@@ -42,7 +42,7 @@ const FEATURE_POPUP_VERSION: string = "0";
 /**
  * Title shown in the popup header.
  */
-const FEATURE_POPUP_TITLE = "HHAuto v7.37.11";
+const FEATURE_POPUP_TITLE = "HHAuto v7.37.12";
 
 /**
  * HTML content for the feature popup.


### PR DESCRIPTION
## Summary

The no-progress watchdog in BlockScheduler measured wall-clock time. Any
stretch where the scheduler was not ticking -- a frozen or backgrounded
browser tab, an OS sleep, a manual mouse pause -- was counted as the active
run making no progress. A multi-reload block (Champion, Places of Power)
stays the active run across reloads for minutes, so after `failureThreshold`
false aborts of the same signature the block auto-disabled, shown in the UI
as "ERROR - re-activate" with a no-progress-timeout reason.

## Changes

- `continueRun` runs the no-progress watchdog AFTER the restore-resume
  handling. A valid resume after a reload refreshes `stepStartedAt` before
  the check, so the first tick after a reload no longer aborts on a stale
  persisted anchor.
- `tick` rebases the active run `stepStartedAt` by any inter-tick gap larger
  than `dormantGapMs` (30s, far above the ~1s autoLoop cadence). A dormant
  scheduler therefore does not accrue no-progress time.
- A genuinely stuck run that keeps ticking still aborts after `noProgressMs`.

## Tests

- 3 new regression tests in `BlockScheduler.spec.ts`: dormant-gap rebasing,
  sub-threshold abort (boundary), reload-restored stale-anchor resume.
- Full suite green (1037/1037). Build green, circular-deps baseline
  unchanged (349), top-level-storage-key gate clean, lint baseline unchanged.