### PR TITLE
fix: unify license metadata to GPL-3.0, bump to 8.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,8 @@ docs-internal/SESSION_HANDOVER_*.md
 docs-internal/RELEASE_RUNBOOK_*.md
 # Lokales Archiv abgeschlossener Notizen (nicht syncen)
 docs-internal/_archive/
+
+# Lokaler KI-Code-Review-Bericht (nicht syncen, wird lokal abgearbeitet)
+/REVIEW.md
+/BACKLOG.md
+/REVIEW_SUMMARY.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.1.1 - Fix inconsistent license metadata
+
+- `package.json` claimed ISC and the userscript header claimed MIT, while the
+  actual `LICENSE` file has been GPL-3.0 since 2020. Both now correctly
+  declare GPL-3.0.
+
 ### v8.1.0 - Auto-clear temporary data on update
 
 - Whenever the script updates to a new version, it now clears its

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.1.0
+// @version      8.1.1
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -17,7 +17,7 @@
 // @grant        GM_addStyle
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
-// @license      MIT
+// @license      GPL-3.0
 // @updateURL    https://github.com/OldRon1977/HHauto/raw/main/HHAuto.user.js
 // @downloadURL  https://github.com/OldRon1977/HHauto/raw/main/HHAuto.user.js
 // ==/UserScript==

--- a/build/HHAuto.template.js
+++ b/build/HHAuto.template.js
@@ -17,7 +17,7 @@
 // @grant        GM_addStyle
 // @grant        GM_registerMenuCommand
 // @grant        GM_unregisterMenuCommand
-// @license      MIT
+// @license      GPL-3.0
 // @updateURL    https://github.com/OldRon1977/HHauto/raw/main/HHAuto.user.js
 // @downloadURL  https://github.com/OldRon1977/HHauto/raw/main/HHAuto.user.js
 // ==/UserScript==

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "[English](https://github.com/OldRon1977/HHauto/wiki/English)",
   "main": "HHAuto.user.js",
   "scripts": {
@@ -23,7 +23,7 @@
     "url": "git+https://github.com/OldRon1977/HHauto.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "GPL-3.0",
   "bugs": {
     "url": "https://github.com/OldRon1977/HHauto/issues"
   },


### PR DESCRIPTION
## Summary
- package.json declared ISC and the userscript banner declared MIT, while LICENSE has been GPL-3.0 since I switched it deliberately in 2020 (commit 0c7239f). All three now agree on GPL-3.0.
- Version bumped to 8.1.1 (PATCH) so Tampermonkey's @updateURL auto-update mechanism actually picks up the corrected artifact header.
- .gitignore updated to exclude local code-review report files (REVIEW.md, BACKLOG.md, REVIEW_SUMMARY.md) worked through locally, not meant to be synced.

## Test plan
- [x] npm run build — artifact rebuilt, @version 8.1.1 / @license GPL-3.0 verified in header
- [x] npm test — 1043/1043 passed
- [x] npm run typecheck — clean
- [ ] Manual in-game verification