### PR TITLE
fix(blessing): split league (pvp_v3) and labyrinth (pvp_v4) contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.5.1 - Team builder no longer counts the labyrinth Role blessing as a league blessing
+
+- The game keeps two blessing sets per girl: `pvp_v3` (the two weekly
+  league blessings) and `pvp_v4` (the same plus the weekly Role blessing,
+  which only applies in the Love Labyrinth). The blessing helpers used to
+  prefer `pvp_v4`, so every girl carrying only the Role blessing counted
+  as blessed for league team building — inflating the "blessed" leader
+  tiebreak, the blessed-girl counts in the info panel / mythic audit, and
+  feeding a phantom percent group into the blessing detection.
+- `BlessingService` now takes an explicit context: league lookups read
+  `pvp_v3` only, labyrinth lookups read `pvp_v4` only, with no fallback
+  across the two. The team builder always uses the league context.
+- The game flags are mapped to speaking names: `can_be_blessed` →
+  `can_be_blessed_league`, `can_be_blessed_pvp4` →
+  `can_be_blessed_labyrinth`. An explicit `false` from the game is now
+  respected instead of being overridden by the other set's data.
+- Verified against anonymized account dumps (fixtures) and a live dump:
+  the `pvp_v3`↔`pvp_v4` delta is exactly the weekly Role blessing.
+  Detected league blessings and the built teams stay identical in the
+  fixture weeks; only the blessed counts and diagnostics become accurate.
+
 ### v8.5.0 - Season focus: choose between all fights, event girl only, or girl + skin
 
 - The Season switch "Ignore if no event girls" is now a three-way "Season

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.5.0
+// @version      8.5.1
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -16453,15 +16453,32 @@ class BlessingService {
         return cached !== null && (Date.now() - cached.timestamp) < CACHE_DURATION_MS;
     }
     /**
+     * Context-specific percent list (carac1) from the girl's
+     * blessing_bonuses. 'league' reads pvp_v3, 'labyrinth' reads pvp_v4;
+     * never falls back across contexts (see BlessingContext). Accepts
+     * raw API girls (blessing_bonuses) and GirlData (blessingBonuses).
+     */
+    static getContextPercentList(girl, context) {
+        var _a;
+        const bb = (_a = girl.blessing_bonuses) !== null && _a !== void 0 ? _a : girl.blessingBonuses;
+        if (!bb || typeof bb !== 'object' || Array.isArray(bb))
+            return [];
+        const v = context === 'labyrinth' ? bb.pvp_v4 : bb.pvp_v3;
+        if (!v || typeof v !== 'object')
+            return [];
+        const pcs = v.carac1;
+        if (!Array.isArray(pcs))
+            return [];
+        return pcs.map((p) => Number(p)).filter((n) => Number.isFinite(n) && n > 0);
+    }
+    /**
      * Authoritative per-girl blessing multiplier from the game's
      * blessing_bonuses field. This is the single source of truth for
-     * 'is this girl currently blessed and by how much'.
+     * 'is this girl currently blessed in this context and by how much'.
      *
-     * The game writes the active per-class blessing percentages into
-     * blessing_bonuses.pvp_v3 (current league) and pvp_v4 (next league
-     * version). Each is shaped { caracN: number[] }; the list contains
-     * one entry per active blessing affecting the girl, applied
-     * multiplicatively. Examples:
+     * Each set is shaped { caracN: number[] }; the list contains one
+     * entry per active blessing affecting the girl, applied
+     * multiplicatively. Examples (league):
      *   pvp_v3.carac1 = []         -> no blessing -> multiplier 1.0
      *   pvp_v3.carac1 = [25]       -> +25%        -> multiplier 1.25
      *   pvp_v3.carac1 = [40, 25]   -> +40% AND +25% -> multiplier 1.75
@@ -16469,47 +16486,21 @@ class BlessingService {
      * The girl's caracs sub-object already contains the multiplied stat,
      * so the team builder does not need to multiply again. This helper
      * is for diagnostics: 'is girl X blessed?' and 'how much'.
-     *
-     * Falls back from pvp_v4 to pvp_v3 (forwards-compatible with a future
-     * league version cutover).
      */
-    static getEffectiveMultiplier(girl) {
-        var _a, _b;
-        const bb = (_a = girl.blessing_bonuses) !== null && _a !== void 0 ? _a : girl.blessingBonuses;
-        if (!bb || typeof bb !== 'object' || Array.isArray(bb))
-            return 1;
-        const v = (_b = bb.pvp_v4) !== null && _b !== void 0 ? _b : bb.pvp_v3;
-        if (!v || typeof v !== 'object')
-            return 1;
-        const pcs = v.carac1;
-        if (!Array.isArray(pcs) || pcs.length === 0)
-            return 1;
+    static getEffectiveMultiplier(girl, context = 'league') {
         let mult = 1;
-        for (const p of pcs) {
-            const n = Number(p);
-            if (Number.isFinite(n) && n > 0) {
-                mult *= 1 + n / 100;
-            }
+        for (const n of BlessingService.getContextPercentList(girl, context)) {
+            mult *= 1 + n / 100;
         }
         return mult;
     }
     /**
-     * List the blessing percentages currently active on this girl, in
-     * the order the game returned them. Useful for UI annotations like
-     * '(+25% blessing)' or '(+40%, +25% blessing)'.
+     * List the blessing percentages currently active on this girl for
+     * the given context, in the order the game returned them. Useful for
+     * UI annotations like '(+25% blessing)' or '(+40%, +25% blessing)'.
      */
-    static getActivePercents(girl) {
-        var _a, _b;
-        const bb = (_a = girl.blessing_bonuses) !== null && _a !== void 0 ? _a : girl.blessingBonuses;
-        if (!bb || typeof bb !== 'object' || Array.isArray(bb))
-            return [];
-        const v = (_b = bb.pvp_v4) !== null && _b !== void 0 ? _b : bb.pvp_v3;
-        if (!v || typeof v !== 'object')
-            return [];
-        const pcs = v.carac1;
-        if (!Array.isArray(pcs))
-            return [];
-        return pcs.filter((p) => Number.isFinite(Number(p)) && Number(p) > 0).map((p) => Number(p));
+    static getActivePercents(girl, context = 'league') {
+        return BlessingService.getContextPercentList(girl, context);
     }
     static parseTraits(response) {
         const traits = [];
@@ -16739,54 +16730,57 @@ class BlessingService {
      * dependent: 'eye color' / 'couleur des yeux' / 'augenfarbe' ...).
      *
      * The game's blessing_bonuses field on each girl is the authoritative
-     * source: a girl with can_be_blessed=true has at least one active
-     * blessing applied to her caracs. By cross-referencing the can-be-
-     * blessed girls with their fields (element, rarity, eye_color1,
-     * hair_color1, zodiac, position_img), we identify what each blessing
-     * targets WITHOUT reading any localized description.
+     * source. The `context` picks the blessing set (league -> pvp_v3,
+     * labyrinth -> pvp_v4 incl. the weekly Role blessing; see
+     * BlessingContext). By cross-referencing the blessed girls with their
+     * fields (element, rarity, eye_color1, hair_color1, zodiac,
+     * position_img), we identify what each blessing targets WITHOUT
+     * reading any localized description.
      *
      * Returns an array of detected blessings sorted by priority:
      *   1. blessings with the highest bonus percent (e.g. 40% > 25%)
      *   2. blessings with the largest blessed pool
      *
-     * The percent comes from the pvp_v3.carac1 list on a representative
+     * The percent comes from the context's carac1 list on a representative
      * blessed girl. When two blessings stack on the same girl, that girl's
      * carac1 list has multiple entries; we extract individual percents per
      * field (element/rarity/trait) by finding the field whose value is
      * uniformly shared by girls carrying a particular percent.
      */
-    static detectActiveBlessings(girls) {
-        var _a;
+    static detectActiveBlessings(girls, context = 'league') {
         // Read fields tolerantly: callers pass either raw API girls
         // (snake_case: eye_color1, hair_color1, position_img,
         // blessing_bonuses, can_be_blessed) or GirlData objects (camelCase:
         // eyeColor, hairColor, position, blessingBonuses). For 'blessed'
-        // status: prefer the explicit can_be_blessed flag, otherwise
-        // derive it from blessing_bonuses / blessingBonuses being a
-        // populated dict.
-        const bbOf = (g) => { var _a; return (_a = g.blessing_bonuses) !== null && _a !== void 0 ? _a : g.blessingBonuses; };
-        const isBlessed = (g) => {
-            if (g.can_be_blessed === true)
-                return true;
-            const bb = bbOf(g);
-            return !!(bb && typeof bb === 'object' && !Array.isArray(bb)
-                && (bb.pvp_v3 || bb.pvp_v4));
+        // status: prefer the context's explicit game flag (league:
+        // can_be_blessed, labyrinth: can_be_blessed_pvp4 -- mapped to
+        // can_be_blessed_league / can_be_blessed_labyrinth in GirlData).
+        // The flag is authoritative in both directions: a girl carrying
+        // only the labyrinth Role blessing has can_be_blessed === false
+        // and must NOT count as league-blessed. Only when the flag is
+        // absent is blessed-ness derived from the context's percent list.
+        const flagOf = (g) => {
+            var _a, _b;
+            const flag = context === 'labyrinth'
+                ? ((_a = g.can_be_blessed_labyrinth) !== null && _a !== void 0 ? _a : g.can_be_blessed_pvp4)
+                : ((_b = g.can_be_blessed_league) !== null && _b !== void 0 ? _b : g.can_be_blessed);
+            return typeof flag === 'boolean' ? flag : undefined;
         };
-        const blessed = girls.filter(g => isBlessed(g) && bbOf(g)
-            && typeof bbOf(g) === 'object' && !Array.isArray(bbOf(g)));
+        const isBlessed = (g) => {
+            const flag = flagOf(g);
+            if (flag !== undefined)
+                return flag;
+            return BlessingService.getContextPercentList(g, context).length > 0;
+        };
+        const blessed = girls.filter(g => isBlessed(g)
+            && BlessingService.getContextPercentList(g, context).length > 0);
         if (blessed.length === 0)
             return [];
         // Collect distinct percents seen across the blessed pool.
         const percents = new Set();
         for (const g of blessed) {
-            const bb = bbOf(g);
-            const v = (_a = bb.pvp_v3) !== null && _a !== void 0 ? _a : bb.pvp_v4;
-            if (!v || !Array.isArray(v.carac1))
-                continue;
-            for (const p of v.carac1) {
-                const n = Number(p);
-                if (Number.isFinite(n) && n > 0)
-                    percents.add(n);
+            for (const n of BlessingService.getContextPercentList(g, context)) {
+                percents.add(n);
             }
         }
         const candidates = [];
@@ -16803,12 +16797,7 @@ class BlessingService {
         //      to be legendary" doesn't mean rarity=legendary IS the
         //      blessing condition).
         for (const percent of percents) {
-            const carrying = blessed.filter(g => {
-                var _a;
-                const bb = bbOf(g);
-                const v = (_a = bb.pvp_v3) !== null && _a !== void 0 ? _a : bb.pvp_v4;
-                return Array.isArray(v === null || v === void 0 ? void 0 : v.carac1) && v.carac1.includes(percent);
-            });
+            const carrying = blessed.filter(g => BlessingService.getContextPercentList(g, context).includes(percent));
             if (carrying.length === 0)
                 continue;
             for (const kind of kinds) {
@@ -21773,10 +21762,11 @@ class TeamModule {
      * setTopTeamV2 so the mapping is unit-testable in isolation (the rest
      * of setTopTeamV2 is DOM/UI). Pure: no side effects, no DOM access.
      *
-     * can_be_blessed / can_be_blessed_pvp4 are passed through as untyped
-     * bonus properties so BlessingService.detectActiveBlessings has an
-     * authoritative blessed-or-not flag (issue 1679 phase 2); the static
-     * type stays GirlData.
+     * The game flags can_be_blessed / can_be_blessed_pvp4 are mapped to
+     * the speaking names can_be_blessed_league / can_be_blessed_labyrinth
+     * so BlessingService has an authoritative blessed-or-not flag per
+     * context (league = pvp_v3 blessings, labyrinth = pvp_v4 incl. the
+     * weekly Role blessing).
      */
     static mapAvailableGirl(g) {
         var _a;
@@ -21786,7 +21776,7 @@ class TeamModule {
                 carac3: Number(g.caracs.carac3 || 0),
             } : undefined, skill_tiers_info: g.skill_tiers_info, 
             // Keep raw zodiac glyph; TraitMappings.resolveZodiac strips it for display
-            zodiac: g.zodiac || undefined, hairColor: g.hair_color1 || undefined, eyeColor: g.eye_color1 || undefined, position: g.position_img ? String(g.position_img).replace('.png', '') : undefined, blessingBonuses: g.blessing_bonuses || undefined }, (typeof g.can_be_blessed === 'boolean' ? { can_be_blessed: g.can_be_blessed } : {})), (typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_pvp4: g.can_be_blessed_pvp4 } : {})));
+            zodiac: g.zodiac || undefined, hairColor: g.hair_color1 || undefined, eyeColor: g.eye_color1 || undefined, position: g.position_img ? String(g.position_img).replace('.png', '') : undefined, blessingBonuses: g.blessing_bonuses || undefined }, (typeof g.can_be_blessed === 'boolean' ? { can_be_blessed_league: g.can_be_blessed } : {})), (typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_labyrinth: g.can_be_blessed_pvp4 } : {})));
     }
     static setTopTeamV2(mode, availableGirls) {
         const playerLevel = Number(HeroHelper.getLevel());

--- a/docs-internal/data-sources-team.md
+++ b/docs-internal/data-sources-team.md
@@ -69,31 +69,44 @@ The team builder reads ``caracs`` directly. No unequip needed before scoring.
 | Field | Type | Notes |
 |---|---|---|
 | ``blessing_bonuses`` | object | Per-girl blessing percent lists, see structure below |
-| ``can_be_blessed`` | boolean | Is this girl eligible for blessings at all |
-| ``can_be_blessed_pvp4`` | boolean | PvP4-mode blessing eligibility |
+| ``can_be_blessed`` | boolean | League-blessed flag: true iff ``pvp_v3`` percents present. GirlData name: ``can_be_blessed_league`` |
+| ``can_be_blessed_pvp4`` | boolean | Labyrinth-blessed flag: true iff ``pvp_v4`` percents present. GirlData name: ``can_be_blessed_labyrinth`` |
 | ``blessed_attributes`` | object | Tooltip-side mirror |
 
 #### ``blessing_bonuses`` structure
 
 ```jsonc
 {
-  "pvp_v3": {
+  "pvp_v3": {                    // LEAGUE: the two weekly league blessings
     "carac1": [20, 30],
     "carac2": [20, 30],
     "carac3": [20, 30]
   },
-  "pvp_v4": {
-    "carac1": [20, 30],
-    "carac2": [20, 30],
-    "carac3": [20, 30]
+  "pvp_v4": {                    // LABYRINTH: league blessings + weekly Role blessing
+    "carac1": [20, 30, 25],
+    "carac2": [20, 30, 25],
+    "carac3": [20, 30, 25]
   }
 }
 ```
 
-- Empty list ``[]`` -- girl matches no active blessing.
+- Empty list ``[]`` / key absent -- girl matches no active blessing in that mode.
 - ``[20]`` -- one blessing match.
 - ``[20, 30]`` -- both active blessings match.
 - Multipliers stack multiplicatively: ``(1 + 0.20) * (1 + 0.30) = 1.56``.
+
+Context semantics (verified 2026-07-13 against the hh-bless-cluster
+fixtures and a live dump; role blessing that week: "Week of the Bugger"
++25%):
+
+- ``pvp_v3`` holds ONLY the two league-relevant blessings (slots 1+2).
+- ``pvp_v4`` == ``pvp_v3`` plus the slot-3 Role blessing, which applies
+  only in the Love Labyrinth. A girl with a ``pvp_v4``-only entry is
+  role-blessed and counts as UNBLESSED for league team building
+  (``can_be_blessed`` is ``false`` for her).
+- ``BlessingService`` therefore takes a ``context`` parameter
+  (``'league'`` -> ``pvp_v3``, ``'labyrinth'`` -> ``pvp_v4``) and never
+  falls back across contexts.
 
 ### Element data
 

--- a/docs-internal/game-mechanics.md
+++ b/docs-internal/game-mechanics.md
@@ -338,8 +338,14 @@ Blessing-Typen:
 | Typ | Bedeutung |
 |-----|-----------|
 | Common-Blessing | Standard wird gewuerfelt |
-| Element-Blessing (PvP3 / pvp_v3) | Element-spezifischer Bonus, Array [20, 30] = 20% Element + 30% Trait |
-| PvP4-Blessing | League-spezifischer Bonus |
+| League-Blessings (``pvp_v3``) | Die zwei woechentlichen League-Blessings, Array [20, 30] = 20% + 30% |
+| Labyrinth-Set (``pvp_v4``) | == ``pvp_v3`` PLUS die Slot-3-Role-Blessing (gilt nur im Love Labyrinth) |
+
+Verifiziert 2026-07-13 (Fixture-Diff + Live-Dump): ``pvp_v4`` ist kein
+eigenes League-Format, sondern das Labyrinth-Set. Fuer League-Teams gilt
+ausschliesslich ``pvp_v3``; ``can_be_blessed`` ist das League-Flag,
+``can_be_blessed_pvp4`` das Labyrinth-Flag. Details:
+``data-sources-team.md``.
 
 lessing_bonuses Struktur in vailableGirls:
 
@@ -353,7 +359,7 @@ Blessing-Typen:
 }
 `
 
-HHAuto-Skript bevorzugt blessed Trait-Kategorien beim Cluster-Score (BLESSED_CATEGORY_BOOST = 1.5 in TeamScoringService).
+HHAuto baut Bless-bewusste Kandidaten-Teams pro erkannter Blessing (Kandidaten-Matrix in TeamBuilderService, seit v7.35.61); der frueher hier erwaehnte ``BLESSED_CATEGORY_BOOST`` existiert seit dem v7.35.39-Rewrite nicht mehr.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.5.0",
+  "version": "8.5.1",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/TeamModule.spec.ts
+++ b/spec/Module/TeamModule.spec.ts
@@ -66,7 +66,7 @@ describe('TeamModule.mapAvailableGirl -- TM-C raw->GirlData mapping', () => {
         expect(g.eyeColor).toBe('00F');
         expect(g.zodiac).toBe('GLYPH Belier');
         expect(g.position).toBe('5'); // .png stripped
-        expect((g as any).can_be_blessed).toBe(true);
+        expect(g.can_be_blessed_league).toBe(true);
     });
 
     it('prefers element_data.type over element, falls back to fire', () => {
@@ -88,6 +88,14 @@ describe('TeamModule.mapAvailableGirl -- TM-C raw->GirlData mapping', () => {
 
     it('omits can_be_blessed flags when not boolean', () => {
         const g = TeamModule.mapAvailableGirl({ id_girl: 9, can_be_blessed: 'yes' as any });
-        expect('can_be_blessed' in (g as any)).toBe(false);
+        expect('can_be_blessed_league' in g).toBe(false);
+    });
+
+    it('maps both game flags to the speaking per-context names', () => {
+        const g = TeamModule.mapAvailableGirl({
+            id_girl: 10, can_be_blessed: false, can_be_blessed_pvp4: true,
+        });
+        expect(g.can_be_blessed_league).toBe(false);
+        expect(g.can_be_blessed_labyrinth).toBe(true);
     });
 });

--- a/spec/Service/BlessingService.spec.ts
+++ b/spec/Service/BlessingService.spec.ts
@@ -1,0 +1,186 @@
+// BlessingService context tests: league (pvp_v3) vs labyrinth (pvp_v4).
+//
+// Verified game semantics (2026-07-13, hh-bless-cluster fixtures + live
+// dump): pvp_v3 holds the two weekly league blessings, pvp_v4 holds the
+// same PLUS the weekly Role blessing which only applies in the Love
+// Labyrinth. The game flags mirror this: can_be_blessed == "has league
+// blessings", can_be_blessed_pvp4 == "has labyrinth blessings". A girl
+// carrying only the Role blessing must NOT count as league-blessed.
+
+import { BlessingService } from '../../src/Service/BlessingService';
+
+// Raw API shape (snake_case), as delivered by availableGirls.
+function rawGirl(overrides: Record<string, any> = {}): any {
+    return {
+        id_girl: overrides.id_girl ?? Math.floor(Math.random() * 1e9),
+        name: 'Girl',
+        rarity: 'legendary',
+        element: 'fire',
+        eye_color1: '00F',
+        hair_color1: 'B62',
+        zodiac: '♎ Balance',
+        position_img: '3.png',
+        ...overrides,
+    };
+}
+
+function bonuses(v3: number[] | null, v4: number[] | null): any {
+    const mk = (l: number[]) => ({ carac1: l, carac2: l, carac3: l });
+    const bb: any = {};
+    if (v3 !== null) bb.pvp_v3 = mk(v3);
+    if (v4 !== null) bb.pvp_v4 = mk(v4);
+    return bb;
+}
+
+// League-blessed girl: v3 percents present, flag true.
+function leagueBlessed(v3: number[], v4: number[], overrides: Record<string, any> = {}): any {
+    return rawGirl({
+        blessing_bonuses: bonuses(v3, v4),
+        can_be_blessed: true,
+        can_be_blessed_pvp4: true,
+        ...overrides,
+    });
+}
+
+// Role-only girl: no pvp_v3 key at all, flag false (as in real dumps).
+function roleOnly(v4: number[], overrides: Record<string, any> = {}): any {
+    return rawGirl({
+        blessing_bonuses: bonuses(null, v4),
+        can_be_blessed: false,
+        can_be_blessed_pvp4: true,
+        ...overrides,
+    });
+}
+
+describe('BlessingService.getEffectiveMultiplier -- context split', () => {
+
+    it('league multiplier reads pvp_v3 only', () => {
+        const g = leagueBlessed([25], [25, 25]);
+        expect(BlessingService.getEffectiveMultiplier(g)).toBeCloseTo(1.25);
+        expect(BlessingService.getEffectiveMultiplier(g, 'league')).toBeCloseTo(1.25);
+    });
+
+    it('labyrinth multiplier reads pvp_v4 (league + Role stacked)', () => {
+        const g = leagueBlessed([25], [25, 25]);
+        expect(BlessingService.getEffectiveMultiplier(g, 'labyrinth')).toBeCloseTo(1.5625);
+    });
+
+    it('a Role-only girl is unblessed for the league but blessed in the labyrinth', () => {
+        const g = roleOnly([25]);
+        expect(BlessingService.getEffectiveMultiplier(g)).toBe(1);
+        expect(BlessingService.getEffectiveMultiplier(g, 'labyrinth')).toBeCloseTo(1.25);
+    });
+
+    it('never falls back across contexts when one set is missing', () => {
+        expect(BlessingService.getEffectiveMultiplier(roleOnly([30]), 'league')).toBe(1);
+        const v3only = rawGirl({ blessing_bonuses: bonuses([40], null) });
+        expect(BlessingService.getEffectiveMultiplier(v3only, 'labyrinth')).toBe(1);
+    });
+
+    it('accepts GirlData camelCase blessingBonuses', () => {
+        const g = { blessingBonuses: bonuses([40], [40, 25]) };
+        expect(BlessingService.getEffectiveMultiplier(g)).toBeCloseTo(1.4);
+        expect(BlessingService.getEffectiveMultiplier(g, 'labyrinth')).toBeCloseTo(1.75);
+    });
+});
+
+describe('BlessingService.getActivePercents -- context split', () => {
+
+    it('returns the context-specific percent list', () => {
+        const g = leagueBlessed([40], [40, 25]);
+        expect(BlessingService.getActivePercents(g)).toEqual([40]);
+        expect(BlessingService.getActivePercents(g, 'labyrinth')).toEqual([40, 25]);
+    });
+
+    it('returns [] for a Role-only girl in league context', () => {
+        expect(BlessingService.getActivePercents(roleOnly([25]))).toEqual([]);
+    });
+});
+
+describe('BlessingService.detectActiveBlessings -- context split', () => {
+
+    // Pool modelled after the verified 2026-07 live week: hair Dark blond
+    // +40% and position Column (here: "3") +25% as league blessings, plus
+    // a Role +25% cohort that only exists in pvp_v4. The Role girls share
+    // an eye color to make the old bug observable: with the pre-fix
+    // cross-context fallback they produced a spurious eyeColor blessing.
+    function buildPool(): any[] {
+        const pool: any[] = [];
+        for (let i = 0; i < 10; i++) {
+            pool.push(leagueBlessed([40], [40], {
+                id_girl: 100 + i, hair_color1: 'B62', eye_color1: i % 2 ? '00F' : 'F00',
+                position_img: (1 + (i % 2)) + '.png',
+            }));
+        }
+        const scatterHair = ['FFF', '000', 'F99', '0F0'];
+        for (let i = 0; i < 8; i++) {
+            pool.push(leagueBlessed([25], [25], {
+                id_girl: 200 + i, hair_color1: scatterHair[i % 4], eye_color1: i % 2 ? '0F0' : '888',
+                position_img: '3.png',
+            }));
+        }
+        for (let i = 0; i < 12; i++) {
+            pool.push(roleOnly([25], {
+                id_girl: 300 + i, hair_color1: '000', eye_color1: 'A55',
+                position_img: (4 + (i % 3)) + '.png',
+            }));
+        }
+        for (let i = 0; i < 30; i++) {
+            pool.push(rawGirl({
+                id_girl: 400 + i, blessing_bonuses: {},
+                can_be_blessed: false, can_be_blessed_pvp4: false,
+                hair_color1: 'F99', eye_color1: '321', position_img: (7 + (i % 5)) + '.png',
+            }));
+        }
+        return pool;
+    }
+
+    it('league context detects exactly the two league blessings', () => {
+        const found = BlessingService.detectActiveBlessings(buildPool());
+        expect(found.map(b => `${b.kind}=${b.value}+${b.percent}`)).toEqual([
+            'hairColor=B62+40',
+            'position=3+25',
+        ]);
+    });
+
+    it('league context ignores the Role-only cohort (pre-fix: spurious eyeColor blessing)', () => {
+        const found = BlessingService.detectActiveBlessings(buildPool());
+        expect(found.some(b => b.kind === 'eyeColor' && b.value === 'A55')).toBe(false);
+    });
+
+    it('labyrinth context sees the Role cohort as blessed (their shared trait surfaces)', () => {
+        const found = BlessingService.detectActiveBlessings(buildPool(), 'labyrinth');
+        expect(found.some(b => b.kind === 'eyeColor' && b.value === 'A55' && b.percent === 25)).toBe(true);
+    });
+
+    it('respects an explicit can_be_blessed=false even when percents are present', () => {
+        // Drifted/inconsistent data: flag says unblessed, list says +25.
+        // The game flag is authoritative.
+        const odd = leagueBlessed([25], [25], { can_be_blessed: false });
+        const pool = [odd, ...buildPool()];
+        const found = BlessingService.detectActiveBlessings(pool);
+        // The girl must not contribute to any percent group as a carrier.
+        const posBless = found.find(b => b.kind === 'position' && b.percent === 25);
+        expect(posBless).toBeDefined();
+    });
+
+    it('accepts mapped GirlData naming (can_be_blessed_league / blessingBonuses)', () => {
+        const pool = buildPool().map(g => ({
+            id_girl: g.id_girl,
+            eyeColor: g.eye_color1,
+            hairColor: g.hair_color1,
+            zodiac: g.zodiac,
+            position: String(g.position_img).replace('.png', ''),
+            element: g.element,
+            rarity: g.rarity,
+            blessingBonuses: g.blessing_bonuses,
+            can_be_blessed_league: g.can_be_blessed,
+            can_be_blessed_labyrinth: g.can_be_blessed_pvp4,
+        }));
+        const found = BlessingService.detectActiveBlessings(pool);
+        expect(found.map(b => `${b.kind}=${b.value}+${b.percent}`)).toEqual([
+            'hairColor=B62+40',
+            'position=3+25',
+        ]);
+    });
+});

--- a/src/Module/TeamModule.ts
+++ b/src/Module/TeamModule.ts
@@ -447,10 +447,11 @@ export class TeamModule {
      * setTopTeamV2 so the mapping is unit-testable in isolation (the rest
      * of setTopTeamV2 is DOM/UI). Pure: no side effects, no DOM access.
      *
-     * can_be_blessed / can_be_blessed_pvp4 are passed through as untyped
-     * bonus properties so BlessingService.detectActiveBlessings has an
-     * authoritative blessed-or-not flag (issue 1679 phase 2); the static
-     * type stays GirlData.
+     * The game flags can_be_blessed / can_be_blessed_pvp4 are mapped to
+     * the speaking names can_be_blessed_league / can_be_blessed_labyrinth
+     * so BlessingService has an authoritative blessed-or-not flag per
+     * context (league = pvp_v3 blessings, labyrinth = pvp_v4 incl. the
+     * weekly Role blessing).
      */
     static mapAvailableGirl(g: any): GirlData {
         return ({
@@ -477,8 +478,8 @@ export class TeamModule {
             eyeColor: g.eye_color1 || undefined,
             position: g.position_img ? String(g.position_img).replace('.png', '') : undefined,
             blessingBonuses: g.blessing_bonuses || undefined,
-            ...(typeof g.can_be_blessed === 'boolean' ? { can_be_blessed: g.can_be_blessed } : {}),
-            ...(typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_pvp4: g.can_be_blessed_pvp4 } : {}),
+            ...(typeof g.can_be_blessed === 'boolean' ? { can_be_blessed_league: g.can_be_blessed } : {}),
+            ...(typeof g.can_be_blessed_pvp4 === 'boolean' ? { can_be_blessed_labyrinth: g.can_be_blessed_pvp4 } : {}),
         }) as GirlData;
     }
 

--- a/src/Service/BlessingService.ts
+++ b/src/Service/BlessingService.ts
@@ -14,6 +14,22 @@ import { TK } from "../config/StorageKeys";
 
 const CACHE_DURATION_MS = 12 * 60 * 60 * 1000; // 12 hours
 
+/**
+ * Which battle mode a blessing lookup is for. The game maintains two
+ * parallel blessing sets per girl (verified 2026-07-13 against the
+ * hh-bless-cluster fixtures and a live dump):
+ *   - 'league'    -> blessing_bonuses.pvp_v3: the two weekly league
+ *                    blessings only. Mirrored by the game flag
+ *                    can_be_blessed (GirlData: can_be_blessed_league).
+ *   - 'labyrinth' -> blessing_bonuses.pvp_v4: the league blessings PLUS
+ *                    the weekly Role blessing, which applies only in the
+ *                    Love Labyrinth. Mirrored by can_be_blessed_pvp4
+ *                    (GirlData: can_be_blessed_labyrinth).
+ * There is deliberately NO fallback from one set to the other: a girl
+ * carrying only the Role blessing is unblessed for league purposes.
+ */
+export type BlessingContext = 'league' | 'labyrinth';
+
 export interface BlessingData {
     timestamp: number;
     raw: any;
@@ -76,15 +92,32 @@ export class BlessingService {
     }
 
     /**
+     * Context-specific percent list (carac1) from the girl's
+     * blessing_bonuses. 'league' reads pvp_v3, 'labyrinth' reads pvp_v4;
+     * never falls back across contexts (see BlessingContext). Accepts
+     * raw API girls (blessing_bonuses) and GirlData (blessingBonuses).
+     */
+    private static getContextPercentList(
+        girl: { blessing_bonuses?: any; blessingBonuses?: any },
+        context: BlessingContext,
+    ): number[] {
+        const bb = (girl as any).blessing_bonuses ?? girl.blessingBonuses;
+        if (!bb || typeof bb !== 'object' || Array.isArray(bb)) return [];
+        const v = context === 'labyrinth' ? bb.pvp_v4 : bb.pvp_v3;
+        if (!v || typeof v !== 'object') return [];
+        const pcs = v.carac1;
+        if (!Array.isArray(pcs)) return [];
+        return pcs.map((p: any) => Number(p)).filter((n: number) => Number.isFinite(n) && n > 0);
+    }
+
+    /**
      * Authoritative per-girl blessing multiplier from the game's
      * blessing_bonuses field. This is the single source of truth for
-     * 'is this girl currently blessed and by how much'.
+     * 'is this girl currently blessed in this context and by how much'.
      *
-     * The game writes the active per-class blessing percentages into
-     * blessing_bonuses.pvp_v3 (current league) and pvp_v4 (next league
-     * version). Each is shaped { caracN: number[] }; the list contains
-     * one entry per active blessing affecting the girl, applied
-     * multiplicatively. Examples:
+     * Each set is shaped { caracN: number[] }; the list contains one
+     * entry per active blessing affecting the girl, applied
+     * multiplicatively. Examples (league):
      *   pvp_v3.carac1 = []         -> no blessing -> multiplier 1.0
      *   pvp_v3.carac1 = [25]       -> +25%        -> multiplier 1.25
      *   pvp_v3.carac1 = [40, 25]   -> +40% AND +25% -> multiplier 1.75
@@ -92,40 +125,28 @@ export class BlessingService {
      * The girl's caracs sub-object already contains the multiplied stat,
      * so the team builder does not need to multiply again. This helper
      * is for diagnostics: 'is girl X blessed?' and 'how much'.
-     *
-     * Falls back from pvp_v4 to pvp_v3 (forwards-compatible with a future
-     * league version cutover).
      */
-    static getEffectiveMultiplier(girl: { blessing_bonuses?: any; blessingBonuses?: any }): number {
-        const bb = (girl as any).blessing_bonuses ?? girl.blessingBonuses;
-        if (!bb || typeof bb !== 'object' || Array.isArray(bb)) return 1;
-        const v = bb.pvp_v4 ?? bb.pvp_v3;
-        if (!v || typeof v !== 'object') return 1;
-        const pcs = v.carac1;
-        if (!Array.isArray(pcs) || pcs.length === 0) return 1;
+    static getEffectiveMultiplier(
+        girl: { blessing_bonuses?: any; blessingBonuses?: any },
+        context: BlessingContext = 'league',
+    ): number {
         let mult = 1;
-        for (const p of pcs) {
-            const n = Number(p);
-            if (Number.isFinite(n) && n > 0) {
-                mult *= 1 + n / 100;
-            }
+        for (const n of BlessingService.getContextPercentList(girl, context)) {
+            mult *= 1 + n / 100;
         }
         return mult;
     }
 
     /**
-     * List the blessing percentages currently active on this girl, in
-     * the order the game returned them. Useful for UI annotations like
-     * '(+25% blessing)' or '(+40%, +25% blessing)'.
+     * List the blessing percentages currently active on this girl for
+     * the given context, in the order the game returned them. Useful for
+     * UI annotations like '(+25% blessing)' or '(+40%, +25% blessing)'.
      */
-    static getActivePercents(girl: { blessing_bonuses?: any; blessingBonuses?: any }): number[] {
-        const bb = (girl as any).blessing_bonuses ?? girl.blessingBonuses;
-        if (!bb || typeof bb !== 'object' || Array.isArray(bb)) return [];
-        const v = bb.pvp_v4 ?? bb.pvp_v3;
-        if (!v || typeof v !== 'object') return [];
-        const pcs = v.carac1;
-        if (!Array.isArray(pcs)) return [];
-        return pcs.filter((p: any) => Number.isFinite(Number(p)) && Number(p) > 0).map((p: any) => Number(p));
+    static getActivePercents(
+        girl: { blessing_bonuses?: any; blessingBonuses?: any },
+        context: BlessingContext = 'league',
+    ): number[] {
+        return BlessingService.getContextPercentList(girl, context);
     }
 
     private static parseTraits(response: any): string[] {
@@ -359,24 +380,26 @@ export class BlessingService {
      * dependent: 'eye color' / 'couleur des yeux' / 'augenfarbe' ...).
      *
      * The game's blessing_bonuses field on each girl is the authoritative
-     * source: a girl with can_be_blessed=true has at least one active
-     * blessing applied to her caracs. By cross-referencing the can-be-
-     * blessed girls with their fields (element, rarity, eye_color1,
-     * hair_color1, zodiac, position_img), we identify what each blessing
-     * targets WITHOUT reading any localized description.
+     * source. The `context` picks the blessing set (league -> pvp_v3,
+     * labyrinth -> pvp_v4 incl. the weekly Role blessing; see
+     * BlessingContext). By cross-referencing the blessed girls with their
+     * fields (element, rarity, eye_color1, hair_color1, zodiac,
+     * position_img), we identify what each blessing targets WITHOUT
+     * reading any localized description.
      *
      * Returns an array of detected blessings sorted by priority:
      *   1. blessings with the highest bonus percent (e.g. 40% > 25%)
      *   2. blessings with the largest blessed pool
      *
-     * The percent comes from the pvp_v3.carac1 list on a representative
+     * The percent comes from the context's carac1 list on a representative
      * blessed girl. When two blessings stack on the same girl, that girl's
      * carac1 list has multiple entries; we extract individual percents per
      * field (element/rarity/trait) by finding the field whose value is
      * uniformly shared by girls carrying a particular percent.
      */
     static detectActiveBlessings(
-        girls: Array<any>
+        girls: Array<any>,
+        context: BlessingContext = 'league',
     ): Array<{
         kind: 'eyeColor' | 'hairColor' | 'zodiac' | 'position' | 'element' | 'rarity';
         value: string;
@@ -387,30 +410,34 @@ export class BlessingService {
         // (snake_case: eye_color1, hair_color1, position_img,
         // blessing_bonuses, can_be_blessed) or GirlData objects (camelCase:
         // eyeColor, hairColor, position, blessingBonuses). For 'blessed'
-        // status: prefer the explicit can_be_blessed flag, otherwise
-        // derive it from blessing_bonuses / blessingBonuses being a
-        // populated dict.
-        const bbOf  = (g: any) => g.blessing_bonuses ?? g.blessingBonuses;
+        // status: prefer the context's explicit game flag (league:
+        // can_be_blessed, labyrinth: can_be_blessed_pvp4 -- mapped to
+        // can_be_blessed_league / can_be_blessed_labyrinth in GirlData).
+        // The flag is authoritative in both directions: a girl carrying
+        // only the labyrinth Role blessing has can_be_blessed === false
+        // and must NOT count as league-blessed. Only when the flag is
+        // absent is blessed-ness derived from the context's percent list.
+        const flagOf = (g: any): boolean | undefined => {
+            const flag = context === 'labyrinth'
+                ? (g.can_be_blessed_labyrinth ?? g.can_be_blessed_pvp4)
+                : (g.can_be_blessed_league ?? g.can_be_blessed);
+            return typeof flag === 'boolean' ? flag : undefined;
+        };
         const isBlessed = (g: any): boolean => {
-            if (g.can_be_blessed === true) return true;
-            const bb = bbOf(g);
-            return !!(bb && typeof bb === 'object' && !Array.isArray(bb)
-                && (bb.pvp_v3 || bb.pvp_v4));
+            const flag = flagOf(g);
+            if (flag !== undefined) return flag;
+            return BlessingService.getContextPercentList(g, context).length > 0;
         };
 
-        const blessed = girls.filter(g => isBlessed(g) && bbOf(g)
-            && typeof bbOf(g) === 'object' && !Array.isArray(bbOf(g)));
+        const blessed = girls.filter(g => isBlessed(g)
+            && BlessingService.getContextPercentList(g, context).length > 0);
         if (blessed.length === 0) return [];
 
         // Collect distinct percents seen across the blessed pool.
         const percents = new Set<number>();
         for (const g of blessed) {
-            const bb = bbOf(g);
-            const v = bb.pvp_v3 ?? bb.pvp_v4;
-            if (!v || !Array.isArray(v.carac1)) continue;
-            for (const p of v.carac1) {
-                const n = Number(p);
-                if (Number.isFinite(n) && n > 0) percents.add(n);
+            for (const n of BlessingService.getContextPercentList(g, context)) {
+                percents.add(n);
             }
         }
 
@@ -439,11 +466,8 @@ export class BlessingService {
         //      to be legendary" doesn't mean rarity=legendary IS the
         //      blessing condition).
         for (const percent of percents) {
-            const carrying = blessed.filter(g => {
-                const bb = bbOf(g);
-                const v = bb.pvp_v3 ?? bb.pvp_v4;
-                return Array.isArray(v?.carac1) && v.carac1.includes(percent);
-            });
+            const carrying = blessed.filter(g =>
+                BlessingService.getContextPercentList(g, context).includes(percent));
             if (carrying.length === 0) continue;
 
             for (const kind of kinds) {

--- a/src/Service/TeamScoringService.ts
+++ b/src/Service/TeamScoringService.ts
@@ -48,6 +48,11 @@ export interface GirlData {
     position?: string;
     // Blessing data (game API). The team builder reads it via BlessingService.
     blessingBonuses?: any;
+    // Per-context blessed flags, mapped from the game fields
+    // can_be_blessed (league / pvp_v3) and can_be_blessed_pvp4
+    // (labyrinth / pvp_v4 incl. the weekly Role blessing).
+    can_be_blessed_league?: boolean;
+    can_be_blessed_labyrinth?: boolean;
 }
 
 // Tier-5 mapping. Priority controls the leader pick (Shield > Stun > Execute > Reflect).


### PR DESCRIPTION
## Summary

League and labyrinth blessings were not separated cleanly (see #1679): girls blessed only for the labyrinth (weekly Role blessing) could slip into the league selection pool as "blessed" and distort the selection — the blessed leader tie-break, the blessed counts in the info panel and the mythic audit, and the blessing detection all read the labyrinth data.

## Changes

- BlessingService takes an explicit context: league lookups read pvp_v3 only, labyrinth lookups read pvp_v4 only, no fallback across the two. The team builder always uses the league context.
- Game flags mapped to speaking names: can_be_blessed -> can_be_blessed_league, can_be_blessed_pvp4 -> can_be_blessed_labyrinth; an explicit false from the game is respected.
- Docs updated (data-sources-team.md, game-mechanics.md) with the verified pvp_v3/pvp_v4 semantics.

## Verification

- 12 new BlessingService tests incl. the spurious-blessing regression case; full suite 1223/1223 green.
- hh-bless-cluster fixture teams (Frank/Julien weeks) are unchanged — only tie-break inputs and diagnostics become accurate.
- Verified against a live dump (2026-07-13): the pvp_v3/pvp_v4 delta is exactly the weekly Role blessing ("Week of the Bugger" +25%).