### PR TITLE
docs: catch up the team/blessing internal docs with the code

### DIFF
--- a/docs-internal/data-sources-team.md
+++ b/docs-internal/data-sources-team.md
@@ -1,6 +1,6 @@
 ---
-last-verified: 2026-05-19
-verified-against-version: 7.35.41
+last-verified: 2026-07-13
+verified-against-version: 8.5.1
 status: current
 ---
 

--- a/docs-internal/data-sources-team.md
+++ b/docs-internal/data-sources-team.md
@@ -7,9 +7,12 @@ status: current
 # API Reference: Team Selection Inputs
 
 Reference for the game-side data structures the team builder consumes.
-Algorithm and behaviour live in ``REVIEW_TeamSelection.md``; this file
-documents only the inputs (game API field shapes) so they can be looked
-up without diffing the live game.
+The algorithm itself lives in the code -- ``TeamBuilderService.ts``
+(candidate matrix, leader rule, cluster/Pos-2-7 fill) over
+``TeamScoringService.ts`` (scoring, Tier-3/Tier-5, element coeff) and
+``BlessingService.ts`` (blessing detection). This file documents only the
+inputs (game API field shapes) so they can be looked up without diffing
+the live game.
 
 ---
 

--- a/docs-internal/game-mechanics.md
+++ b/docs-internal/game-mechanics.md
@@ -403,7 +403,7 @@ Wichtige Eigenschaften:
 | Thema | HHAuto-Doku |
 |-------|-------------|
 | Battle-Simulation und Crit-Berechnung | bdsm-battle-simulator.md |
-| Team-Auswahl-Algorithmus (League) | REVIEW_TeamSelection.md |
+| Team-Auswahl-Algorithmus (League) | Code: `TeamBuilderService.ts` / `TeamScoringService.ts` |
 | availableGirls-Felder, Blessing-API | data-sources-team.md |
 | Storage-Keys fuer Settings (Boost-Filter, Threshold) | storage-keys.md |
 

--- a/docs-internal/game-mechanics.md
+++ b/docs-internal/game-mechanics.md
@@ -1,6 +1,6 @@
 ---
-last-verified: 2026-05-06
-verified-against-version: HentaiHeroes BDSM (release 2021-07-21), v7.35.21 HHAuto
+last-verified: 2026-07-13
+verified-against-version: HentaiHeroes BDSM (release 2021-07-21), v8.5.1 HHAuto
 status: current
 sources:
   - INPUT/Your Performance Handbook!*.pdf (Slynia, 2021-11-20+)

--- a/docs-internal/storage-keys.md
+++ b/docs-internal/storage-keys.md
@@ -438,7 +438,7 @@ Die Spalte "Storage" zeigt den Wert aus der Registry. `--` heisst: nicht in `HHS
 | `haremTeam` | `Temp_haremTeam` | `sessionStorage` | `Temp` | Team-Daten (JSON) |
 | `haremTeamScrolls` | `Temp_haremTeamScrolls` | `sessionStorage` | `Temp` | Team-Scrolls |
 | `haremTeamSettings` | `Temp_haremTeamSettings` | `sessionStorage` | `Temp` | Team-Einstellungen |
-| `blessingsCache` | `Temp_blessingsCache` | `localStorage` | `Temp` | *(neu, noch keine Beschreibung)* |
+| `blessingsCache` | `Temp_blessingsCache` | `localStorage` | `Temp` | Blessing-API-Cache (`BlessingData` JSON), 12 h Lebensdauer, gesetzt in `BlessingService.fetchAndCache` |
 
 ### Resources
 


### PR DESCRIPTION
Docs-only follow-up to v8.5.1, no code change.

- Bump the last-verified frontmatter on data-sources-team.md and game-mechanics.md (blessing-context updates were verified against a live dump on 2026-07-13).
- Repoint two dead REVIEW_TeamSelection.md references (that spec is not in the repo) to the actual source: TeamBuilderService.ts / TeamScoringService.ts / BlessingService.ts.
- Fill the missing description for the blessingsCache storage key.

Verified against current code: all cited source paths, referenced service/helper methods, storage keys, the Tier-3 constants and the BlessingData cache shape are consistent.