### PR TITLE
chore: ignore BACKLOG-ISSUES.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs-internal/_archive/
 /REVIEW.md
 /BACKLOG.md
 /REVIEW_SUMMARY.md
+BACKLOG-ISSUES.md


### PR DESCRIPTION
Adds BACKLOG-ISSUES.md to .gitignore, consistent with the other local working files (BACKLOG.md, REVIEW.md, REVIEW_SUMMARY.md).