### PR TITLE
docs(changelog): drop redundant "New:" prefix from v8.1.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Older entries below were migrated 1:1 from `README.md`.
 
 ### v8.1.0 - Auto-clear temporary data on update
 
-- **New:** whenever the script updates to a new version, it now clears its
+- Whenever the script updates to a new version, it now clears its
   temporary working data **once**, automatically (issue #1784). This is the
   same operation as the manual "Delete Temp Storage" button: your settings and
   preferences are fully preserved — only the internal timing/rotation state and


### PR DESCRIPTION
Removes the "**New:**" prefix from the v8.1.0 changelog entry — everything in a changelog is new by definition, so it was redundant. Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)