### PR TITLE
feat(startup): clear temp vars once on version update (#1784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.1.0 - Auto-clear temporary data on update
+
+- **New:** whenever the script updates to a new version, it now clears its
+  temporary working data **once**, automatically (issue #1784). This is the
+  same operation as the manual "Delete Temp Storage" button: your settings and
+  preferences are fully preserved — only the internal timing/rotation state and
+  caches are reset, so the script rebuilds them fresh on the new version. This
+  avoids the post-update rotation loops that some updates could trigger (as seen
+  with v8.0.0), without anyone having to press the button by hand.
+
 ### v8.0.0 - Major release: stability overhaul and smarter automation
 
 This is the first public release since **v7.29.19**. It bundles a large

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.0.0
+// @version      8.1.0
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -27518,6 +27518,22 @@ class StartService {
                 deleteStoredValue(HHStoredVarPrefixKey + SK.SeasonMaskRewards);
                 deleteStoredValue(HHStoredVarPrefixKey + SK.SeasonalEventMaskRewards);
             }
+            // Issue #1784: clear the temporary working data once whenever a
+            // new script version is installed. Some updates leave stale
+            // timing/rotation state behind that glitches the loop; wiping the
+            // Temp vars forces the script to rebuild them from scratch on the
+            // fresh version. This is the same operation as the manual "Delete
+            // Temp Storage" button (debugDeleteTempVars), which preserves all
+            // Settings and only resets Temp vars.
+            //
+            // Runs AFTER the per-version migrations above so it cannot clobber
+            // a migration mid-flight. scriptversion is itself a Temp var, so
+            // the wipe resets it to its "0" default; we MUST re-write it after
+            // the wipe, otherwise the next page load would see "0" != current
+            // version, detect a "new version" again and re-wipe on every load
+            // (exactly the update loop this feature is meant to prevent).
+            debugDeleteTempVars();
+            setStoredValue(HHStoredVarPrefixKey + TK.scriptversion, GM.info.script.version);
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/src/Service/StartService.ts
+++ b/src/Service/StartService.ts
@@ -119,6 +119,23 @@ export class StartService {
                 deleteStoredValue(HHStoredVarPrefixKey + SK.SeasonMaskRewards);
                 deleteStoredValue(HHStoredVarPrefixKey + SK.SeasonalEventMaskRewards);
             }
+
+            // Issue #1784: clear the temporary working data once whenever a
+            // new script version is installed. Some updates leave stale
+            // timing/rotation state behind that glitches the loop; wiping the
+            // Temp vars forces the script to rebuild them from scratch on the
+            // fresh version. This is the same operation as the manual "Delete
+            // Temp Storage" button (debugDeleteTempVars), which preserves all
+            // Settings and only resets Temp vars.
+            //
+            // Runs AFTER the per-version migrations above so it cannot clobber
+            // a migration mid-flight. scriptversion is itself a Temp var, so
+            // the wipe resets it to its "0" default; we MUST re-write it after
+            // the wipe, otherwise the next page load would see "0" != current
+            // version, detect a "new version" again and re-wipe on every load
+            // (exactly the update loop this feature is meant to prevent).
+            debugDeleteTempVars();
+            setStoredValue(HHStoredVarPrefixKey + TK.scriptversion, GM.info.script.version);
         }
     }
 }


### PR DESCRIPTION
## What

Automatically clears the script's temporary working data **once** whenever a new version is installed (ref: #1784).

On a new version, `StartService.checkVersion` now runs the same cleanup as the manual **"Delete Temp Storage"** button (`debugDeleteTempVars`): all **Settings are preserved**, only **Temp vars** (timings, rotation state, caches) are reset. This forces the script to rebuild its timing/rotation state fresh on the new version and avoids the post-update loops some updates could trigger (as seen with v8.0.0).

## Key correctness details

- **No update loop.** `scriptversion` is itself a Temp var, so the wipe resets it to its `"0"` default. It is re-written to the current version *right after* the wipe — otherwise every page load would see `"0" != current`, detect a "new version" again and re-wipe endlessly (the exact loop this feature prevents).
- **Ordering.** The wipe runs *after* the per-version migrations so it cannot clobber a migration mid-flight.

## Testing

Built 8.1.0, installed over 8.0.0 in the live game:
- `checkVersion: New script version detected from 8.0.0 to 8.1.0` → wipe ran once.
- Custom settings restored intact (e.g. `autoPowerPlacesIndexFilter`, `autoEquipBoostersSlots`).
- After reload, `localStorage.HHAuto_Temp_scriptversion === "8.1.0"` → no second wipe (loop protection confirmed).
- Typecheck ✓, ESLint 0 errors ✓, storage tests 39/39 ✓.

## Versioning

Bumped to **8.1.0** (new feature → SemVer MINOR). CHANGELOG updated, artifact rebuilt.

Ref: #1784

🤖 Generated with [Claude Code](https://claude.com/claude-code)