### PR TITLE
fix(quest): stop main/side quest self-disable at the newest known quest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.5.2 - Main and side quest no longer switch themselves off at the newest quest
+
+- When you had reached the newest available main quest, the bot could
+  navigate onto that final quest screen, fail to find a proceed button,
+  and switch both the main-quest and side-quest auto-settings off - even
+  right after you re-enabled them. This is the same self-disable that was
+  addressed once before; it returned as soon as the game added quests
+  beyond the last quest id the script knew about.
+- The bot now recognizes when you are at or beyond the newest known quest
+  and waits for new content instead of treating that screen as an error,
+  so both auto-settings stay on. Other games already behaved this way.
+
 ### v8.5.1 - Team builder no longer counts the labyrinth Role blessing as a league blessing
 
 - The game keeps two blessing sets per girl: `pvp_v3` (the two weekly

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.5.1
+// @version      8.5.2
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -101,8 +101,9 @@ GM_addStyle('#girl_preview_popup #poses-tab_container .pose-preview_wrapper.lock
 
 /******/ (() => { // webpackBootstrap
 /******/ 	"use strict";
+var __webpack_exports__ = {};
 
-;// ./src/i18n/empty.ts
+;// CONCATENATED MODULE: ./src/i18n/empty.ts
 const HHAuto_ToolTips = { en: {}, fr: {}, es: {}, de: {}, it: {} };
 const w = (typeof unsafeWindow == 'undefined') ? window : unsafeWindow;
 var hhTimerLocale = w.Phoenix ? w.Phoenix.language : null;
@@ -122,7 +123,7 @@ else {
     timerDefinitions = { 'en': { days: "d", hours: "h", minutes: "m", seconds: "s" } };
 }
 
-;// ./src/i18n/en.ts
+;// CONCATENATED MODULE: ./src/i18n/en.ts
 
 HHAuto_ToolTips.en['saveDebug'] = { version: "5.6.24", elementText: "Save Debug", tooltip: "Allow to produce a debug log file." };
 HHAuto_ToolTips.en['gitHub'] = { version: "5.6.24", elementText: "GitHub", tooltip: "Link to GitHub project." };
@@ -507,7 +508,7 @@ HHAuto_ToolTips.en['sideAdventure'] = { version: "7.23.0", elementText: "Side ad
 HHAuto_ToolTips.en['otherTrollOption'] = { version: "7.23.0", elementText: "Others", tooltip: "" };
 //HHAuto_ToolTips.en['scriptWarning'] = { version: "7.4.0", elementText: "Warning", tooltip: "An issue is detected in bot execution, open menu and logs for more info"};
 
-;// ./src/i18n/fr.ts
+;// CONCATENATED MODULE: ./src/i18n/fr.ts
 
 HHAuto_ToolTips.fr['saveDebug'] = { version: "5.6.24", elementText: "Sauver log", tooltip: "Sauvegarder un fichier journal de débogage." };
 HHAuto_ToolTips.fr['gitHub'] = { version: "5.6.24", elementText: "GitHub", tooltip: "Lien vers le projet GitHub." };
@@ -660,7 +661,7 @@ HHAuto_ToolTips.en['sideAdventure'] = { version: "7.23.0", elementText: "Aventur
 HHAuto_ToolTips.en['otherTrollOption'] = { version: "7.23.0", elementText: "Autre options", tooltip: "" };
 HHAuto_ToolTips.fr['autoEquipMythicBooster'] = { version: "8.3.0", elementText: "Mythic Slot", tooltip: "(up to 5 codes separated by ;)<br>Mythic boosters to keep equipped. The game offers 5 mythic slots (one equipped booster per kind): every listed booster you own that is not equipped yet is placed into a free slot, in list order (order = priority). Empty field = off.<br>Example: MB1;MB2;MB5;MB8;MB12<br>Equipped boosters are never replaced and nothing is bought (only equips from inventory).<br>The Sandalwood auto-equip keeps control of MB1: while active, MB1 on this list is skipped and one slot is kept free for Sandalwood." };
 
-;// ./src/i18n/de.ts
+;// CONCATENATED MODULE: ./src/i18n/de.ts
 
 HHAuto_ToolTips.de['saveDebug'] = { version: "5.6.24", elementText: "Save Debug", tooltip: "Erlaube das Erstellen einer Debug Log Datei." };
 HHAuto_ToolTips.de['gitHub'] = { version: "5.6.24", elementText: "GitHub", tooltip: "Link zum GitHub Projekt." };
@@ -741,7 +742,7 @@ HHAuto_ToolTips.de['sandalwoodMinShardsThreshold'] = { version: "7.34.16", eleme
 HHAuto_ToolTips.de['povTitle'] = { version: "5.20.3", elementText: "Pfad der Tapferkeit (PoV)" };
 HHAuto_ToolTips.de['pogTitle'] = { version: "5.20.3", elementText: "Pfad des Ruhmes (PoG)" };
 
-;// ./src/i18n/es.ts
+;// CONCATENATED MODULE: ./src/i18n/es.ts
 
 HHAuto_ToolTips.es['saveDebug'] = { version: "5.6.24", elementText: "Salvar Debug", tooltip: "Permite generar un fichero log de depuración." };
 HHAuto_ToolTips.es['gitHub'] = { version: "5.6.24", elementText: "GitHub", tooltip: "Link al proyecto GitHub." };
@@ -825,7 +826,7 @@ HHAuto_ToolTips.es['povTitle'] = { version: "5.20.3", elementText: "Camino del V
 HHAuto_ToolTips.es['autoEquipMythicBooster'] = { version: "8.3.0", elementText: "Mythic Slot", tooltip: "(up to 5 codes separated by ;)<br>Mythic boosters to keep equipped. The game offers 5 mythic slots (one equipped booster per kind): every listed booster you own that is not equipped yet is placed into a free slot, in list order (order = priority). Empty field = off.<br>Example: MB1;MB2;MB5;MB8;MB12<br>Equipped boosters are never replaced and nothing is bought (only equips from inventory).<br>The Sandalwood auto-equip keeps control of MB1: while active, MB1 on this list is skipped and one slot is kept free for Sandalwood." };
 HHAuto_ToolTips.es['pogTitle'] = { version: "5.20.3", elementText: "Camino de la Gloria" };
 
-;// ./src/Helper/LanguageHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/LanguageHelper.ts
 // LanguageHelper.ts
 //
 // Handles UI text localization for the HHAuto menu and tooltips.
@@ -906,7 +907,7 @@ function getTextForUI(id, type) {
             return defaultLanguageText;
         }
         else {
-            logHHAuto("not found text for " + HHAuto_Lang + "/" + id + "/" + type);
+            LogUtils_logHHAuto("not found text for " + HHAuto_Lang + "/" + id + "/" + type);
             return HHAuto_Lang + "/" + id + "/" + type + " not found.";
         }
     }
@@ -1027,7 +1028,7 @@ function manageTranslationPopUp() {
     }
 }
 
-;// ./src/config/StorageKeys.ts
+;// CONCATENATED MODULE: ./src/config/StorageKeys.ts
 /**
  * Centralized storage key constants.
  * Use these instead of raw strings like HHStoredVarPrefixKey+"Setting_autoTrollBattle"
@@ -1390,7 +1391,7 @@ const TK = {
     trollWaitForEnergy: "Temp_trollWaitForEnergy",
 };
 
-;// ./src/Helper/TimeHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/TimeHelper.ts
 // TimeHelper.ts
 //
 // Time-related utilities: converting between human-readable durations
@@ -1480,28 +1481,28 @@ function convertTimeToInt(remainingTimer, failSafe = true) {
                         newTimer += parseInt(splittedTime[i]);
                         break;
                     default:
-                        logHHAuto('Timer symbol not recognized: ' + timerSymbol);
+                        LogUtils_logHHAuto('Timer symbol not recognized: ' + timerSymbol);
                 }
             }
         }
         catch ({ errName, message }) {
             if (failSafe) {
-                logHHAuto(`ERROR: occured, reset to 15min: ${errName}, ${message}`);
+                LogUtils_logHHAuto(`ERROR: occured, reset to 15min: ${errName}, ${message}`);
                 newTimer = randomInterval(15 * 60, 17 * 60);
             }
             else {
-                logHHAuto(`ERROR: occured, return -1: ${errName}, ${message}`);
+                LogUtils_logHHAuto(`ERROR: occured, return -1: ${errName}, ${message}`);
                 newTimer = -1;
             }
         }
     }
     else {
         if (failSafe) {
-            logHHAuto('No valid timer definitions, reset to 15min');
+            LogUtils_logHHAuto('No valid timer definitions, reset to 15min');
             newTimer = randomInterval(15 * 60, 17 * 60);
         }
         else {
-            logHHAuto('No valid timer definitions, return -1');
+            LogUtils_logHHAuto('No valid timer definitions, return -1');
             newTimer = -1;
         }
     }
@@ -1514,7 +1515,7 @@ function randomInterval(min, max) {
     return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
-;// ./src/Helper/TimerHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/TimerHelper.ts
 // TimerHelper.ts
 //
 // Manages named cooldown timers that prevent actions from running too
@@ -1545,7 +1546,7 @@ function setTimer(name, seconds) {
     var ND = new Date().getTime() + seconds * 1000;
     Timers[name] = ND;
     setStoredValue(HHStoredVarPrefixKey + TK.Timers, JSON.stringify(Timers));
-    logHHAuto(name + " set to " + TimeHelper.toHHMMSS(ND / 1000 - new Date().getTimezoneOffset() * 60) + ' (' + TimeHelper.toHHMMSS(seconds) + ')');
+    LogUtils_logHHAuto(name + " set to " + TimeHelper.toHHMMSS(ND / 1000 - new Date().getTimezoneOffset() * 60) + ' (' + TimeHelper.toHHMMSS(seconds) + ')');
 }
 function clearTimer(name) {
     delete Timers[name];
@@ -1599,7 +1600,7 @@ function getTimeLeft(name) {
     return TimeHelper.toHHMMSS(diff);
 }
 
-;// ./src/config/HHStoredVars.ts
+;// CONCATENATED MODULE: ./src/config/HHStoredVars.ts
 // Registry of all stored variables (settings and temporary state) for HHAuto.
 // Defines each variable's storage type (setting vs. temp), default value,
 // validation regex, UI label, and type. Used by the settings menu and storage layer.
@@ -1616,11 +1617,11 @@ function cleanTempPopToStart() {
     deleteStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart);
     deleteStoredValue(HHStoredVarPrefixKey + TK.PopToStart);
 }
-const HHStoredVars = {};
+const HHStoredVars_HHStoredVars = {};
 //Settings Vars
 const HHStoredVarPrefixKey = "HHAuto_"; // default HHAuto_
 //Do not move, has to be first one
-HHStoredVars[HHStoredVarPrefixKey + SK.settPerTab] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.settPerTab] =
     {
         default: "false",
         storage: "localStorage",
@@ -1632,7 +1633,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.settPerTab] =
         kobanUsing: false
     };
 // Rest of settings vars
-HHStoredVars[HHStoredVarPrefixKey + SK.autoAff] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoAff] =
     {
         default: "500000000",
         storage: "Storage()",
@@ -1643,7 +1644,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoAff] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoAffW] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoAffW] =
     {
         default: "false",
         storage: "Storage()",
@@ -1654,7 +1655,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoAffW] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoosters] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoosters] =
     {
         default: "false",
         storage: "Storage()",
@@ -1665,7 +1666,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoosters] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoostersFilter] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoostersFilter] =
     {
         default: "B1;B2;B3;B4",
         storage: "Storage()",
@@ -1676,7 +1677,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyBoostersFilter] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoosters] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoosters] =
     {
         default: "false",
         storage: "Storage()",
@@ -1687,7 +1688,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoosters] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoostersSlots] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoostersSlots] =
     {
         default: "B1;B2;B3;B4",
         storage: "Storage()",
@@ -1698,7 +1699,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipBoostersSlots] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster] =
     {
         default: "",
         storage: "Storage()",
@@ -1710,7 +1711,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoEquipMythicBooster] =
         kobanUsing: false,
         isValid: /^(\s*(MB[1-9]|MB1[0-2])\s*(;\s*(MB[1-9]|MB1[0-2])\s*){0,4})?$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChamps] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChamps] =
     {
         default: "false",
         storage: "Storage()",
@@ -1724,7 +1725,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChamps] =
             clearTimer('nextChampionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampAlignTimer] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampAlignTimer] =
     {
         default: "false",
         storage: "Storage()",
@@ -1735,7 +1736,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampAlignTimer] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStart] =
     {
         default: "false",
         storage: "Storage()",
@@ -1749,7 +1750,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStart] =
             clearTimer('nextChampionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsFilter] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsFilter] =
     {
         default: "1;2;3;4;5;6",
         storage: "Storage()",
@@ -1763,7 +1764,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsFilter] =
             clearTimer('nextChampionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamLoop] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamLoop] =
     {
         default: "10",
         storage: "Storage()",
@@ -1774,7 +1775,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamLoop] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsGirlThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsGirlThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -1785,7 +1786,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsGirlThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamKeepSecondLine] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamKeepSecondLine] =
     {
         default: "false",
         storage: "Storage()",
@@ -1796,7 +1797,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsTeamKeepSecondLine] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsUseEne] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsUseEne] =
     {
         default: "false",
         storage: "Storage()",
@@ -1807,7 +1808,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsUseEne] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuildChampsTeam] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuildChampsTeam] =
     {
         default: "false",
         storage: "Storage()",
@@ -1818,7 +1819,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuildChampsTeam] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showClubButtonInPoa] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showClubButtonInPoa] =
     {
         default: "true",
         storage: "Storage()",
@@ -1829,7 +1830,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showClubButtonInPoa] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChamp] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChamp] =
     {
         default: "false",
         storage: "Storage()",
@@ -1843,7 +1844,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChamp] =
             clearTimer('nextClubChampionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChampMax] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChampMax] =
     {
         default: "999",
         storage: "Storage()",
@@ -1854,7 +1855,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoClubChampMax] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoClubForceStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoClubForceStart] =
     {
         default: "false",
         storage: "Storage()",
@@ -1868,7 +1869,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoClubForceStart] =
             clearTimer('nextClubChampionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoContest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoContest] =
     {
         default: "false",
         storage: "Storage()",
@@ -1882,7 +1883,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoContest] =
             clearTimer('nextContestCollectTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.compactEndedContests] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.compactEndedContests] =
     {
         default: "false",
         storage: "Storage()",
@@ -1893,7 +1894,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.compactEndedContests] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoExp] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoExp] =
     {
         default: "500000000",
         storage: "Storage()",
@@ -1904,7 +1905,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoExp] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoExpW] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoExpW] =
     {
         default: "false",
         storage: "Storage()",
@@ -1915,7 +1916,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoExpW] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoFreePachinko] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoFreePachinko] =
     {
         default: "false",
         storage: "Storage()",
@@ -1931,7 +1932,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoFreePachinko] =
             clearTimer('nextPachinkoEquipTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeagues] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeagues] =
     {
         default: "false",
         storage: "Storage()",
@@ -1945,7 +1946,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeagues] =
             clearTimer('nextLeaguesTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesAllowWinCurrent] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesAllowWinCurrent] =
     {
         default: "false",
         storage: "Storage()",
@@ -1956,7 +1957,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesAllowWinCurrent] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -1967,7 +1968,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesCollect] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesBoostedOnly] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesBoostedOnly] =
     {
         default: "false",
         storage: "Storage()",
@@ -1978,7 +1979,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesBoostedOnly] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesRunThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesRunThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -1989,7 +1990,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesRunThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesForceOneFight] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesForceOneFight] =
     {
         default: "false",
         storage: "Storage()",
@@ -2000,7 +2001,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesForceOneFight] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.leagueListDisplayPowerCalc] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.leagueListDisplayPowerCalc] =
     {
         default: "false",
         storage: "Storage()",
@@ -2014,7 +2015,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.leagueListDisplayPowerCalc] =
             deleteStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList);
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSelectedIndex] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSelectedIndex] =
     {
         default: "0",
         storage: "Storage()",
@@ -2027,7 +2028,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSelectedIndex] =
         customMenuID: "autoLeaguesSelector",
         isValid: /^[0-9]$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSortIndex] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSortIndex] =
     {
         default: "1",
         storage: "Storage()",
@@ -2043,7 +2044,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSortIndex] =
             deleteStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList);
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2054,7 +2055,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSecurityThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSecurityThreshold] =
     {
         default: "40",
         storage: "Storage()",
@@ -2065,7 +2066,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLeaguesSecurityThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.compactMissions] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.compactMissions] =
     {
         default: "false",
         storage: "Storage()",
@@ -2076,7 +2077,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.compactMissions] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoMission] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoMission] =
     {
         default: "false",
         storage: "Storage()",
@@ -2090,7 +2091,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoMission] =
             clearTimer('nextMissionTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -2101,7 +2102,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionCollect] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionKFirst] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionKFirst] =
     {
         default: "false",
         storage: "Storage()",
@@ -2112,7 +2113,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoMissionKFirst] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.invertMissions] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.invertMissions] =
     {
         default: "false",
         storage: "Storage()",
@@ -2123,7 +2124,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.invertMissions] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.compactPowerPlace] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.compactPowerPlace] =
     {
         default: "false",
         storage: "Storage()",
@@ -2134,7 +2135,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.compactPowerPlace] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlaces] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlaces] =
     {
         default: "false",
         storage: "Storage()",
@@ -2149,7 +2150,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlaces] =
             cleanTempPopToStart();
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -2164,7 +2165,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesAll] =
             cleanTempPopToStart();
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesPrecision] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesPrecision] =
     {
         default: "false",
         storage: "Storage()",
@@ -2175,7 +2176,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesPrecision] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesInverted] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesInverted] =
     {
         default: "false",
         storage: "Storage()",
@@ -2186,7 +2187,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesInverted] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesWaitMax] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesWaitMax] =
     {
         default: "false",
         storage: "Storage()",
@@ -2197,7 +2198,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesWaitMax] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesIndexFilter] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesIndexFilter] =
     {
         default: "1;2;3",
         storage: "Storage()",
@@ -2212,7 +2213,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPowerPlacesIndexFilter] =
             cleanTempPopToStart();
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoQuest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoQuest] =
     {
         default: "false",
         storage: "Storage()",
@@ -2226,7 +2227,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoQuest] =
             deleteStoredValue(HHStoredVarPrefixKey + TK.questRequirement);
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSideQuest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSideQuest] =
     {
         default: "false",
         storage: "Storage()",
@@ -2237,7 +2238,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSideQuest] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoQuestThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoQuestThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2248,7 +2249,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoQuestThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSalary] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSalary] =
     {
         default: "false",
         storage: "Storage()",
@@ -2262,7 +2263,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSalary] =
             clearTimer('nextSalaryTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSalaryMinSalary] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSalaryMinSalary] =
     {
         default: "20000",
         storage: "Storage()",
@@ -2276,7 +2277,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSalaryMinSalary] =
             clearTimer('nextSalaryTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeason] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeason] =
     {
         default: "false",
         storage: "Storage()",
@@ -2290,7 +2291,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeason] =
             clearTimer('nextSeasonTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -2308,7 +2309,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -2319,7 +2320,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonFocus] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonFocus] =
     {
         default: "off",
         storage: "Storage()",
@@ -2332,7 +2333,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonFocus] =
         kobanUsing: false,
         isValid: /^(off|girl|girlAndSkin)$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.seasonDisplayPowerCalc] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.seasonDisplayPowerCalc] =
     {
         default: "true",
         storage: "Storage()",
@@ -2343,14 +2344,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.seasonDisplayPowerCalc] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonPassReds] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonPassReds] =
     {
         default: "false",
         storage: "Storage()",
@@ -2361,7 +2362,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonPassReds] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2372,7 +2373,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonRunThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonRunThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2383,7 +2384,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonRunThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTier] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTier] =
     {
         default: "false",
         storage: "Storage()",
@@ -2394,7 +2395,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTier] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierNb] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierNb] =
     {
         default: "63",
         storage: "Storage()",
@@ -2405,7 +2406,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierNb] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierHard] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierHard] =
     {
         default: "false",
         storage: "Storage()",
@@ -2416,7 +2417,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonMaxTierHard] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonBoostedOnly] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonBoostedOnly] =
     {
         default: "false",
         storage: "Storage()",
@@ -2427,7 +2428,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonBoostedOnly] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonSkipLowMojo] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonSkipLowMojo] =
     {
         default: "true",
         storage: "Storage()",
@@ -2438,7 +2439,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonSkipLowMojo] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrill] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrill] =
     {
         default: "false",
         storage: "Storage()",
@@ -2452,7 +2453,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrill] =
             clearTimer('nextPentaDrillTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -2471,7 +2472,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -2482,14 +2483,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2500,7 +2501,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillRunThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillRunThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2511,7 +2512,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillRunThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillDelay] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillDelay] =
     {
         default: "6",
         storage: "Storage()",
@@ -2523,7 +2524,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillDelay] =
         isValid: /^(1[0-9]|20|[3-9])$/,
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillBoostedOnly] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillBoostedOnly] =
     {
         default: "false",
         storage: "Storage()",
@@ -2534,7 +2535,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPentaDrillBoostedOnly] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoStats] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoStats] =
     {
         default: "500000000",
         storage: "Storage()",
@@ -2545,7 +2546,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoStats] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoStatsSwitch] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoStatsSwitch] =
     {
         default: "false",
         storage: "Storage()",
@@ -2556,7 +2557,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoStatsSwitch] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollBattle] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollBattle] =
     {
         default: "false",
         storage: "Storage()",
@@ -2567,7 +2568,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollBattle] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollMythicByPassParanoia] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollMythicByPassParanoia] =
     {
         default: "false",
         storage: "Storage()",
@@ -2578,7 +2579,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollMythicByPassParanoia] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollSelectedIndex] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollSelectedIndex] =
     {
         default: "0",
         storage: "Storage()",
@@ -2591,7 +2592,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollSelectedIndex] =
         customMenuID: "autoTrollSelector",
         isValid: /^([0-9]|[1-9][0-9])$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2602,7 +2603,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollRunThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollRunThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2613,7 +2614,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollRunThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStartEventGirl] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStartEventGirl] =
     {
         default: "false",
         storage: "Storage()",
@@ -2624,29 +2625,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoChampsForceStartEventGirl] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.buyCombat] =
-    {
-        default: "false",
-        storage: "Storage()",
-        HHType: "Setting",
-        valueType: "Boolean",
-        getMenu: true,
-        setMenu: true,
-        menuType: "checked",
-        kobanUsing: true
-    };
-HHStoredVars[HHStoredVarPrefixKey + SK.buyCombTimer] =
-    {
-        default: "16",
-        storage: "Storage()",
-        HHType: "Setting",
-        valueType: "Small Integer",
-        getMenu: true,
-        setMenu: true,
-        menuType: "value",
-        kobanUsing: false
-    };
-HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombat] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.buyCombat] =
     {
         default: "false",
         storage: "Storage()",
@@ -2657,7 +2636,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombat] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombTimer] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.buyCombTimer] =
     {
         default: "16",
         storage: "Storage()",
@@ -2668,7 +2647,29 @@ HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombTimer] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoFreeBundlesCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombat] =
+    {
+        default: "false",
+        storage: "Storage()",
+        HHType: "Setting",
+        valueType: "Boolean",
+        getMenu: true,
+        setMenu: true,
+        menuType: "checked",
+        kobanUsing: true
+    };
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.buyMythicCombTimer] =
+    {
+        default: "16",
+        storage: "Storage()",
+        HHType: "Setting",
+        valueType: "Small Integer",
+        getMenu: true,
+        setMenu: true,
+        menuType: "value",
+        kobanUsing: false
+    };
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoFreeBundlesCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -2686,14 +2687,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoFreeBundlesCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoFreeBundlesCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoFreeBundlesCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.waitforContest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.waitforContest] =
     {
         default: "true",
         storage: "Storage()",
@@ -2708,7 +2709,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.waitforContest] =
             clearTimer('nextContestTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.safeSecondsForContest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.safeSecondsForContest] =
     {
         default: "120",
         storage: "Storage()",
@@ -2718,7 +2719,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.safeSecondsForContest] =
         setMenu: true,
         menuType: "value"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.mousePause] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.mousePause] =
     {
         default: "false",
         storage: "Storage()",
@@ -2729,7 +2730,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.mousePause] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.mousePauseTimeout] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.mousePauseTimeout] =
     {
         default: "5000",
         storage: "Storage()",
@@ -2739,7 +2740,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.mousePauseTimeout] =
         setMenu: true,
         menuType: "value"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.collectAllTimer] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.collectAllTimer] =
     {
         default: "12",
         storage: "Storage()",
@@ -2750,7 +2751,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.collectAllTimer] =
         menuType: "value",
         isValid: /^([1-9][0-9]|[1-9])$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.eventTrollOrder] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.eventTrollOrder] =
     {
         default: "1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20",
         storage: "Storage()",
@@ -2761,7 +2762,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.eventTrollOrder] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyTrollNumber] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyTrollNumber] =
     {
         default: "20",
         storage: "Storage()",
@@ -2772,7 +2773,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyTrollNumber] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyMythicTrollNumber] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyMythicTrollNumber] =
     {
         default: "20",
         storage: "Storage()",
@@ -2783,7 +2784,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyMythicTrollNumber] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.master] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.master] =
     {
         default: "false",
         storage: "Storage()",
@@ -2794,7 +2795,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.master] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.maxAff] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.maxAff] =
     {
         default: "50000",
         storage: "Storage()",
@@ -2805,7 +2806,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.maxAff] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.maxBooster] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.maxBooster] =
     {
         default: "10",
         storage: "Storage()",
@@ -2816,7 +2817,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.maxBooster] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.maxExp] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.maxExp] =
     {
         default: "10000",
         storage: "Storage()",
@@ -2827,7 +2828,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.maxExp] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX10] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX10] =
     {
         default: "10",
         storage: "Storage()",
@@ -2839,7 +2840,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX10] =
         kobanUsing: false,
         isValid: /^(\d)+$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX50] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX50] =
     {
         default: "50",
         storage: "Storage()",
@@ -2850,7 +2851,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.minShardsX50] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.sandalwoodMinShardsThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.sandalwoodMinShardsThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -2861,7 +2862,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.sandalwoodMinShardsThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.sandalwoodMaxUsages] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.sandalwoodMaxUsages] =
     {
         default: "11",
         storage: "sessionStorage",
@@ -2877,12 +2878,12 @@ HHStoredVars[HHStoredVarPrefixKey + TK.sandalwoodMaxUsages] =
 // refusal time. Survives page navigations (the userscript restarts on every
 // page) so a permanently conflicting booster is not re-tried every cycle --
 // it is re-tried as soon as the equipped mythic loadout changes.
-HHStoredVars[HHStoredVarPrefixKey + TK.mythicEquipConflicts] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.mythicEquipConflicts] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.updateMarket] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.updateMarket] =
     {
         default: "true",
         storage: "Storage()",
@@ -2893,7 +2894,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.updateMarket] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.paranoia] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.paranoia] =
     {
         default: "true",
         storage: "Storage()",
@@ -2907,13 +2908,13 @@ HHStoredVars[HHStoredVarPrefixKey + SK.paranoia] =
             clearTimer('paranoiaSwitch');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.paranoiaSettings] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.paranoiaSettings] =
     {
         default: "140-320/Sleep:28800-30400|Active:250-460|Casual:1500-2700/6:Sleep|8:Casual|10:Active|12:Casual|14:Active|18:Casual|20:Active|22:Casual|24:Sleep",
         storage: "Storage()",
         HHType: "Setting"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.paranoiaSpendsBefore] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.paranoiaSpendsBefore] =
     {
         default: "true",
         storage: "Storage()",
@@ -2924,7 +2925,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.paranoiaSpendsBefore] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusGirlSkins] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusGirlSkins] =
     {
         default: "false",
         storage: "Storage()",
@@ -2935,7 +2936,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusGirlSkins] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollLoveRaidByPassThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollLoveRaidByPassThreshold] =
     {
         default: "false",
         storage: "Storage()",
@@ -2946,7 +2947,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoTrollLoveRaidByPassThreshold] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaidMythic] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaidMythic] =
     {
         default: "off",
         storage: "Storage()",
@@ -2959,7 +2960,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaidMythic] =
         kobanUsing: false,
         isValid: /^(off|exact3|min3|exact5)$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaid] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaid] =
     {
         default: "false",
         storage: "Storage()",
@@ -2975,7 +2976,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusLoveRaid] =
             deleteStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex);
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex] =
     {
         default: "0",
         storage: "Storage()",
@@ -2988,7 +2989,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex] =
         customMenuID: "loveRaidSelector",
         isValid: /^(0|first|\d+_\d+)$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.buyLoveRaidCombat] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.buyLoveRaidCombat] =
     {
         default: "false",
         storage: "Storage()",
@@ -2999,7 +3000,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.buyLoveRaidCombat] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyLoveRaidTrollNumber] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyLoveRaidTrollNumber] =
     {
         default: "20",
         storage: "Storage()",
@@ -3010,7 +3011,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoBuyLoveRaidTrollNumber] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood] =
     {
         default: "false",
         storage: "Storage()",
@@ -3021,7 +3022,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusEvent] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusEvent] =
     {
         default: "false",
         storage: "Storage()",
@@ -3032,7 +3033,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusEvent] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythic] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythic] =
     {
         default: "false",
         storage: "Storage()",
@@ -3043,7 +3044,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythic] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusEventSandalWood] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusEventSandalWood] =
     {
         default: "false",
         storage: "Storage()",
@@ -3054,7 +3055,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusEventSandalWood] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythicSandalWood] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythicSandalWood] =
     {
         default: "false",
         storage: "Storage()",
@@ -3065,7 +3066,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.plusEventMythicSandalWood] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3083,14 +3084,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3101,7 +3102,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autodpEventCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3119,14 +3120,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3137,7 +3138,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLivelySceneEventCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.bossBangEvent] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.bossBangEvent] =
     {
         default: "false",
         storage: "Storage()",
@@ -3148,7 +3149,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.bossBangEvent] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.bossBangMinTeam] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.bossBangMinTeam] =
     {
         default: "5",
         storage: "Storage()",
@@ -3159,7 +3160,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.bossBangMinTeam] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.sultryMysteriesEventRefreshShop] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.sultryMysteriesEventRefreshShop] =
     {
         default: "false",
         storage: "Storage()",
@@ -3170,7 +3171,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.sultryMysteriesEventRefreshShop] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.collectEventChest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.collectEventChest] =
     {
         default: "false",
         storage: "Storage()",
@@ -3181,7 +3182,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.collectEventChest] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.AllMaskRewards] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.AllMaskRewards] =
     {
         default: "false",
         storage: "Storage()",
@@ -3192,7 +3193,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.AllMaskRewards] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalBuyFreeCard] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalBuyFreeCard] =
     {
         default: "false",
         storage: "Storage()",
@@ -3206,7 +3207,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalBuyFreeCard] =
             clearTimer('nextSeasonalCardCollectTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showCalculatePower] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showCalculatePower] =
     {
         default: "true",
         storage: "Storage()",
@@ -3217,7 +3218,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showCalculatePower] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showAdsBack] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showAdsBack] =
     {
         default: "true",
         storage: "Storage()",
@@ -3228,7 +3229,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showAdsBack] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoAdsClick] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoAdsClick] =
     {
         default: "false",
         storage: "Storage()",
@@ -3246,7 +3247,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoAdsClick] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showRewardsRecap] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showRewardsRecap] =
     {
         default: "true",
         storage: "Storage()",
@@ -3257,7 +3258,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showRewardsRecap] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.hideOwnedGirls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.hideOwnedGirls] =
     {
         default: "true",
         storage: "Storage()",
@@ -3268,7 +3269,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.hideOwnedGirls] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showInfo] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showInfo] =
     {
         default: "true",
         storage: "Storage()",
@@ -3279,7 +3280,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showInfo] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showInfoLeft] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showInfoLeft] =
     {
         default: "false",
         storage: "Storage()",
@@ -3290,7 +3291,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showInfoLeft] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showHaremAvatarMissingGirls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showHaremAvatarMissingGirls] =
     {
         default: "false",
         storage: "Storage()",
@@ -3301,7 +3302,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showHaremAvatarMissingGirls] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showHaremTools] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showHaremTools] =
     {
         default: "true",
         storage: "Storage()",
@@ -3312,7 +3313,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showHaremTools] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showHaremSkillsButtons] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showHaremSkillsButtons] =
     {
         default: "true",
         storage: "Storage()",
@@ -3323,7 +3324,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showHaremSkillsButtons] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showMarketTools] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showMarketTools] =
     {
         default: "false",
         storage: "Storage()",
@@ -3334,7 +3335,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showMarketTools] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.showTooltips] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.showTooltips] =
     {
         default: "true",
         storage: "Storage()",
@@ -3345,7 +3346,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.showTooltips] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.spendKobans0] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.spendKobans0] =
     {
         default: "false",
         storage: "Storage()",
@@ -3356,7 +3357,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.spendKobans0] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.kobanBank] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.kobanBank] =
     {
         default: "1000000",
         storage: "Storage()",
@@ -3367,7 +3368,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.kobanBank] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.useX10Fights] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.useX10Fights] =
     {
         default: "false",
         storage: "Storage()",
@@ -3378,7 +3379,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.useX10Fights] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.useX10FightsAllowNormalEvent] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.useX10FightsAllowNormalEvent] =
     {
         default: "false",
         storage: "Storage()",
@@ -3389,7 +3390,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.useX10FightsAllowNormalEvent] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.useX50Fights] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.useX50Fights] =
     {
         default: "false",
         storage: "Storage()",
@@ -3400,7 +3401,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.useX50Fights] =
         menuType: "checked",
         kobanUsing: true
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.useX50FightsAllowNormalEvent] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.useX50FightsAllowNormalEvent] =
     {
         default: "false",
         storage: "Storage()",
@@ -3411,12 +3412,12 @@ HHStoredVars[HHStoredVarPrefixKey + SK.useX50FightsAllowNormalEvent] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.saveDefaults] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.saveDefaults] =
     {
         storage: "localStorage",
         HHType: "Setting"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheon] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheon] =
     {
         default: "false",
         storage: "Storage()",
@@ -3430,7 +3431,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheon] =
             clearTimer('nextPantheonTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -3441,7 +3442,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonRunThreshold] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonRunThreshold] =
     {
         default: "0",
         storage: "Storage()",
@@ -3452,7 +3453,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonRunThreshold] =
         menuType: "value",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonBoostedOnly] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonBoostedOnly] =
     {
         default: "false",
         storage: "Storage()",
@@ -3463,7 +3464,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPantheonBoostedOnly] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyrinth] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyrinth] =
     {
         default: "false",
         storage: "Storage()",
@@ -3477,7 +3478,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyrinth] =
             clearTimer('nextLabyrinthTime');
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLabySweep] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLabySweep] =
     {
         default: "false",
         storage: "Storage()",
@@ -3488,7 +3489,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLabySweep] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyCustomTeamBuilder] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyCustomTeamBuilder] =
     {
         default: "false",
         storage: "Storage()",
@@ -3499,7 +3500,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyCustomTeamBuilder] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyHard] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyHard] =
     {
         default: "false",
         storage: "Storage()",
@@ -3510,7 +3511,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyHard] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyDifficultyIndex] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyDifficultyIndex] =
     {
         default: "0",
         storage: "Storage()",
@@ -3523,7 +3524,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoLabyDifficultyIndex] =
         customMenuID: "autoLabyDifficulty",
         isValid: /^[0-9]$/
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3541,7 +3542,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3552,14 +3553,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoSeasonalEventCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3577,7 +3578,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3588,14 +3589,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoVCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3613,7 +3614,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3624,14 +3625,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoGCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3649,7 +3650,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollectAll] =
     {
         default: "false",
         storage: "Storage()",
@@ -3660,14 +3661,14 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollectAll] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoPoACollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
         HHType: "Setting",
         valueType: "Array"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoals] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoals] =
     {
         default: "false",
         storage: "Storage()",
@@ -3678,7 +3679,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoals] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.compactDailyGoals] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.compactDailyGoals] =
     {
         default: "false",
         storage: "Storage()",
@@ -3689,7 +3690,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.compactDailyGoals] =
         menuType: "checked",
         kobanUsing: false
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollect] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollect] =
     {
         default: "false",
         storage: "Storage()",
@@ -3707,7 +3708,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollect] =
             }
         }
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollectablesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollectablesList] =
     {
         default: JSON.stringify([]),
         storage: "Storage()",
@@ -3715,484 +3716,484 @@ HHStoredVars[HHStoredVarPrefixKey + SK.autoDailyGoalsCollectablesList] =
         valueType: "Array"
     };
 // Temp vars
-HHStoredVars[HHStoredVarPrefixKey + TK.scriptversion] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.scriptversion] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.autoLoop] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.autoLoop] =
     {
         default: "true",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.battlePowerRequired] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.battlePowerRequired] =
     {
         default: "0",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.dailyGoalsList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.dailyGoalsList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.lastActionPerformed] =
-    {
-        default: "none",
-        storage: "sessionStorage",
-        HHType: "Temp"
-    };
-HHStoredVars[HHStoredVarPrefixKey + TK.questRequirement] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.lastActionPerformed] =
     {
         default: "none",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.autoLoopTimeMili] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.questRequirement] =
+    {
+        default: "none",
+        storage: "sessionStorage",
+        HHType: "Temp"
+    };
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.autoLoopTimeMili] =
     {
         default: "1000",
         storage: "Storage()",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.freshStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.freshStart] =
     {
         default: "no",
         storage: "Storage()",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.Logging] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.Logging] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.Debug] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.Debug] =
     {
         default: "false",
         storage: "sessionStorage",
         valueType: "Boolean",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.autoTrollBattleSaveQuest] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.autoTrollBattleSaveQuest] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.burst] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.burst] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.charLevel] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.charLevel] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.filteredGirlsList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.filteredGirlsList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlActions] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlActions] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlMode] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlMode] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremMoneyOnStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremMoneyOnStart] =
     {
         default: "0",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlPayLast] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlPayLast] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlEnd] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlEnd] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlLimit] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremGirlLimit] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremTeam] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremTeam] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremTeamScrolls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremTeamScrolls] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haremTeamSettings] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haremTeamSettings] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.blessingsCache] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.blessingsCache] =
     {
         default: "",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.loveRaids] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.loveRaids] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.eventsGirlz] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.eventsGirlz] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.eventGirl] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.eventGirl] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.eventMythicGirl] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.eventMythicGirl] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.autoChampsEventGirls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.autoChampsEventGirls] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.raidGirls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.raidGirls] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.champBuildTeam] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.champBuildTeam] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.clubChampLimitReached] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.clubChampLimitReached] =
     {
         default: "false",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.trollWithGirls] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.trollWithGirls] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.fought] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.fought] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haveAff] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haveAff] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haveExp] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haveExp] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.haveBooster] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.haveBooster] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.hideBeatenOppo] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.hideBeatenOppo] =
     {
         default: "0",
         storage: "Storage()",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.LeagueOpponentList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.LeagueOpponentList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaQuestBlocked] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaQuestBlocked] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaSpendings] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.paranoiaSpendings] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.pinfo] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.pinfo] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PopTargeted] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PopTargeted] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PopToStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PopToStart] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PopUnableToStart] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PopUnableToStart] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.storeContents] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.storeContents] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.Timers] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.Timers] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.NextSwitch] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.NextSwitch] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.Totalpops] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.Totalpops] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.currentlyAvailablePops] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.currentlyAvailablePops] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.CheckSpentPoints] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.CheckSpentPoints] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.eventsList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.eventsList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.bossBangTeam] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.bossBangTeam] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatus] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatus] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatusLastUpdate] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterStatusLastUpdate] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.boosterIdMap] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.boosterIdMap] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.sandalwoodFailure] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.sandalwoodFailure] =
     {
         default: "0",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.LeagueSavedData] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.LeagueSavedData] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.LeagueHumanLikeRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.LeagueHumanLikeRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.TrollHumanLikeRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.TrollHumanLikeRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.TrollInvalid] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.TrollInvalid] =
     {
         default: "false",
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.MainAdventureWorldID] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.MainAdventureWorldID] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.SideAdventureWorldID] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.SideAdventureWorldID] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PantheonHumanLikeRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PantheonHumanLikeRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.SeasonHumanLikeRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.SeasonHumanLikeRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PentaDrillHumanLikeRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PentaDrillHumanLikeRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.HaremSize] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.HaremSize] =
     {
         storage: "localStorage",
         HHType: "Temp",
         isValid: /{"count":(\d)+,"count_date":(\d)+}/
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.LastPageCalled] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.LastPageCalled] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PoAEndDate] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PoAEndDate] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PoVEndDate] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PoVEndDate] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.PoGEndDate] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.PoGEndDate] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.poaManualCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.poaManualCollectAll] =
     {
         default: "false",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.lseManualCollectAll] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.lseManualCollectAll] =
     {
         default: "false",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.unknownPagesList] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.unknownPagesList] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.trollPoints] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.trollPoints] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
 // Survey
-HHStoredVars[HHStoredVarPrefixKey + TK.surveyShown] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.surveyShown] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.surveyDismissCount] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.surveyDismissCount] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.surveyLastHash] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.surveyLastHash] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
 // Feature Popup (What's New)
-HHStoredVars[HHStoredVarPrefixKey + TK.featurePopupShown] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.featurePopupShown] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.featurePopupDismissCount] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.featurePopupDismissCount] =
     {
         default: "0",
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.mouseLastActivity] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.mouseLastActivity] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.pipelineLastRunAt] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.pipelineLastRunAt] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.trollWaitForEnergy] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.trollWaitForEnergy] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
 // Pipeline-block architecture (v7.37.0, ADR-001)
-HHStoredVars[HHStoredVarPrefixKey + TK.activeBlockRun] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.activeBlockRun] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.blockCooldownUntil] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.blockCooldownUntil] =
     {
         storage: "sessionStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.blockAutoDisabled] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.blockAutoDisabled] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.blockFailureCount] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.blockFailureCount] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.pipelineOrder] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.pipelineOrder] =
     {
         storage: "localStorage",
         HHType: "Setting" // user choice: survive "delete temp vars" (was "Temp")
     };
-HHStoredVars[HHStoredVarPrefixKey + TK.pipelineLogContext] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + TK.pipelineLogContext] =
     {
         storage: "localStorage",
         HHType: "Temp"
     };
-HHStoredVars[HHStoredVarPrefixKey + SK.pipelineDiagnose] =
+HHStoredVars_HHStoredVars[HHStoredVarPrefixKey + SK.pipelineDiagnose] =
     {
         default: "false",
         storage: "localStorage",
@@ -4203,7 +4204,7 @@ HHStoredVars[HHStoredVarPrefixKey + SK.pipelineDiagnose] =
         menuType: "checked"
     };
 
-;// ./src/Utils/BrowserUtils.ts
+;// CONCATENATED MODULE: ./src/Utils/BrowserUtils.ts
 /**
  * Browser detection utilities.
  *
@@ -4267,7 +4268,7 @@ function getBrowserData(nav) {
 }
 ;
 
-;// ./src/Utils/LogUtils.ts
+;// CONCATENATED MODULE: ./src/Utils/LogUtils.ts
 /**
  * Logging and debug-export utilities for HHAuto.
  *
@@ -4324,7 +4325,7 @@ function cleanLogsInStorage() {
  * When the stored log exceeds MAX_LINES, the oldest entries are removed.
  * Duplicate keys within the same millisecond get a numeric suffix.
  */
-function logHHAuto(...args) {
+function LogUtils_logHHAuto(...args) {
     var _a;
     const stackTrace = (new Error()).stack || '';
     let match;
@@ -4418,7 +4419,7 @@ function saveHHDebugLog() {
     a.click();
 }
 
-;// ./src/Helper/NumberHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/NumberHelper.ts
 // NumberHelper.ts
 //
 // Utility functions for formatting and parsing numbers across the UI.
@@ -4477,7 +4478,7 @@ class NumberHelper {
     }
 }
 
-;// ./src/Helper/menu/MenuPorts.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuPorts.ts
 // MenuPorts.ts
 //
 // Dependency-injection "ports" for the extracted menu leaf modules
@@ -4517,7 +4518,7 @@ function setMenuPorts(ports) {
     Object.assign(MenuPorts, ports);
 }
 
-;// ./src/Helper/menu/MenuSettings.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuSettings.ts
 // MenuSettings.ts
 //
 // Settings binding: moves values between the DOM menu inputs and persistent
@@ -4649,9 +4650,7 @@ function addEventsOnMenuItems() {
     }
 }
 
-;// ./src/Helper/StorageHelper.ts
-/* unused harmony import specifier */ var StorageHelper_logHHAuto;
-/* unused harmony import specifier */ var StorageHelper_HHStoredVars;
+;// CONCATENATED MODULE: ./src/Helper/StorageHelper.ts
 // StorageHelper.ts
 //
 // Abstraction layer over browser localStorage and sessionStorage for
@@ -4739,10 +4738,10 @@ function getStorage() {
     return getStoredValue(HHStoredVarPrefixKey + SK.settPerTab) === "true" ? sessionStorage : localStorage;
 }
 function getStoredValue(inVarName) {
-    if (!HHStoredVars.hasOwnProperty(inVarName))
+    if (!HHStoredVars_HHStoredVars.hasOwnProperty(inVarName))
         return undefined;
-    const storedValue = getStorageItem(HHStoredVars[inVarName].storage)[inVarName];
-    if (!HHStoredVars[inVarName].kobanUsing)
+    const storedValue = getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName];
+    if (!HHStoredVars_HHStoredVars[inVarName].kobanUsing)
         return storedValue;
     // Check main switch for spending Koban via a direct storage read,
     // NOT recursion via getStoredValue, to avoid an infinite call stack
@@ -4750,20 +4749,20 @@ function getStoredValue(inVarName) {
     // with kobanUsing: true. The master switch is itself a Storage()
     // entry so we route through getStorageItem with its registered type.
     const masterKey = HHStoredVarPrefixKey + SK.spendKobans0;
-    const masterEntry = HHStoredVars[masterKey];
+    const masterEntry = HHStoredVars_HHStoredVars[masterKey];
     const masterValue = masterEntry ? getStorageItem(masterEntry.storage)[masterKey] : undefined;
     return masterValue === "true" ? storedValue : "false";
 }
 function deleteStoredValue(inVarName) {
-    if (HHStoredVars.hasOwnProperty(inVarName)) {
-        getStorageItem(HHStoredVars[inVarName].storage).removeItem(inVarName);
+    if (HHStoredVars_HHStoredVars.hasOwnProperty(inVarName)) {
+        getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage).removeItem(inVarName);
     }
 }
 function setStoredValue(inVarName, inValue, retry = false) {
-    if (!HHStoredVars.hasOwnProperty(inVarName))
+    if (!HHStoredVars_HHStoredVars.hasOwnProperty(inVarName))
         return;
     try {
-        getStorageItem(HHStoredVars[inVarName].storage)[inVarName] = inValue;
+        getStorageItem(HHStoredVars_HHStoredVars[inVarName].storage)[inVarName] = inValue;
     }
     catch (e) {
         // Robust catch: destructuring `{ errName, message }` from a
@@ -4773,18 +4772,18 @@ function setStoredValue(inVarName, inValue, retry = false) {
         // per tick. Coerce to a string message instead.
         const message = (e instanceof Error) ? e.message : String(e);
         cleanLogsInStorage();
-        logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry ? 'user storage need to be cleaned' : 'retry...'}`);
+        LogUtils_logHHAuto(`ERROR: Can't save value in storage for ${inVarName} (${message}), ${retry ? 'user storage need to be cleaned' : 'retry...'}`);
         if (!retry)
             setStoredValue(inVarName, inValue, true);
     }
 }
 function extractHHVars(dataToSave, extractLog = false, extractTemp = true, extractSettings = true) {
     const currentStorageName = getStoredValue(HHStoredVarPrefixKey + SK.settPerTab) === "true" ? "sessionStorage" : "localStorage";
-    for (const i of Object.keys(HHStoredVars)) {
-        const varType = HHStoredVars[i].HHType;
+    for (const i of Object.keys(HHStoredVars_HHStoredVars)) {
+        const varType = HHStoredVars_HHStoredVars[i].HHType;
         if (!((varType === "Setting" && extractSettings) || (varType === "Temp" && extractTemp)))
             continue;
-        const storageType = HHStoredVars[i].storage;
+        const storageType = HHStoredVars_HHStoredVars[i].storage;
         const storageName = storageType === 'Storage()' ? currentStorageName : storageType;
         if (i !== HHStoredVarPrefixKey + TK.Logging) {
             dataToSave[storageName + "." + i] = getStoredValue(i);
@@ -4837,9 +4836,9 @@ function migrateHHVars() {
     // Remove together with the multi-account feature, not before.
     if (HHStoredVarPrefixKey === 'HHAuto_' || !haveHHAutoSettings())
         return;
-    for (const newKey of Object.keys(HHStoredVars)) {
+    for (const newKey of Object.keys(HHStoredVars_HHStoredVars)) {
         const oldKeys = newKey.replace(HHStoredVarPrefixKey, 'HHAuto_');
-        const storageItem = getStorageItem(HHStoredVars[newKey].storage);
+        const storageItem = getStorageItem(HHStoredVars_HHStoredVars[newKey].storage);
         const itemValue = storageItem[oldKeys];
         storageItem.removeItem(oldKeys);
         // Preserve the value if it is set at all -- including the empty
@@ -4871,21 +4870,21 @@ function saveHHStoredVarsDefaults() {
     const savedHHStoredVars = {};
     for (const i of Object.keys(dataToSave)) {
         const variableName = i.split(".")[1];
-        if (variableName !== HHStoredVarPrefixKey + SK.saveDefaults && HHStoredVars[variableName].default !== dataToSave[i]) {
+        if (variableName !== HHStoredVarPrefixKey + SK.saveDefaults && HHStoredVars_HHStoredVars[variableName].default !== dataToSave[i]) {
             savedHHStoredVars[variableName] = dataToSave[i];
         }
     }
     setStoredValue(HHStoredVarPrefixKey + SK.saveDefaults, JSON.stringify(savedHHStoredVars));
-    logHHAuto("HHStoredVar defaults saved !");
+    LogUtils_logHHAuto("HHStoredVar defaults saved !");
 }
 function setHHStoredVarToDefault(inVarName) {
-    const entry = HHStoredVars[inVarName];
+    const entry = HHStoredVars_HHStoredVars[inVarName];
     if (entry === undefined) {
-        logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
         return;
     }
     if (entry.default === undefined || entry.storage === undefined) {
-        logHHAuto("HHStoredVar " + inVarName + " either have no storage or default defined.");
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " either have no storage or default defined.");
         return;
     }
     const storageItem = getStorageItem(entry.storage);
@@ -4898,25 +4897,25 @@ function setHHStoredVarToDefault(inVarName) {
     // could re-introduce the issue.
     if (userDefinedDefault !== null
         && (entry.isValid === undefined || entry.isValid.test(userDefinedDefault))) {
-        logHHAuto("HHStoredVar " + inVarName + " set to user default value : " + userDefinedDefault);
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to user default value : " + userDefinedDefault);
         storageItem[inVarName] = userDefinedDefault;
     }
     else {
-        logHHAuto("HHStoredVar " + inVarName + " set to default value : " + entry.default);
+        LogUtils_logHHAuto("HHStoredVar " + inVarName + " set to default value : " + entry.default);
         storageItem[inVarName] = entry.default;
     }
 }
 function getHHStoredVarDefault(inVarName) {
-    if (StorageHelper_HHStoredVars[inVarName] !== undefined) {
-        if (StorageHelper_HHStoredVars[inVarName].default !== undefined) {
-            return StorageHelper_HHStoredVars[inVarName].default;
+    if (HHStoredVars[inVarName] !== undefined) {
+        if (HHStoredVars[inVarName].default !== undefined) {
+            return HHStoredVars[inVarName].default;
         }
         else {
-            StorageHelper_logHHAuto("HHStoredVar " + inVarName + " have no default defined.");
+            logHHAuto("HHStoredVar " + inVarName + " have no default defined.");
         }
     }
     else {
-        StorageHelper_logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
+        logHHAuto("HHStoredVar " + inVarName + " doesn't exist.");
     }
 }
 function debugDeleteAllVars() {
@@ -4928,12 +4927,12 @@ function debugDeleteAllVars() {
     // does not own). TK.Logging stays so a fresh log buffer is
     // available when the user presses the debug-delete button.
     const loggingKey = HHStoredVarPrefixKey + TK.Logging;
-    for (const key of Object.keys(HHStoredVars)) {
+    for (const key of Object.keys(HHStoredVars_HHStoredVars)) {
         if (key === loggingKey)
             continue;
         deleteStoredValue(key);
     }
-    logHHAuto('Deleted all script vars.');
+    LogUtils_logHHAuto('Deleted all script vars.');
 }
 function debugDeleteTempVars() {
     // Snapshot Settings BEFORE wiping. extractHHVars serialises each
@@ -4950,7 +4949,7 @@ function debugDeleteTempVars() {
     setDefaults(true);
     for (const compoundKey of Object.keys(dataToSave)) {
         const variableName = compoundKey.split(".")[1];
-        logHHAuto(compoundKey + ':' + dataToSave[compoundKey]);
+        LogUtils_logHHAuto(compoundKey + ':' + dataToSave[compoundKey]);
         setStoredValue(variableName, dataToSave[compoundKey]);
     }
 }
@@ -5024,7 +5023,7 @@ function getLocalStorageSize() {
     return allStrings ? 3 + ((allStrings.length * 16) / (8 * 1024)) + ' KB' : 'Empty (0 KB)';
 }
 
-;// ./src/Helper/UrlHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/UrlHelper.ts
 // UrlHelper.ts
 //
 // Simple URL query-string utilities. Wraps URLSearchParams for
@@ -5046,7 +5045,7 @@ function url_add_param(url, param, value) {
     return url + param + "=" + value;
 }
 
-;// ./src/Helper/PageHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/PageHelper.ts
 // PageHelper.ts
 //
 // Determines which game page the player is currently viewing. The game
@@ -5083,10 +5082,10 @@ function url_add_param(url, param, value) {
  * Used by StartService when it bootstraps and finds no game root.
  */
 function haltScript(reason) {
-    logHHAuto(`haltScript: ${reason}`);
+    LogUtils_logHHAuto(`haltScript: ${reason}`);
     setStoredValue(HHStoredVarPrefixKey + SK.master, "false");
     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-    logHHAuto("setting autoloop to false");
+    LogUtils_logHHAuto("setting autoloop to false");
 }
 function resolvePopState() {
     var _a;
@@ -5233,7 +5232,7 @@ function getPage(checkUnknown = false) {
         // what to do. Bootstraps that need a hard halt call haltScript()
         // themselves; transient missing-root states (tab redraw, slow first
         // paint) are tolerated by callers that compare against pagesIDFoo.
-        logHHAuto("PageHelper.getPage: game root element missing, returning empty page id");
+        LogUtils_logHHAuto("PageHelper.getPage: game root element missing, returning empty page id");
         return "";
     }
     const activitiesMainPage = ConfigHelper.getHHScriptVars("pagesIDActivities");
@@ -5257,7 +5256,7 @@ function getPage(checkUnknown = false) {
             // when this page was already recorded with the same pathname (avoids
             // a write per AutoLoop tick on long-running unknown pages).
             if (unknownPageList[page] !== window.location.pathname) {
-                logHHAuto(`Page unknown for script : ${page} / ${window.location.pathname}`);
+                LogUtils_logHHAuto(`Page unknown for script : ${page} / ${window.location.pathname}`);
                 unknownPageList[page] = window.location.pathname;
                 setStoredValue(HHStoredVarPrefixKey + TK.unknownPagesList, JSON.stringify(unknownPageList));
             }
@@ -5266,7 +5265,7 @@ function getPage(checkUnknown = false) {
     return page;
 }
 
-;// ./src/Service/AjaxTracker.ts
+;// CONCATENATED MODULE: ./src/Service/AjaxTracker.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -5449,7 +5448,7 @@ function installAjaxTracker() {
         catch (e) { /* ignore */ }
     };
     installed = true;
-    logHHAuto('[AjaxTracker] installed');
+    LogUtils_logHHAuto('[AjaxTracker] installed');
     return true;
 }
 /**
@@ -5490,7 +5489,7 @@ function waitForAjaxIdle() {
         }
         const reachedIdle = pending === 0;
         if (!reachedIdle) {
-            logHHAuto(`[AjaxTracker] waitForAjaxIdle timeout, ${pending} request(s) still pending`);
+            LogUtils_logHHAuto(`[AjaxTracker] waitForAjaxIdle timeout, ${pending} request(s) still pending`);
         }
         if (settleMs > 0) {
             yield sleep(settleMs);
@@ -5512,7 +5511,7 @@ function acquirePostMutex(holderName = "anonymous") {
     if (postMutexHeld) {
         const heldFor = Date.now() - postMutexAcquiredAt;
         if (heldFor > POST_MUTEX_STALE_MS) {
-            logHHAuto('[AjaxTracker] POST mutex stale-released after ' + heldFor +
+            LogUtils_logHHAuto('[AjaxTracker] POST mutex stale-released after ' + heldFor +
                 'ms (was held by ' + (postMutexHolder || 'unknown') + ')');
             postMutexHeld = false;
         }
@@ -5543,7 +5542,7 @@ function isPostInFlight() {
         // pinned by a forgotten holder.
         const heldFor = Date.now() - postMutexAcquiredAt;
         if (heldFor > POST_MUTEX_STALE_MS) {
-            logHHAuto('[AjaxTracker] POST mutex stale-released after ' + heldFor +
+            LogUtils_logHHAuto('[AjaxTracker] POST mutex stale-released after ' + heldFor +
                 'ms (was held by ' + (postMutexHolder || 'unknown') + ')');
             releasePostMutex();
         }
@@ -5569,7 +5568,7 @@ function awaitServerSettleAfterPost(claimXhrDurationMs) {
             ? claimXhrDurationMs
             : 0;
         const settle = Math.max(POST_SETTLE_MIN_MS, Math.round(durationMs * POST_SETTLE_FACTOR));
-        logHHAuto('[AjaxTracker] server-settle pause ' + settle + 'ms (claim ' + Math.round(durationMs) + 'ms)');
+        LogUtils_logHHAuto('[AjaxTracker] server-settle pause ' + settle + 'ms (claim ' + Math.round(durationMs) + 'ms)');
         yield sleep(settle);
     });
 }
@@ -5601,7 +5600,7 @@ function _resetAjaxTrackerForTests() {
     installed = false;
 }
 
-;// ./src/Service/PageNavigationService.ts
+;// CONCATENATED MODULE: ./src/Service/PageNavigationService.ts
 // PageNavigationService.ts
 //
 // Centralized page navigation. Translates abstract page IDs into
@@ -5720,9 +5719,9 @@ function resolveByRegexPassthrough(page) {
 function scheduleAfterIdle(delay, logContext, action) {
     navInFlight = true;
     setTimeout(() => {
-        waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250)).then((idle) => {
+        waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS).then((idle) => {
             if (!idle) {
-                logHHAuto(`${logContext}: AJAX still busy after ${(/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000)}ms, deferring`);
+                LogUtils_logHHAuto(`${logContext}: AJAX still busy after ${AJAX_IDLE_TIMEOUT_MS}ms, deferring`);
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                 navInFlight = false;
                 return;
@@ -5735,7 +5734,7 @@ function logBlockedNavigation(prefix, detail) {
     const now = Date.now();
     if (now - lastNavBlockedLogAt > NAV_BLOCKED_LOG_INTERVAL_MS) {
         lastNavBlockedLogAt = now;
-        logHHAuto(`${prefix}: navigation already in flight, ignoring ${detail}`);
+        LogUtils_logHHAuto(`${prefix}: navigation already in flight, ignoring ${detail}`);
     }
 }
 function resolveDelay(delay) {
@@ -5753,7 +5752,7 @@ function gotoPage(page, inArgs = {}, delay = -1) {
         return false;
     }
     const cp = getPage();
-    logHHAuto(`going ${cp}->${page}`);
+    LogUtils_logHHAuto(`going ${cp}->${page}`);
     delay = resolveDelay(delay);
     const resolverMap = buildResolverMap();
     let togoto;
@@ -5764,7 +5763,7 @@ function gotoPage(page, inArgs = {}, delay = -1) {
     else {
         togoto = resolveByRegexPassthrough(page);
         if (togoto === undefined) {
-            logHHAuto(`Unknown goto page request. No page '${page}' defined.`);
+            LogUtils_logHHAuto(`Unknown goto page request. No page '${page}' defined.`);
             return false;
         }
     }
@@ -5772,7 +5771,7 @@ function gotoPage(page, inArgs = {}, delay = -1) {
         // resolveByRegexPassthrough already logged and returned false.
         // This branch is defensive for resolver functions that yield
         // undefined despite the page-id being in the resolver map.
-        logHHAuto(`Couldn't resolve URL for page '${page}', skipping.`);
+        LogUtils_logHHAuto(`Couldn't resolve URL for page '${page}', skipping.`);
         return false;
     }
     setLastPageCalled(togoto);
@@ -5783,8 +5782,8 @@ function gotoPage(page, inArgs = {}, delay = -1) {
     }
     togoto = addNutakuSession(togoto);
     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-    logHHAuto("setting autoloop to false");
-    logHHAuto(`GotoPage : ${togoto} in ${delay}ms.`);
+    LogUtils_logHHAuto("setting autoloop to false");
+    LogUtils_logHHAuto(`GotoPage : ${togoto} in ${delay}ms.`);
     const targetUrl = togoto;
     scheduleAfterIdle(delay, 'gotoPage', () => {
         // Wait for any in-flight game AJAX (e.g. PoP claim POSTs) to
@@ -5812,7 +5811,7 @@ function safeReload(delay = -1) {
     }
     delay = resolveDelay(delay);
     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-    logHHAuto(`safeReload: scheduled in ${delay}ms`);
+    LogUtils_logHHAuto(`safeReload: scheduled in ${delay}ms`);
     scheduleAfterIdle(delay, 'safeReload', () => {
         location.reload();
     });
@@ -5831,7 +5830,7 @@ function safeNavigateHref(url, delay = -1) {
     }
     delay = resolveDelay(delay);
     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-    logHHAuto(`safeNavigateHref: ${url} in ${delay}ms`);
+    LogUtils_logHHAuto(`safeNavigateHref: ${url} in ${delay}ms`);
     scheduleAfterIdle(delay, 'safeNavigateHref', () => {
         location.href = url;
     });
@@ -5844,7 +5843,7 @@ function addNutakuSession(togoto) {
     }
     const hhSession = queryStringGetParam(window.location.search, 'sess');
     if (!hhSession) {
-        logHHAuto('ERROR Nutaku detected and no session found');
+        LogUtils_logHHAuto('ERROR Nutaku detected and no session found');
         return togoto;
     }
     if (typeof togoto === 'string') {
@@ -5869,7 +5868,7 @@ function _resetPageNavigationServiceForTests() {
     lastNavBlockedLogAt = 0;
 }
 
-;// ./src/Utils/Utils.ts
+;// CONCATENATED MODULE: ./src/Utils/Utils.ts
 // General-purpose utility functions for HHAuto.
 // Provides callItOnce (ensures a function executes only once), safeJsonParse,
 // AJAX response interception helpers, and other shared convenience methods.
@@ -6009,14 +6008,14 @@ function myfileLoad_onReaderLoad(event) {
     var variableName;
     //Json validation
     if (isJSON(text)) {
-        logHHAuto('the json is ok');
+        LogUtils_logHHAuto('the json is ok');
         var jsonNewSettings = JSON.parse(event.target.result);
         //Assign new values to Storage();
         for (const [key, value] of Object.entries(jsonNewSettings)) {
             storageType = key.split(".")[0];
             variableName = key.split(".")[1];
             storageItem = getStorageItem(storageType);
-            logHHAuto(key + ':' + value);
+            LogUtils_logHHAuto(key + ':' + value);
             storageItem[variableName] = value;
         }
         // C1: safeReload waits for any in-flight game AJAX before the
@@ -6026,11 +6025,11 @@ function myfileLoad_onReaderLoad(event) {
     }
     else {
         $('#LoadConfError')[0].innerText = 'Selected file broken!';
-        logHHAuto('the json is Not ok');
+        LogUtils_logHHAuto('the json is Not ok');
     }
 }
 
-;// ./src/Utils/HHPopup.ts
+;// CONCATENATED MODULE: ./src/Utils/HHPopup.ts
 /**
  * Custom popup/modal system for the HHAuto userscript.
  *
@@ -6168,7 +6167,7 @@ function checkAndClosePopup(inBurst) {
     }
 }
 
-;// ./src/Helper/HHHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/HHHelper.ts
 
 
 function prefixIfNeeded(infoSearched) {
@@ -6187,7 +6186,7 @@ function getHHVars(infoSearched, logging = true) {
     for (let i = 0; i < splittedInfoSearched.length; i++) {
         if (returnValue[splittedInfoSearched[i]] === undefined) {
             if (logging) {
-                logHHAuto("HH var not found : " + infoSearched + " (" + splittedInfoSearched[i] + " not defined).");
+                LogUtils_logHHAuto("HH var not found : " + infoSearched + " (" + splittedInfoSearched[i] + " not defined).");
             }
             return null;
         }
@@ -6206,7 +6205,7 @@ function setHHVars(infoSearched, newValue) {
     let splittedInfoSearched = infoSearched.split(".");
     for (let i = 0; i < splittedInfoSearched.length; i++) {
         if (returnValue[splittedInfoSearched[i]] === undefined) {
-            logHHAuto("HH var not found : " + infoSearched + " (" + splittedInfoSearched[i] + " not defined).");
+            LogUtils_logHHAuto("HH var not found : " + infoSearched + " (" + splittedInfoSearched[i] + " not defined).");
             return -1;
         }
         else if (i === splittedInfoSearched.length - 1) {
@@ -6219,7 +6218,7 @@ function setHHVars(infoSearched, newValue) {
     }
 }
 
-;// ./src/Helper/HeroHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/HeroHelper.ts
 var HeroHelper_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -6307,7 +6306,7 @@ function doStatUpgrades() {
                     && (nowTs - lastStatAttempt.ts) < 3000
                     && lastStatAttempt.carac === carac
                     && lastStatAttempt.value === stats[carac - 1]) {
-                    logHHAuto('doStatUpgrades: stat carac' + carac + '=' + stats[carac - 1]
+                    LogUtils_logHHAuto('doStatUpgrades: stat carac' + carac + '=' + stats[carac - 1]
                         + ' did not advance after the last buy (page=' + location.pathname
                         + '); stopping to avoid an infinite loop.');
                     lastStatAttempt = null;
@@ -6315,7 +6314,7 @@ function doStatUpgrades() {
                 }
                 lastStatAttempt = { carac: carac, value: stats[carac - 1], ts: nowTs };
                 count++;
-                logHHAuto('money: ' + money + ' stat' + carac + ': ' + stats[carac - 1] + ' [+' + mult + '] price: ' + price);
+                LogUtils_logHHAuto('money: ' + money + ' stat' + carac + ': ' + stats[carac - 1] + ' [+' + mult + '] price: ' + price);
                 money -= price;
                 var params = {
                     carac: "carac" + carac,
@@ -6323,7 +6322,7 @@ function doStatUpgrades() {
                     nb: mult
                 };
                 getHHAjax()(params, function (data) {
-                    logHHAuto('doStatUpgrades resp: success=' + !!(data && data.success)
+                    LogUtils_logHHAuto('doStatUpgrades resp: success=' + !!(data && data.success)
                         + ' page=' + location.pathname
                         + ' carac' + carac + '=' + getHHVars('Hero.infos.carac' + carac)
                         + ' money=' + HeroHelper.getMoney()
@@ -6363,7 +6362,7 @@ class HeroHelper {
             if (!booster)
                 return Promise.resolve(false);
             if (!HeroHelper.haveBoosterInInventory(booster.identifier)) {
-                logHHAuto("Booster " + booster + " not in inventory");
+                LogUtils_logHHAuto("Booster " + booster + " not in inventory");
                 return Promise.resolve(false);
             }
             let itemId = ConfigHelper.getHHScriptVars("boosterId_" + booster.identifier, false);
@@ -6372,7 +6371,7 @@ class HeroHelper {
             }
             //action=market_equip_booster&id_item=316&type=booster
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("equipBooster: Equip " + booster.name + " (id_item=" + itemId + "), setting autoloop to false");
+            LogUtils_logHHAuto("equipBooster: Equip " + booster.name + " (id_item=" + itemId + "), setting autoloop to false");
             const params = {
                 action: "market_equip_booster",
                 id_item: itemId,
@@ -6401,7 +6400,7 @@ class HeroHelper {
                 timeoutId = setTimeout(() => {
                     if (settled)
                         return;
-                    logHHAuto('equipBooster: AJAX timeout after 15s — resolving with false and invalidating boosterStatus');
+                    LogUtils_logHHAuto('equipBooster: AJAX timeout after 15s — resolving with false and invalidating boosterStatus');
                     // Treat a hang as "state unknown": drop the freshness stamp so the next
                     // auto-equip cycle re-reads boosterStatus from the market.
                     deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
@@ -6409,12 +6408,12 @@ class HeroHelper {
                     settle(false);
                 }, 15000);
                 getHHAjax()(params, function (data) {
-                    logHHAuto(`equipBooster: AJAX success callback, data.success=${data.success}, full response=${JSON.stringify(data)}`);
+                    LogUtils_logHHAuto(`equipBooster: AJAX success callback, data.success=${data.success}, full response=${JSON.stringify(data)}`);
                     if (data.success) {
-                        logHHAuto('equipBooster: Booster equipped successfully');
+                        LogUtils_logHHAuto('equipBooster: Booster equipped successfully');
                     }
                     else {
-                        logHHAuto('equipBooster: Server returned success:false (may already be equipped)');
+                        LogUtils_logHHAuto('equipBooster: Server returned success:false (may already be equipped)');
                         // Option D: a success:false response means our local boosterStatus is
                         // out of sync with the server (another browser/tab probably equipped
                         // boosters while we were paused). Invalidate the freshness timestamp
@@ -6422,14 +6421,14 @@ class HeroHelper {
                         deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                         HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
                     }
-                    logHHAuto(`equipBooster: resolving with ${data.success}`);
+                    LogUtils_logHHAuto(`equipBooster: resolving with ${data.success}`);
                     settle(!!data.success);
                 }, function (err) {
-                    logHHAuto('equipBooster: AJAX error callback - ' + err);
+                    LogUtils_logHHAuto('equipBooster: AJAX error callback - ' + err);
                     // Network/server error also implies our cached state may be wrong — invalidate.
                     deleteStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate);
                     HeroHelper.getSandalWoodEquipFailure(true); // Increase failure
-                    logHHAuto('equipBooster: resolving with false');
+                    LogUtils_logHHAuto('equipBooster: resolving with false');
                     settle(false);
                 });
                 // change referer
@@ -6450,7 +6449,7 @@ class HeroHelper {
     }
 }
 
-;// ./src/Module/harem/HaremFilter.ts
+;// CONCATENATED MODULE: ./src/Module/harem/HaremFilter.ts
 var HaremFilter_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -6513,7 +6512,7 @@ class HaremFilter {
                 yield this.selectOption('girl-max-grade-dropdown', starsMapping[stars]);
             }
             else {
-                logHHAuto(`Error unkown GirlAffectionCategory ${stars}, selecting all`);
+                LogUtils_logHHAuto(`Error unkown GirlAffectionCategory ${stars}, selecting all`);
                 yield this.selectOption('girl-max-grade-dropdown', 0);
             }
         });
@@ -6546,21 +6545,21 @@ class HaremFilter {
     }
     selectGirlFilters(girlType) {
         return HaremFilter_awaiter(this, void 0, void 0, function* () {
-            logHHAuto(`selectGirlRarity ${girlType.charAt(0)}.`);
+            LogUtils_logHHAuto(`selectGirlRarity ${girlType.charAt(0)}.`);
             yield this.selectGirlRarity(Number(girlType.charAt(0)));
             if (girlType.length === 3) {
-                logHHAuto(`selectGirlCategory ${girlType.charAt(2)}.`);
+                LogUtils_logHHAuto(`selectGirlCategory ${girlType.charAt(2)}.`);
                 yield this.selectGirlAffectionCategory(Number(girlType.charAt(2)));
             }
             else if (this.getGirlAffectionCategory() != '0') {
-                logHHAuto('reset selectGirlCategory');
+                LogUtils_logHHAuto('reset selectGirlCategory');
                 yield this.selectGirlAffectionCategory(0);
             }
         });
     }
 }
 
-;// ./src/Helper/PriceHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/PriceHelper.ts
 // PriceHelper.ts
 //
 // Parses human-readable price strings from the game UI back into raw
@@ -6641,7 +6640,7 @@ export function manageUnits(inText)
 }
 */ 
 
-;// ./src/config/InputPattern.ts
+;// CONCATENATED MODULE: ./src/config/InputPattern.ts
 // Regex patterns used for input validation in the HHAuto settings menu.
 // Each pattern constrains what the user can enter in a specific settings field
 // (e.g., timers, thresholds, booster filters).
@@ -6690,7 +6689,7 @@ const HHAuto_inputPattern = {
     sandalwoodLimit: "(100|[1-9][0-9]|[0-9])"
 };
 
-;// ./src/Module/harem/HaremGirl.pure.ts
+;// CONCATENATED MODULE: ./src/Module/harem/HaremGirl.pure.ts
 /**
  * Sum of all stat fields plus the count of class/element/figure resonance
  * matches against the wearer.
@@ -6763,7 +6762,7 @@ function isBetter(candidate, current, girl) {
     return false;
 }
 
-;// ./src/Module/harem/HaremGirl.ts
+;// CONCATENATED MODULE: ./src/Module/harem/HaremGirl.ts
 var HaremGirl_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -6818,13 +6817,13 @@ class HaremGirl {
             confirmMaxOutButton.trigger('click');
         }
         else
-            logHHAuto('Confirm max out button not found');
+            LogUtils_logHHAuto('Confirm max out button not found');
     }
     static maxOutButtonAndConfirm(haremItem, girl) {
         return new Promise((resolve) => {
             const maxOutButton = HaremGirl.getMaxOutButton(haremItem);
             if (maxOutButton.length > 0) {
-                logHHAuto('Max out ' + haremItem + ' for girl ' + girl.id_girl);
+                LogUtils_logHHAuto('Max out ' + haremItem + ' for girl ' + girl.id_girl);
                 maxOutButton.trigger('click');
                 setTimeout(() => {
                     HaremGirl.confirmMaxOut();
@@ -6834,7 +6833,7 @@ class HaremGirl {
                 }, randomInterval(700, 1100));
             }
             else {
-                logHHAuto('Max out button for' + haremItem + ' for girl ' + girl.id_girl + ' not enabled');
+                LogUtils_logHHAuto('Max out button for' + haremItem + ' for girl ' + girl.id_girl + ' not enabled');
                 resolve(false);
             }
         });
@@ -6845,7 +6844,7 @@ class HaremGirl {
             confirmMaxOutButton.trigger('click');
         }
         else
-            logHHAuto('Confirm max out all button not found');
+            LogUtils_logHHAuto('Confirm max out all button not found');
     }
     static getMaxOutPrice() {
         return Number($('#girl_max_out_all_levels_popup .slot_soft_currency .amount').text().replace(/\D+/g, ""));
@@ -6856,7 +6855,7 @@ class HaremGirl {
             confirmMaxOutButton.trigger('click');
         }
         else
-            logHHAuto('Confirm max out all button not found');
+            LogUtils_logHHAuto('Confirm max out all button not found');
     }
     static getMaxOutGems() {
         return Number($('#girl_max_out_all_levels_popup .slot_gems .amount').text().replace(/\D+/g, ""));
@@ -6870,7 +6869,7 @@ class HaremGirl {
                 if (haremItem === HaremGirl.EXPERIENCE_TYPE) {
                     setTimeout(() => HaremGirl_awaiter(this, void 0, void 0, function* () {
                         const cost = HaremGirl.getMaxOutGems();
-                        logHHAuto(`Max out all ${haremItem} (for ${cost} gems) for girl ${girl.name} (${girl.id_girl})`);
+                        LogUtils_logHHAuto(`Max out all ${haremItem} (for ${cost} gems) for girl ${girl.name} (${girl.id_girl})`);
                         HaremGirl.confirmMaxOutAllGems();
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.confirmMaxOut(); // No gems
@@ -6881,19 +6880,19 @@ class HaremGirl {
                 else if (haremItem === HaremGirl.AFFECTION_TYPE) {
                     setTimeout(() => HaremGirl_awaiter(this, void 0, void 0, function* () {
                         const cost = HaremGirl.getMaxOutPrice();
-                        logHHAuto(`Max out all ${haremItem} (for ${cost}) for girl ${girl.name} (${girl.id_girl})`);
+                        LogUtils_logHHAuto(`Max out all ${haremItem} (for ${cost}) for girl ${girl.name} (${girl.id_girl})`);
                         HaremGirl.confirmMaxOutAllCash();
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         resolve(cost);
                     }), randomInterval(700, 1100));
                 }
                 else {
-                    logHHAuto(`Max out all confirm path not implemented for haremItem '${haremItem}', resolving without confirm`);
+                    LogUtils_logHHAuto(`Max out all confirm path not implemented for haremItem '${haremItem}', resolving without confirm`);
                     resolve(0);
                 }
             }
             else {
-                logHHAuto(`Max out all button for ${haremItem} for girl ${girl.name} (${girl.id_girl}) not enabled`);
+                LogUtils_logHHAuto(`Max out all button for ${haremItem} for girl ${girl.name} (${girl.id_girl}) not enabled`);
                 resolve(0);
             }
         });
@@ -6905,7 +6904,7 @@ class HaremGirl {
             return true;
         }
         else {
-            logHHAuto('Confirmation awake button is not enabled');
+            LogUtils_logHHAuto('Confirmation awake button is not enabled');
             Harem.clearHaremToolVariables();
             // TODO Do not clear in list mode
             return false;
@@ -6917,13 +6916,13 @@ class HaremGirl {
         const canXpGirl = numberOfGem >= girl.awakening_costs;
         const awakButton = $('#awaken:not([disabled])');
         if (awakButton.length > 0 && canXpGirl) {
-            logHHAuto('Awake for girl ' + girl.id_girl);
+            LogUtils_logHHAuto('Awake for girl ' + girl.id_girl);
             awakButton.trigger('click');
             setTimeout(HaremGirl.confirmAwake, randomInterval(500, 1000)); // Page will be refreshed if done
             return true;
         }
         else {
-            logHHAuto('Awake button for girl ' + girl.id_girl + ' not enabled or not enough gems (' + numberOfGem + '<' + girl.awakening_costs + ')');
+            LogUtils_logHHAuto('Awake button for girl ' + girl.id_girl + ' not enabled or not enough gems (' + numberOfGem + '<' + girl.awakening_costs + ')');
             return false;
         }
     }
@@ -6932,14 +6931,14 @@ class HaremGirl {
         const canGiftGirl = girl.nb_grades > girl.graded;
         const upgradeQuest = $('.upgrade_girl').attr('href');
         if (canGiftGirl && upgradeQuest && upgradeQuest.indexOf('/quest/') >= 0) {
-            logHHAuto('Upgrade for girl ' + girl.id_girl + ' quest:' + upgradeQuest);
+            LogUtils_logHHAuto('Upgrade for girl ' + girl.id_girl + ' quest:' + upgradeQuest);
             gotoPage(upgradeQuest);
             return true;
         }
         else {
-            logHHAuto('Can\'t upgrade girl ' + girl.id_girl + ': grade (' + girl.graded + '/' + girl.nb_grades + '), quest :' + upgradeQuest);
+            LogUtils_logHHAuto('Can\'t upgrade girl ' + girl.id_girl + ': grade (' + girl.graded + '/' + girl.nb_grades + '), quest :' + upgradeQuest);
             if (!upgradeQuest && retry < 2) {
-                logHHAuto('Can be loading time, retry in 1s');
+                LogUtils_logHHAuto('Can be loading time, retry in 1s');
                 setTimeout(() => {
                     HaremGirl.goToGirlQuest(girl, retry + 1);
                 }, randomInterval(1000, 1500));
@@ -6953,7 +6952,7 @@ class HaremGirl {
         if (proceedButtonMatch.length > 0) {
             var proceedButtonCost = $(".price", proceedButtonMatch);
             if (proceedButtonCost.length === 0 || !proceedButtonCost[0].innerText) {
-                logHHAuto("ERROR No price node on grade-complete button, stopping.");
+                LogUtils_logHHAuto("ERROR No price node on grade-complete button, stopping.");
                 Harem.clearHaremToolVariables();
                 return false;
             }
@@ -6963,14 +6962,14 @@ class HaremGirl {
             console.log("Debug girl Quest MONEY for : " + proceedCost);
             if (proceedCost <= moneyCurrent) {
                 // We have money.
-                logHHAuto("Spending " + proceedCost + " Money to proceed.");
+                LogUtils_logHHAuto("Spending " + proceedCost + " Money to proceed.");
                 setTimeout(function () {
                     proceedButtonMatch.trigger('click');
                 }, randomInterval(500, 800));
                 return true;
             }
             else {
-                logHHAuto("Need " + proceedCost + " Money to proceed.");
+                LogUtils_logHHAuto("Need " + proceedCost + " Money to proceed.");
                 Harem.clearHaremToolVariables();
                 return false;
             }
@@ -6983,7 +6982,7 @@ class HaremGirl {
                 return true;
             }
             else {
-                logHHAuto("ERROR No pay button found stopping.");
+                LogUtils_logHHAuto("ERROR No pay button found stopping.");
                 Harem.clearHaremToolVariables();
                 return false;
             }
@@ -7020,9 +7019,9 @@ class HaremGirl {
             }
             else {
                 if (Number(selectedGirl.level) >= Number(userHaremGirlLimit))
-                    logHHAuto("Girl already above target, ignoring action");
+                    LogUtils_logHHAuto("Girl already above target, ignoring action");
                 else
-                    logHHAuto("Girl and max out will be above target, ignoring action");
+                    LogUtils_logHHAuto("Girl and max out will be above target, ignoring action");
             }
         });
     }
@@ -7051,7 +7050,7 @@ class HaremGirl {
                         return true;
                     }
                     else {
-                        logHHAuto("Girl grade reach, keep last to buy manually");
+                        LogUtils_logHHAuto("Girl grade reach, keep last to buy manually");
                     }
                 }
                 else if ($('.upgrade_girl').length > 0) {
@@ -7063,12 +7062,12 @@ class HaremGirl {
                         return true;
                     }
                     else {
-                        logHHAuto("Girl grade reach, keep last to buy manually");
+                        LogUtils_logHHAuto("Girl grade reach, keep last to buy manually");
                     }
                 }
             }
             else {
-                logHHAuto("Girl grade is already maxed out");
+                LogUtils_logHHAuto("Girl grade is already maxed out");
             }
             return false;
         });
@@ -7084,7 +7083,7 @@ class HaremGirl {
                 return true;
             }
             else {
-                logHHAuto("Girl level is already maxed out");
+                LogUtils_logHHAuto("Girl level is already maxed out");
             }
             return false;
         });
@@ -7214,7 +7213,7 @@ class HaremGirl {
             return girl.nb_grades > girl.graded && HaremGirl.getMaxOutButton(HaremGirl.AFFECTION_TYPE).length > 0;
         }
         catch (_a) {
-            logHHAuto("ERROR can't compute canGiftGirl");
+            LogUtils_logHHAuto("ERROR can't compute canGiftGirl");
             return false;
         }
     }
@@ -7226,7 +7225,7 @@ class HaremGirl {
             return numberOfGem >= girl.awakening_costs;
         }
         catch (_d) {
-            logHHAuto("ERROR can't compute canAwakeGirl");
+            LogUtils_logHHAuto("ERROR can't compute canAwakeGirl");
             return false;
         }
     }
@@ -7237,9 +7236,9 @@ class HaremGirl {
             const girl = HaremGirl.getCurrentGirl();
             const numberOfGem = (_c = (_b = (_a = unsafeWindow.player_gems_amount) === null || _a === void 0 ? void 0 : _a[girl.element]) === null || _b === void 0 ? void 0 : _b.amount) !== null && _c !== void 0 ? _c : 0;
             //logHHAuto("moduleHaremGirl: " + girl.id_girl);
-            logHHAuto("Current level : " + girl.level + ', max level without gems : ' + girl.level_cap);
-            logHHAuto("Number of gem needed in next awakening : " + girl.awakening_costs + " / Gem in stock : " + numberOfGem);
-            logHHAuto("Girl grade : " + girl.graded + '/' + girl.nb_grades);
+            LogUtils_logHHAuto("Current level : " + girl.level + ', max level without gems : ' + girl.level_cap);
+            LogUtils_logHHAuto("Number of gem needed in next awakening : " + girl.awakening_costs + " / Gem in stock : " + numberOfGem);
+            LogUtils_logHHAuto("Girl grade : " + girl.graded + '/' + girl.nb_grades);
             const menuIDXp = "haremGirlGiveXP";
             var giveHaremXp = function () { HaremGirl.displayExpMenu(HaremGirl.EXPERIENCE_TYPE); };
             if (canAwakeGirl)
@@ -7251,7 +7250,7 @@ class HaremGirl {
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const errName = err instanceof Error ? err.name : 'Error';
-            logHHAuto(`ERROR: Can't add menu girl: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`ERROR: Can't add menu girl: ${errName}, ${message}`);
             console.error(message);
         }
     }
@@ -7294,13 +7293,13 @@ class HaremGirl {
                     // No action to be peformed
                     return false;
                 }
-                logHHAuto("run HaremGirl: " + girl.name + ' (' + girl.id_girl + '), level ' + girl.level + ', rarity: ' + girl.rarity);
+                LogUtils_logHHAuto("run HaremGirl: " + girl.name + ' (' + girl.id_girl + '), level ' + girl.level + ', rarity: ' + girl.rarity);
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false as action to be performed on girl");
-                logHHAuto("Action to be performed (mode: " + haremGirlMode + ") : give " + haremItem);
+                LogUtils_logHHAuto("setting autoloop to false as action to be performed on girl");
+                LogUtils_logHHAuto("Action to be performed (mode: " + haremGirlMode + ") : give " + haremItem);
                 if (haremGirlMode === 'girl') {
                     if (haremItem === HaremGirl.EXPERIENCE_TYPE && haremGirlLimit && (Number(girl.level) + 50) <= Number(haremGirlLimit)) {
-                        logHHAuto("haremGirlLimit: " + haremGirlLimit);
+                        LogUtils_logHHAuto("haremGirlLimit: " + haremGirlLimit);
                         HaremGirl.HaremDisplayGirlPopup(haremItem, girl.name + ' ' + girl.Xp.cur + "xp, level " + girl.level + "/" + haremGirlLimit, (1) * 5, haremGirlSpent);
                         if ((Number(girl.level) + 50) >= Number(haremGirlLimit)) {
                             yield HaremGirl.maxOutButtonAndConfirm(haremItem, girl);
@@ -7313,7 +7312,7 @@ class HaremGirl {
                     else if (haremItem === HaremGirl.AFFECTION_TYPE && (canGiftGirl)) {
                         HaremGirl.HaremDisplayGirlPopup(haremItem, girl.name + ' ' + girl.graded + "/" + girl.nb_grades + "star", 2, haremGirlSpent);
                         if (!(yield HaremGirl.fillAllAffection())) {
-                            logHHAuto("No more quest");
+                            LogUtils_logHHAuto("No more quest");
                             // No more quest
                             HaremGirl.HaremClearGirlPopup();
                             Harem.clearHaremToolVariables();
@@ -7321,7 +7320,7 @@ class HaremGirl {
                         }
                     }
                     else {
-                        logHHAuto('ERROR, no action found to be executed. ', { haremItem: haremItem, canGiftGirl: canGiftGirl, canAwakeGirl: canAwakeGirl });
+                        LogUtils_logHHAuto('ERROR, no action found to be executed. ', { haremItem: haremItem, canGiftGirl: canGiftGirl, canAwakeGirl: canAwakeGirl });
                         Harem.clearHaremToolVariables();
                         return false;
                     }
@@ -7334,7 +7333,7 @@ class HaremGirl {
                     let girlListProgress = '';
                     const lastGirlListProgress = '<br />' + getTextForUI("giveLastGirl", "elementText");
                     const filteredGirlsList = getStoredJSON(HHStoredVarPrefixKey + TK.filteredGirlsList, []);
-                    logHHAuto("filteredGirlsList", filteredGirlsList);
+                    LogUtils_logHHAuto("filteredGirlsList", filteredGirlsList);
                     if (filteredGirlsList && filteredGirlsList.length > 0) {
                         girlPosInList = filteredGirlsList.indexOf("" + girl.id_girl);
                         if (girlPosInList >= 0 && filteredGirlsList.length > (girlPosInList + 1)) {
@@ -7344,14 +7343,14 @@ class HaremGirl {
                         }
                     }
                     else {
-                        logHHAuto("ERROR: no girls stored");
+                        LogUtils_logHHAuto("ERROR: no girls stored");
                     }
                     if (haremGirlEnd && haremItem === HaremGirl.AFFECTION_TYPE) {
                         if (Number(girl.graded) === Number(girl.nb_grades) && nextGirlId < 0)
                             girlListProgress += lastGirlListProgress;
                         HaremGirl.HaremDisplayGirlPopup(haremItem, girl.name + ' ' + girl.graded + "/" + girl.nb_grades + "star : Girl " + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
                         if (yield HaremGirl.fillAllAffection()) {
-                            logHHAuto("Going to girl quest");
+                            LogUtils_logHHAuto("Going to girl quest");
                             return true;
                         }
                     }
@@ -7363,7 +7362,7 @@ class HaremGirl {
                         HaremGirl.HaremDisplayGirlPopup(haremItem, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
                         HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
-                        logHHAuto('Upgrade skills, Scroll available: ' + $('.main-skill-block .available-resources .resource-value').text());
+                        LogUtils_logHHAuto('Upgrade skills, Scroll available: ' + $('.main-skill-block .available-resources .resource-value').text());
                         yield HaremGirl.fullSkillsUpgrade();
                         yield TimeHelper.sleep(randomInterval(400, 700));
                     }
@@ -7376,17 +7375,17 @@ class HaremGirl {
                             yield HaremGirl.maxOutButtonAndConfirm(haremItem, girl);
                         }
                         else {
-                            logHHAuto("Max out button not clickable or not found");
+                            LogUtils_logHHAuto("Max out button not clickable or not found");
                             HaremGirl.HaremDisplayGirlPopup(haremItem, girl.name + ' ' + getTextForUI("giveMaxedOut", "elementText") + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
                         }
                     }
                     if (nextGirlId >= 0) {
-                        logHHAuto('Go to next girl (' + nextGirlId + ') remaining ' + remainingGirls + ' girls');
+                        LogUtils_logHHAuto('Go to next girl (' + nextGirlId + ') remaining ' + remainingGirls + ' girls');
                         gotoPage('/girl/' + nextGirlId, { resource: haremItem }, randomInterval(1500, 2500));
                         return true;
                     }
                     else {
-                        logHHAuto("No more girls, go back to harem list");
+                        LogUtils_logHHAuto("No more girls, go back to harem list");
                         gotoPage('/characters/' + girl.id_girl, {}, randomInterval(1500, 2500));
                         Harem.clearHaremToolVariables();
                     }
@@ -7410,7 +7409,7 @@ class HaremGirl {
                         }
                     }
                     if (girlPosInList === 0)
-                        logHHAuto('Main girl from the team');
+                        LogUtils_logHHAuto('Main girl from the team');
                     if (upgradeEquipment) {
                         HaremGirl.switchTabs(HaremGirl.EQUIPMENT_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
@@ -7423,18 +7422,18 @@ class HaremGirl {
                         HaremGirl.switchTabs(HaremGirl.SKILLS_TYPE);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.SKILLS_TYPE, getTextForUI("giveMaxingOut", "elementText") + ' ' + girl.name + ' : ' + girlListProgress, (remainingGirls + 1) * 5, haremGirlSpent);
-                        logHHAuto('Upgrade skills, Scroll available: ' + $('.main-skill-block .available-resources .resource-value').text());
+                        LogUtils_logHHAuto('Upgrade skills, Scroll available: ' + $('.main-skill-block .available-resources .resource-value').text());
                         yield HaremGirl.fullSkillsUpgrade(girlPosInList === 0 ? 5 : 4);
                         yield TimeHelper.sleep(randomInterval(400, 700));
                     }
                     if (nextGirlId >= 0) {
-                        logHHAuto('Go to next girl (' + nextGirlId + ') remaining ' + remainingGirls + ' girls');
+                        LogUtils_logHHAuto('Go to next girl (' + nextGirlId + ') remaining ' + remainingGirls + ' girls');
                         gotoPage('/girl/' + nextGirlId, { resource: (HaremGirl.EXPERIENCE_TYPE) }, randomInterval(1500, 2500));
                         return true;
                     }
                     else {
                         // Todo end team.
-                        logHHAuto("No more girls, go back to harem list");
+                        LogUtils_logHHAuto("No more girls, go back to harem list");
                         gotoPage('/characters/' + girl.id_girl, {}, randomInterval(1500, 2500));
                         Harem.clearHaremToolVariables();
                     }
@@ -7447,7 +7446,7 @@ class HaremGirl {
             catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 const errName = err instanceof Error ? err.name : 'Error';
-                logHHAuto(`ERROR: Can't add menu girl: ${errName}, ${message}`);
+                LogUtils_logHHAuto(`ERROR: Can't add menu girl: ${errName}, ${message}`);
                 console.error(message);
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                 Harem.clearHaremToolVariables();
@@ -7458,7 +7457,7 @@ class HaremGirl {
     }
     static singleSkillsUpgrade(skillId) {
         return HaremGirl_awaiter(this, void 0, void 0, function* () {
-            logHHAuto('Upgrade skill ' + skillId);
+            LogUtils_logHHAuto('Upgrade skill ' + skillId);
             try {
                 const skillButton = $(`#skills .skill-upgrade .skill-upgrade-row[skill-id='${skillId}'] button.blue_button_L:not([disabled])`).first();
                 if (skillButton.length > 0) {
@@ -7468,7 +7467,7 @@ class HaremGirl {
                 }
             }
             catch (_a) {
-                logHHAuto("Can't remove popup_message_harem");
+                LogUtils_logHHAuto("Can't remove popup_message_harem");
             }
             setTimeout(() => { HaremGirl.showSkillButtons(); }, 200);
             return Promise.resolve();
@@ -7499,7 +7498,7 @@ class HaremGirl {
                 }
             }
             catch (_a) {
-                logHHAuto("Can't remove popup_message_harem");
+                LogUtils_logHHAuto("Can't remove popup_message_harem");
             }
             return Promise.resolve();
         });
@@ -7527,7 +7526,7 @@ class HaremGirl {
             }
         }
         catch (_a) {
-            logHHAuto("Can't remove popup_message_harem");
+            LogUtils_logHHAuto("Can't remove popup_message_harem");
         }
     }
     static equipItem(girlId, armorId) {
@@ -7544,12 +7543,12 @@ class HaremGirl {
                 },
                 dataType: 'json',
                 success: function (data) {
-                    logHHAuto(`equipItem response for armor ${armorId}: success=${data === null || data === void 0 ? void 0 : data.success}, keys=${JSON.stringify(Object.keys(data || {}))}`);
+                    LogUtils_logHHAuto(`equipItem response for armor ${armorId}: success=${data === null || data === void 0 ? void 0 : data.success}, keys=${JSON.stringify(Object.keys(data || {}))}`);
                     resolve(data);
                 },
                 error: function (xhr, status, error) {
                     var _a;
-                    logHHAuto(`equipItem HTTP error for armor ${armorId}: status=${status}, error=${error}, response=${(_a = xhr === null || xhr === void 0 ? void 0 : xhr.responseText) === null || _a === void 0 ? void 0 : _a.substring(0, 200)}`);
+                    LogUtils_logHHAuto(`equipItem HTTP error for armor ${armorId}: status=${status}, error=${error}, response=${(_a = xhr === null || xhr === void 0 ? void 0 : xhr.responseText) === null || _a === void 0 ? void 0 : _a.substring(0, 200)}`);
                     resolve(null);
                 }
             });
@@ -7574,7 +7573,7 @@ class HaremGirl {
             // Also try the document/body as fallback
             scrollables.push(document.scrollingElement || document.body);
             let prevCount = countItems();
-            logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
+            LogUtils_logHHAuto(`forceLoadAllInventoryItems: found ${scrollables.length} scrollable elements, initial item count=${prevCount}`);
             // Require 2 consecutive stable iterations before breaking — a single
             // stable iteration can happen during a network hiccup while more items
             // are still loading (see issue #1573).
@@ -7615,7 +7614,7 @@ class HaremGirl {
             var _a, _b, _c, _d, _e, _f;
             const equipmentSlots = $('.equipment_slot');
             const slotCount = equipmentSlots.length;
-            logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
+            LogUtils_logHHAuto(`Optimize equipment: checking ${slotCount} slots for ${girl.name}`);
             for (let i = 0; i < slotCount; i++) {
                 const slot = equipmentSlots.eq(i);
                 slot.trigger('click');
@@ -7647,9 +7646,9 @@ class HaremGirl {
                 });
                 // Filter candidates by slot_index so we don't compare pants to necklaces
                 const inventoryItems = allDomItems.filter(it => Number(it.data.slot_index) === Number(targetSlotIndex));
-                logHHAuto(`Slot ${i}: ${inventoryItems.length} candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
+                LogUtils_logHHAuto(`Slot ${i}: ${inventoryItems.length} candidates, equipped=${equippedData ? `L${equippedData.level} ${equippedData.rarity}` : 'none'}`);
                 if (inventoryItems.length === 0) {
-                    logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
+                    LogUtils_logHHAuto(`Slot ${i}: no inventory items for slot_index=${targetSlotIndex}, skipping`);
                     continue;
                 }
                 // Rank candidates: total stats, then resonance, then individual stats
@@ -7667,7 +7666,7 @@ class HaremGirl {
                 const bestScore = scoreItem(bestInventory.data, girl);
                 const shouldReplace = isBetter(bestInventory.data, equippedData, girl);
                 if (shouldReplace) {
-                    logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
+                    LogUtils_logHHAuto(`Slot ${i}: replacing with better item (L${bestInventory.data.level} ${bestInventory.data.rarity}, score=${bestScore.caracSum}, resonance=${bestScore.resonanceMatches})`);
                     // Capture previous equipped identity so we can verify a real change below (see issue #1573)
                     const previousEquippedKey = equippedData ? ((_c = (_b = equippedData.id_item) !== null && _b !== void 0 ? _b : equippedData.id_equipement) !== null && _c !== void 0 ? _c : JSON.stringify(equippedData)) : null;
                     const MAX_EQUIP_ATTEMPTS = 3;
@@ -7701,19 +7700,19 @@ class HaremGirl {
                                 if ($fresh.length > 0) {
                                     bestInventory.el = $fresh;
                                     raw = $fresh.get(0);
-                                    logHHAuto(`Slot ${i}: item was detached, re-queried fresh node`);
+                                    LogUtils_logHHAuto(`Slot ${i}: item was detached, re-queried fresh node`);
                                     if (typeof raw.scrollIntoView === 'function') {
                                         raw.scrollIntoView({ block: 'center' });
                                         yield TimeHelper.sleep(randomInterval(50, 100));
                                     }
                                 }
                                 else {
-                                    logHHAuto(`Slot ${i}: no connected candidate after re-query, aborting attempts`);
+                                    LogUtils_logHHAuto(`Slot ${i}: no connected candidate after re-query, aborting attempts`);
                                     break;
                                 }
                             }
                             else {
-                                logHHAuto(`Slot ${i}: detached and no id_girl_armor to re-query, aborting attempts`);
+                                LogUtils_logHHAuto(`Slot ${i}: detached and no id_girl_armor to re-query, aborting attempts`);
                                 break;
                             }
                         }
@@ -7740,10 +7739,10 @@ class HaremGirl {
                             else
                                 $equipBtn.trigger('click');
                             yield TimeHelper.sleep(randomInterval(500, 700));
-                            logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                            LogUtils_logHHAuto(`Slot ${i}: equip button clicked (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         }
                         else {
-                            logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                            LogUtils_logHHAuto(`Slot ${i}: #girl-equipment-equip not found (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         }
                         // Verify the equipped item actually changed (see issue #1573)
                         yield TimeHelper.sleep(randomInterval(100, 200));
@@ -7757,25 +7756,25 @@ class HaremGirl {
                         }
                         const verifyKey = verifyData ? ((_f = (_e = verifyData.id_item) !== null && _e !== void 0 ? _e : verifyData.id_equipement) !== null && _f !== void 0 ? _f : JSON.stringify(verifyData)) : null;
                         if (verifyKey !== previousEquippedKey) {
-                            logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
+                            LogUtils_logHHAuto(`Slot ${i}: equip verified (L${verifyData === null || verifyData === void 0 ? void 0 : verifyData.level} ${verifyData === null || verifyData === void 0 ? void 0 : verifyData.rarity})`);
                             equipSucceeded = true;
                             break;
                         }
-                        logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
+                        LogUtils_logHHAuto(`Slot ${i}: equip NOT verified, previous item still equipped (attempt ${attempt}/${MAX_EQUIP_ATTEMPTS})`);
                         if (attempt < MAX_EQUIP_ATTEMPTS) {
                             yield TimeHelper.sleep(randomInterval(200, 300));
                         }
                     }
                     if (!equipSucceeded) {
-                        logHHAuto(`Slot ${i}: equip failed after ${MAX_EQUIP_ATTEMPTS} attempts, skipping`);
+                        LogUtils_logHHAuto(`Slot ${i}: equip failed after ${MAX_EQUIP_ATTEMPTS} attempts, skipping`);
                     }
                 }
                 else {
                     const eqScore = equippedData ? scoreItem(equippedData, girl) : null;
-                    logHHAuto(`Slot ${i}: current item is optimal (L${equippedData === null || equippedData === void 0 ? void 0 : equippedData.level} ${equippedData === null || equippedData === void 0 ? void 0 : equippedData.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
+                    LogUtils_logHHAuto(`Slot ${i}: current item is optimal (L${equippedData === null || equippedData === void 0 ? void 0 : equippedData.level} ${equippedData === null || equippedData === void 0 ? void 0 : equippedData.rarity}, score=${eqScore === null || eqScore === void 0 ? void 0 : eqScore.caracSum})`);
                 }
             }
-            logHHAuto('Equipment optimization complete');
+            LogUtils_logHHAuto('Equipment optimization complete');
         });
     }
 }
@@ -7810,7 +7809,7 @@ HaremGirl.SCROLLS_NEED_4 = {
 HaremGirl.SKILL_BUTTON_SELECTOR = "#skills .skill-upgrade button.blue_button_L:not([disabled])";
 HaremGirl.SKILL_ORDER_PRIO = [2, 5, 4, 8];
 
-;// ./src/Module/harem/Harem.ts
+;// CONCATENATED MODULE: ./src/Module/harem/Harem.ts
 var Harem_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -7862,7 +7861,7 @@ class Harem {
         deleteStoredValue(HHStoredVarPrefixKey + TK.haremTeamScrolls);
         deleteStoredValue(HHStoredVarPrefixKey + TK.haremTeamSettings);
         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-        logHHAuto("clearHaremToolVariables: re-enabling autoLoop.");
+        LogUtils_logHHAuto("clearHaremToolVariables: re-enabling autoLoop.");
         const lastActionPerformed = getStoredValue(HHStoredVarPrefixKey + TK.lastActionPerformed);
         if (lastActionPerformed === Harem.HAREM_UPGRADE_LAST_ACTION) {
             setStoredValue(HHStoredVarPrefixKey + TK.lastActionPerformed, "none");
@@ -7878,7 +7877,7 @@ class Harem {
                     girlsMap.sort(ConfigHelper.getHHScriptVars("haremSortingFunctions")[inSortType]);
                 }
                 else {
-                    logHHAuto("Unknown sorting function, returning Girls Map sorted by date acquired.");
+                    LogUtils_logHHAuto("Unknown sorting function, returning Girls Map sorted by date acquired.");
                     girlsMap.sort(ConfigHelper.getHHScriptVars("haremSortingFunctions").DateAcquired);
                 }
             }
@@ -7976,7 +7975,7 @@ class Harem {
             var gMap = getHHVars('girls_data_list') || getHHVars('availableGirls');
             if (gMap === null) {
                 // error
-                logHHAuto("Girls Map was undefined...! Error, cannot export girls.");
+                LogUtils_logHHAuto("Girls Map was undefined...! Error, cannot export girls.");
             }
             else {
                 try {
@@ -8005,7 +8004,7 @@ class Harem {
                 }
                 catch (exp) {
                     // error
-                    logHHAuto("Catched error : Girls Map had undefined property...! Error, cannot export girls : " + exp);
+                    LogUtils_logHHAuto("Catched error : Girls Map had undefined property...! Error, cannot export girls : " + exp);
                 }
             }
             return dataToSave;
@@ -8060,14 +8059,14 @@ class Harem {
                     if (!!haremItem && haremGirlMode === 'team') {
                         HaremGirl.HaremDisplayGirlPopup(HaremGirl.SKILLS_TYPE, "Get scrolls", 1, 0);
                         if (debugEnabled)
-                            logHHAuto("Waifu page detected, get girls with skills");
+                            LogUtils_logHHAuto("Waifu page detected, get girls with skills");
                         const girlDictionary = getHHVars("girls_data_list");
                         const skilledGirls = Object.values(girlDictionary).filter((girl) => {
                             const skills = Object.values(girl.skill_tiers_info);
                             return Number(skills.reduce((accumulator, skill) => accumulator + (skill.skill_points_used || 0), 0)) > 0;
                         });
                         if (debugEnabled)
-                            logHHAuto('Found skilled girls: ' + skilledGirls.length);
+                            LogUtils_logHHAuto('Found skilled girls: ' + skilledGirls.length);
                         const skilledGirlsScrolls = { 'mythic': {}, 'legendary': {}, 'epic': {}, 'rare': {}, 'common': {} };
                         for (let index = 0; index < skilledGirls.length; index++) {
                             const girl = skilledGirls[index];
@@ -8078,7 +8077,7 @@ class Harem {
                             skilledGirlsScrolls[girlRarity][girl.id_girl + ""] = totalScrolls;
                         }
                         if (debugEnabled)
-                            logHHAuto("Found skilled girls: ", skilledGirlsScrolls);
+                            LogUtils_logHHAuto("Found skilled girls: ", skilledGirlsScrolls);
                         setStoredValue(HHStoredVarPrefixKey + TK.haremTeamScrolls, JSON.stringify(skilledGirlsScrolls));
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHarem"));
                         return true;
@@ -8097,15 +8096,15 @@ class Harem {
                             haremFilter.openFilter();
                             yield TimeHelper.sleep(randomInterval(200, 400)); // wait open
                             if (debugEnabled)
-                                logHHAuto('Reseting girl filters');
+                                LogUtils_logHHAuto('Reseting girl filters');
                             haremFilter.resetFilter();
                             yield TimeHelper.sleep(randomInterval(800, 1200)); // wait loading
                             if (debugEnabled)
-                                logHHAuto('selectOnlyOwnedGirls');
+                                LogUtils_logHHAuto('selectOnlyOwnedGirls');
                             yield haremFilter.selectOnlyOwnedGirls();
                             yield TimeHelper.sleep(randomInterval(200, 400));
                             if (debugEnabled)
-                                logHHAuto('selectSkilledGirls');
+                                LogUtils_logHHAuto('selectSkilledGirls');
                             yield haremFilter.selectSkilledGirls();
                             yield TimeHelper.sleep(randomInterval(800, 1200));
                             girlListDisplayed = Object.values(getHHVars("shared.GirlSalaryManager.girlsMap"));
@@ -8115,7 +8114,7 @@ class Harem {
                         }
                         const getScrolls = (rarity) => Harem_awaiter(this, void 0, void 0, function* () {
                             HaremGirl.HaremDisplayGirlPopup(HaremGirl.SKILLS_TYPE, "resetting " + rarity, 7, 0);
-                            logHHAuto('Get ' + rarity + ' scrolls needed: ' + team['scrolls_' + rarity]);
+                            LogUtils_logHHAuto('Get ' + rarity + ' scrolls needed: ' + team['scrolls_' + rarity]);
                             let scrollGot = 0;
                             //await haremFilter.selectGirlFilters('6');
                             //const mythicGirls: KKHaremSalaryGirl[] = girlListDisplayed.filter((girl: KKHaremSalaryGirl) => girl.gData.rarity == 'mythic');
@@ -8123,17 +8122,17 @@ class Harem {
                             for (const girlId in girls) {
                                 if (team.girlIds.includes(Number(girlId))) {
                                     if (debugEnabled)
-                                        logHHAuto('Found ' + rarity + ' girl in team: (' + girlId + '), keep skilled');
+                                        LogUtils_logHHAuto('Found ' + rarity + ' girl in team: (' + girlId + '), keep skilled');
                                     continue;
                                 }
                                 const girlSkillNb = girls[girlId];
                                 // common 5M per skill
                                 const cost = girlSkillNb * 5000000;
                                 if (teamSettings.moneyToKeep && (heroMoney - cost) < teamSettings.moneyToKeep) {
-                                    logHHAuto(`Not enough money to reset skills for ${rarity} girl (${girlId}) for ${girls[girlId]} scrolls for a cost of ${cost / 1000000}M. Player money: ${heroMoney}`);
+                                    LogUtils_logHHAuto(`Not enough money to reset skills for ${rarity} girl (${girlId}) for ${girls[girlId]} scrolls for a cost of ${cost / 1000000}M. Player money: ${heroMoney}`);
                                     continue;
                                 }
-                                logHHAuto(`Reset skills for ${rarity} girl (${girlId}) for ${girls[girlId]} scrolls for a cost of ${cost / 1000000}M. Player money: ${heroMoney}`);
+                                LogUtils_logHHAuto(`Reset skills for ${rarity} girl (${girlId}) for ${girls[girlId]} scrolls for a cost of ${cost / 1000000}M. Player money: ${heroMoney}`);
                                 const resetSuccess = yield Harem.resetGirlSkills(Number(girlId));
                                 if (resetSuccess) {
                                     scrollGot += girls[girlId];
@@ -8146,7 +8145,7 @@ class Harem {
                                 // await TimeHelper.sleep(randomInterval(200, 400)); // wait open
                                 if (scrollGot >= team['scrolls_' + rarity]) {
                                     if (debugEnabled)
-                                        logHHAuto('Got enough ' + rarity + ' scrolls, stop resetting');
+                                        LogUtils_logHHAuto('Got enough ' + rarity + ' scrolls, stop resetting');
                                     break;
                                 }
                             }
@@ -8157,20 +8156,20 @@ class Harem {
                             const haveAlreadySkilledGirls = skilledGirlsScrolls[rarity] && Object.keys(skilledGirlsScrolls[rarity]).length > 0;
                             const userSelectedResetScrolls = teamSettings['reset' + rarity.charAt(0).toUpperCase() + rarity.slice(1) + 'Girls'] === true;
                             if (debugEnabled)
-                                logHHAuto(`For rarity ${rarity}, needScrolls: ${needScrolls}, haveAlreadySkilledGirls: ${haveAlreadySkilledGirls}, userSelectedResetScrolls: ${userSelectedResetScrolls}`);
+                                LogUtils_logHHAuto(`For rarity ${rarity}, needScrolls: ${needScrolls}, haveAlreadySkilledGirls: ${haveAlreadySkilledGirls}, userSelectedResetScrolls: ${userSelectedResetScrolls}`);
                             if (needScrolls && haveAlreadySkilledGirls && userSelectedResetScrolls) {
                                 if (!(yield getScrolls(rarity))) {
-                                    logHHAuto(`Failed to get enough ${rarity} scrolls, stop process`);
+                                    LogUtils_logHHAuto(`Failed to get enough ${rarity} scrolls, stop process`);
                                     break;
                                 }
                             }
                         }
                         if (debugEnabled)
-                            logHHAuto('Finished getting scrolls, go to first girl');
+                            LogUtils_logHHAuto('Finished getting scrolls, go to first girl');
                         const nextGirlId = team.girlIds[0] || -1;
                         if (nextGirlId >= 0) {
                             if (debugEnabled)
-                                logHHAuto('Go to first team girl (' + nextGirlId + ') remaining ' + (team.girlIds.length - 1) + ' girls');
+                                LogUtils_logHHAuto('Go to first team girl (' + nextGirlId + ') remaining ' + (team.girlIds.length - 1) + ' girls');
                             gotoPage('/girl/' + nextGirlId, { resource: (HaremGirl.EQUIPMENT_TYPE) }, randomInterval(1500, 2500));
                             return true;
                         }
@@ -8183,7 +8182,7 @@ class Harem {
             catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 const errName = err instanceof Error ? err.name : 'Error';
-                logHHAuto(`ERROR: run harem auto: ${errName}, ${message}`);
+                LogUtils_logHHAuto(`ERROR: run harem auto: ${errName}, ${message}`);
                 console.error(message);
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                 Harem.clearHaremToolVariables();
@@ -8213,7 +8212,7 @@ class Harem {
                 window.history.replaceState(null, '', addNutakuSession(currentPage));
                 resolve(data.success || true);
             }, function (err) {
-                logHHAuto('Error occured during girl skills reset', err);
+                LogUtils_logHHAuto('Error occured during girl skills reset', err);
                 resolve(false);
             });
         });
@@ -8242,15 +8241,15 @@ class Harem {
         const filteredGirlsList = Harem.getFilteredGirlList();
         if (filteredGirlsList && filteredGirlsList.length > 0) {
             const girlToGoTo = filteredGirlsList[0];
-            logHHAuto("Go to " + girlToGoTo);
+            LogUtils_logHHAuto("Go to " + girlToGoTo);
             gotoPage('/girl/' + girlToGoTo, { resource: haremItem });
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("setting autoloop to false");
+            LogUtils_logHHAuto("setting autoloop to false");
         }
         setStoredValue(HHStoredVarPrefixKey + TK.haremGirlActions, haremItem);
         setStoredValue(HHStoredVarPrefixKey + TK.haremGirlMode, 'list');
         if (!(Number(getStoredValue(HHStoredVarPrefixKey + TK.haremMoneyOnStart)) > 0)) {
-            logHHAuto('set money to ' + HeroHelper.getMoney());
+            LogUtils_logHHAuto('set money to ' + HeroHelper.getMoney());
             setStoredValue(HHStoredVarPrefixKey + TK.haremMoneyOnStart, HeroHelper.getMoney());
         }
         if (payLast)
@@ -8303,7 +8302,7 @@ class Harem {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            logHHAuto(`ERROR in display DP rewards: ${message}`);
+            LogUtils_logHHAuto(`ERROR in display DP rewards: ${message}`);
         }
     }
     static addGirlListMenu() {
@@ -8386,7 +8385,7 @@ class Harem {
         const girlList = getHHVars('girls_data_list', false) || getHHVars('availableGirls', false);
         if (Harem.HaremSizeNeedsRefresh(ConfigHelper.getHHScriptVars("HaremMinSizeExpirationSecs")) && girlList !== null) {
             setStoredValue(HHStoredVarPrefixKey + TK.HaremSize, JSON.stringify({ count: Object.keys(girlList).length, count_date: new Date().getTime() }));
-            logHHAuto("Harem size updated to : " + Object.keys(girlList).length);
+            LogUtils_logHHAuto("Harem size updated to : " + Object.keys(girlList).length);
         }
     }
     static getGirlUpgradeCost(inRarity, inTargetGrade) {
@@ -8421,7 +8420,7 @@ class Harem {
 }
 Harem.HAREM_UPGRADE_LAST_ACTION = 'haremGirl';
 
-;// ./src/config/game/AmourAgentVars.ts
+;// CONCATENATED MODULE: ./src/config/game/AmourAgentVars.ts
 // Game-variant configuration for Amour Agent.
 // Provides domain-to-environment mapping, troll names, and quest data
 // specific to the Amour Agent game variant.
@@ -8446,7 +8445,7 @@ class AmourAgent {
 AmourAgent.trollIdMapping = {};
 AmourAgent.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/game/ComixHaremVars.ts
+;// CONCATENATED MODULE: ./src/config/game/ComixHaremVars.ts
 // Game-variant configuration for Comix Harem.
 // Provides domain-to-environment mapping, troll names, and quest data
 // specific to the Comix Harem game variant.
@@ -8503,7 +8502,7 @@ ComixHarem.spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4
 ComixHarem.trollIdMapping = {};
 ComixHarem.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/game/GayHaremVars.ts
+;// CONCATENATED MODULE: ./src/config/game/GayHaremVars.ts
 // Game-variant configuration for Gay Harem.
 // Provides domain-to-environment mapping, troll names, and quest data
 // specific to the Gay Harem game variant.
@@ -8570,7 +8569,7 @@ GayHarem.spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4k-
 GayHarem.trollIdMapping = {};
 GayHarem.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/game/GayPornstarHaremVars.ts
+;// CONCATENATED MODULE: ./src/config/game/GayPornstarHaremVars.ts
 // Game-variant configuration for Gay Pornstar Harem.
 // Provides domain-to-environment mapping, troll ID remapping, troll names,
 // and quest data specific to the Gay Pornstar Harem game variant.
@@ -8614,7 +8613,7 @@ GayPornstarHarem.spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZM
 GayPornstarHarem.trollIdMapping = { 6: 2, 7: 3, 8: 4, 9: 5, 10: 6, 11: 7, 12: 8 };
 GayPornstarHarem.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/game/HentaiHeroesVars.ts
+;// CONCATENATED MODULE: ./src/config/game/HentaiHeroesVars.ts
 // Game-variant configuration for Hentai Heroes (the primary/default variant).
 // Provides domain-to-environment mapping, troll ID remapping, troll names,
 // and quest data specific to the Hentai Heroes game variant.
@@ -8733,9 +8732,9 @@ class HentaiHeroes {
 HentaiHeroes.spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4k-IpxTTTELAeaipjR_v1twlqW5vbI'; // zoopokemon
 HentaiHeroes.trollIdMapping = { 21: 19, 24: 22 };
 HentaiHeroes.sideTrollIdMapping = { 22: 20, 23: 21 };
-HentaiHeroes.lastQuestId = 2408; //  TODO update when new quest comes
+HentaiHeroes.lastQuestId = 2412; //  TODO update when new quest comes
 
-;// ./src/config/game/MangaRpgVars.ts
+;// CONCATENATED MODULE: ./src/config/game/MangaRpgVars.ts
 // Game-variant configuration for Manga RPG.
 // Provides domain-to-environment mapping, troll ID remapping, troll names,
 // and quest data specific to the Manga RPG game variant.
@@ -8769,7 +8768,7 @@ class MangaRpg {
 MangaRpg.trollIdMapping = { 3: 3 };
 MangaRpg.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/game/PornstarHaremVars.ts
+;// CONCATENATED MODULE: ./src/config/game/PornstarHaremVars.ts
 // Game-variant configuration for Pornstar Harem.
 // Provides domain-to-environment mapping, troll ID remapping, troll names,
 // and quest data specific to the Pornstar Harem game variant.
@@ -8839,7 +8838,7 @@ class PornstarHarem {
 PornstarHarem.trollIdMapping = { 10: 9, 14: 11, 16: 12, 18: 13, 20: 14, 23: 15, 26: 17, 27: 18, 28: 19 }; // under 10 id as usual
 PornstarHarem.lastQuestId = 16100; //  TODO update when new quest comes
 
-;// ./src/config/game/TransPornstarHaremVars.ts
+;// CONCATENATED MODULE: ./src/config/game/TransPornstarHaremVars.ts
 // Game-variant configuration for Trans Pornstar Harem.
 // Provides domain-to-environment mapping, troll ID remapping, troll names,
 // and quest data specific to the Trans Pornstar Harem game variant.
@@ -8886,7 +8885,7 @@ class TransPornstarHarem {
 TransPornstarHarem.trollIdMapping = { 2: 1, 3: 2, 5: 3, 6: 4, 7: 5, 8: 6, 9: 7, 11: 8, 13: 9, 14: 10, 15: 11 };
 TransPornstarHarem.lastQuestId = -1; //  TODO update when new quest comes
 
-;// ./src/config/HHEnvVariables.ts
+;// CONCATENATED MODULE: ./src/config/HHEnvVariables.ts
 // Per-environment (game variant) configuration for HHAuto.
 // Detects the current game domain and loads the matching set of page IDs, URLs,
 // CSS selectors, feature flags, and troll/quest data for that variant.
@@ -9353,7 +9352,7 @@ for (const key in GayPornstarHarem.getEnv()) {
 ;
 // Object.values(girlsDataList).filter(girl => girl.source?.name == "troll_tier" && girl.source?.group?.id == "7")
 
-;// ./src/Helper/ConfigHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/ConfigHelper.ts
 
 
 
@@ -9382,7 +9381,7 @@ class ConfigHelper {
             }
             else {
                 if (logNotFound) {
-                    logHHAuto("not found var for " + environnement + "/" + id);
+                    LogUtils_logHHAuto("not found var for " + environnement + "/" + id);
                 }
                 return null;
             }
@@ -9390,7 +9389,7 @@ class ConfigHelper {
     }
 }
 
-;// ./src/Module/LabyrinthDifficulty.ts
+;// CONCATENATED MODULE: ./src/Module/LabyrinthDifficulty.ts
 // Labyrinth difficulty option values shared between the menu (difficulty
 // select) and LabyrinthAuto. Kept in a dependency-free leaf module so the
 // menu does not have to import LabyrinthAuto (and its transitive module
@@ -9401,7 +9400,7 @@ const LABY_DIFFICULTY = {
     HARD: "2",
 };
 
-;// ./src/Module/LeagueSortModes.ts
+;// CONCATENATED MODULE: ./src/Module/LeagueSortModes.ts
 // League opponent-list sort mode values shared between the menu (sort-mode
 // select) and LeagueHelper. Kept in a dependency-free leaf module so the
 // menu does not have to import the League module (and its transitive module
@@ -9412,7 +9411,7 @@ const LEAGUE_SORT = {
     POWERCALC: '2',
 };
 
-;// ./src/Module/Events/BossBang.ts
+;// CONCATENATED MODULE: ./src/Module/Events/BossBang.ts
 var BossBang_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -9478,23 +9477,23 @@ class BossBang {
                         if (!teamz.hasClass('.selected-hero-team'))
                             teamz.click();
                         teamFound = true;
-                        logHHAuto("Select team " + (teamIndex + 1) + ", Ego: " + parseInt(teamEgo.text()));
+                        LogUtils_logHHAuto("Select team " + (teamIndex + 1) + ", Ego: " + parseInt(teamEgo.text()));
                         setStoredValue(HHStoredVarPrefixKey + TK.bossBangTeam, teamIndex);
                         return true;
                     }
                 }
                 else {
-                    logHHAuto("Team " + teamIndex + " not eligible");
+                    LogUtils_logHHAuto("Team " + teamIndex + " not eligible");
                 }
             }
             // setTimer('nextBossBangTime', randomInterval(30, 60) * 60); // 30 to 60 minutes
         }
         else if (eventList[eventID]["isCompleted"]) {
-            logHHAuto("Boss bang completed, disabled boss bang event setting");
+            LogUtils_logHHAuto("Boss bang completed, disabled boss bang event setting");
             setStoredValue(HHStoredVarPrefixKey + SK.bossBangEvent, false);
         }
         else {
-            logHHAuto(`No eligible team found for boss bang event, need team ${firstTeamToStartWith} or higher`);
+            LogUtils_logHHAuto(`No eligible team found for boss bang event, need team ${firstTeamToStartWith} or higher`);
         }
         if (!teamFound) {
             setStoredValue(HHStoredVarPrefixKey + TK.bossBangTeam, -1);
@@ -9514,21 +9513,21 @@ class BossBang {
                 //     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 // and (if no other ADR-003 block remains) drop the imports/markers above.
                 if (!acquirePostMutex('bossbang:rewards')) {
-                    logHHAuto('BossBang: another POST in flight, deferring rewards click');
+                    LogUtils_logHHAuto('BossBang: another POST in flight, deferring rewards click');
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     return;
                 }
-                logHHAuto("Click get rewards bang fight");
+                LogUtils_logHHAuto("Click get rewards bang fight");
                 const claimStart = Date.now();
                 rewardsButton.trigger('click');
-                const idle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                const idle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                 const claimDuration = Date.now() - claimStart;
                 releasePostMutex();
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 if (idle)
                     yield awaitServerSettleAfterPost(claimDuration);
                 else
-                    logHHAuto('BossBang: rewards AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                    LogUtils_logHHAuto('BossBang: rewards AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                 // <<< ADR-003 / issue #1598 - bossbang:rewards end
             }
             else if (skipFightButton.length > 0) {
@@ -9542,21 +9541,21 @@ class BossBang {
                 //     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 // and (if no other ADR-003 block remains) drop the imports/markers above.
                 if (!acquirePostMutex('bossbang:skipFight')) {
-                    logHHAuto('BossBang: another POST in flight, deferring skip click');
+                    LogUtils_logHHAuto('BossBang: another POST in flight, deferring skip click');
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     return;
                 }
-                logHHAuto("Click skip boss bang fight");
+                LogUtils_logHHAuto("Click skip boss bang fight");
                 const claimStart = Date.now();
                 skipFightButton.trigger('click');
-                const idle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                const idle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                 const claimDuration = Date.now() - claimStart;
                 releasePostMutex();
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 if (idle)
                     yield awaitServerSettleAfterPost(claimDuration);
                 else
-                    logHHAuto('BossBang: skip AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                    LogUtils_logHHAuto('BossBang: skip AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                 setTimeout(BossBang.skipFightPage, randomInterval(1300, 1900));
                 // <<< ADR-003 / issue #1598 - bossbang:skipFight end
             }
@@ -9568,7 +9567,7 @@ class BossBang {
                 const teamIndexFound = parseInt(getStoredValue(HHStoredVarPrefixKey + TK.bossBangTeam));
                 let bangButton = $('#contains_all #events #boss_bang .boss-bang-event-info #start-bang-button:not([disabled])');
                 if (teamIndexFound >= 0 && bangButton.length > 0) {
-                    logHHAuto("Go to boss bang fight page");
+                    LogUtils_logHHAuto("Go to boss bang fight page");
                     // Use safeNavigateHref so any in-flight game AJAX completes
                     // before the URL change. Direct location.href = ... cancels
                     // open XHRs with NS_BINDING_ABORTED, which can trigger the
@@ -9579,7 +9578,7 @@ class BossBang {
                     return true;
                 }
                 else {
-                    logHHAuto(`Cannot go to boss bang fight page, no team selected ${teamIndexFound} or no bang button found`);
+                    LogUtils_logHHAuto(`Cannot go to boss bang fight page, no team selected ${teamIndexFound} or no bang button found`);
                     setTimer('nextBossBangTime', randomInterval(30, 60) * 60); // 30 to 60 minutes
                 }
             }
@@ -9591,7 +9590,7 @@ class BossBang {
                     if (bossbangEventIDs.length > 0)
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDEvent"), { tab: bossbangEventIDs[0] });
                     else {
-                        logHHAuto("Cannot go to boss bang fight page, no boss bang event found");
+                        LogUtils_logHHAuto("Cannot go to boss bang fight page, no boss bang event found");
                         setTimer('nextBossBangTime', randomInterval(30, 60) * 60); // 30 to 60 minutes
                     }
                 }
@@ -9601,7 +9600,7 @@ class BossBang {
     }
 }
 
-;// ./src/Module/Events/CumbackContests.ts
+;// CONCATENATED MODULE: ./src/Module/Events/CumbackContests.ts
 // CumbackContests.ts -- Cumback Contest event handling and auto-collection.
 //
 // Cumback Contests are periodic events that reward returning players. This
@@ -9639,7 +9638,7 @@ class CumbackContests {
     }
 }
 
-;// ./src/Helper/ButtonHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/ButtonHelper.ts
 /**
  * ButtonHelper.ts - Reusable HTML button generators for the game UI
  *
@@ -9657,7 +9656,7 @@ function getGoToClubChampionButton() {
     return `<button data-href="${ConfigHelper.getHHScriptVars("pagesURLClubChampion")}" class="blue_button_L hh-club-poa">${getTextForUI("goToClubChampions", "elementText")}</button>`;
 }
 
-;// ./src/model/BDSMPlayer.ts
+;// CONCATENATED MODULE: ./src/model/BDSMPlayer.ts
 // Model for a player in the BDSM (battle simulation) system.
 // Holds combat stats (HP, attack, defense, crit, shields, stun, reflect, etc.)
 // used by the battle simulator to predict fight outcomes.
@@ -9676,7 +9675,7 @@ class BDSMPlayer {
     }
 }
 
-;// ./src/Helper/BDSMHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/BDSMHelper.ts
 
 
 class BDSMHelper {
@@ -9765,7 +9764,7 @@ let _cache;
 function calculateBattleProbabilities(player, opponent, debugEnabled = false) {
     if (debugEnabled) {
         // logHHAuto('Running simulation against' + opponent.name, opponent);
-        logHHAuto('Running simulation against' + opponent.name);
+        LogUtils_logHHAuto('Running simulation against' + opponent.name);
     }
     _player = player;
     _opponent = opponent;
@@ -9791,7 +9790,7 @@ function calculateBattleProbabilities(player, opponent, debugEnabled = false) {
         ret = playerTurn(_player.hp, _opponent.hp, _player.playerShield, _opponent.opponentShield, _player.stunned, _opponent.stunned, _player.reflect, _opponent.reflect, 1);
     }
     catch ({ errName, message }) {
-        logHHAuto(`An error occurred during the simulation against ${_opponent.name}`, errName, message);
+        LogUtils_logHHAuto(`An error occurred during the simulation against ${_opponent.name}`, errName, message);
         return {};
     }
     const sum = ret.win + ret.loss;
@@ -9799,7 +9798,7 @@ function calculateBattleProbabilities(player, opponent, debugEnabled = false) {
     ret.loss /= sum;
     ret.scoreClass = ret.win > 0.9 ? 'plus' : ret.win < 0.5 ? 'minus' : 'close';
     if (debugEnabled) {
-        logHHAuto(`Ran ${_runs} simulations against ${_opponent.name}; aggregated win chance: ${ret.win * 100}%`);
+        LogUtils_logHHAuto(`Ran ${_runs} simulations against ${_opponent.name}; aggregated win chance: ${ret.win * 100}%`);
     }
     return ret;
     function calculateDmg(x, turns) {
@@ -10084,7 +10083,7 @@ function getSkillPercentage(team, id) {
     return 1 + (team.girls.map((e) => { var _a, _b; return (_b = (_a = e.skills[id]) === null || _a === void 0 ? void 0 : _a.skill.percentage_value) !== null && _b !== void 0 ? _b : 0; }).reduce((a, b) => a + b, 0) / 100);
 }
 
-;// ./src/model/SeasonOpponent.ts
+;// CONCATENATED MODULE: ./src/model/SeasonOpponent.ts
 // Model for a season (Seasons of Love) opponent.
 // Holds the opponent's ID, nickname, mojo/exp/affection rewards,
 // and the pre-computed battle simulation result.
@@ -10100,14 +10099,14 @@ class SeasonOpponent {
     }
 }
 
-;// ./src/model/LoveRaid.ts
+;// CONCATENATED MODULE: ./src/model/LoveRaid.ts
 // Model representing a Love Raid event instance.
 // Contains the raid target (girl), associated troll/champion/season module,
 // timing (start/end), shard progress, and reward availability flags.
 class LoveRaid {
 }
 
-;// ./src/Module/Events/LoveRaidManager.ts
+;// CONCATENATED MODULE: ./src/Module/Events/LoveRaidManager.ts
 // LoveRaidManager.ts -- Love Raid event: manages raids and tracks girl shards.
 //
 // Love Raids are cooperative events where players raid together for girl shard
@@ -10155,13 +10154,13 @@ class LoveRaidManager {
             }
             catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
-                logHHAuto(`ERROR during Love raid run: ${message}, retry in 1h`);
+                LogUtils_logHHAuto(`ERROR during Love raid run: ${message}, retry in 1h`);
                 setTimer('nextLoveRaidTime', randomInterval(3600, 4000));
                 return false;
             }
         }
         else {
-            logHHAuto("Switching to Love raid screen.");
+            LogUtils_logHHAuto("Switching to Love raid screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDLoveRaid"));
             return true;
         }
@@ -10217,7 +10216,7 @@ class LoveRaidManager {
         const plusGirlSkins = getStoredValue(HHStoredVarPrefixKey + SK.plusGirlSkins) === "true";
         let raid = undefined;
         let autoRaidSelectedIndex = getStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex);
-        logHHAuto(`getRaidToFight: selector="${autoRaidSelectedIndex}", raids=${raids.length}, raidIds=[${raids.map(r => r.trollId + '_' + r.id_girl).join(',')}]`);
+        LogUtils_logHHAuto(`getRaidToFight: selector="${autoRaidSelectedIndex}", raids=${raids.length}, raidIds=[${raids.map(r => r.trollId + '_' + r.id_girl).join(',')}]`);
         if (autoRaidSelectedIndex === undefined || autoRaidSelectedIndex === '') {
             autoRaidSelectedIndex = '0';
         }
@@ -10225,7 +10224,7 @@ class LoveRaidManager {
             const autoRaidSelectedIndexArray = autoRaidSelectedIndex.split('_');
             if (autoRaidSelectedIndexArray.length !== 2) {
                 if (logging)
-                    logHHAuto('Saved raid index is malformed, resetting to default');
+                    LogUtils_logHHAuto('Saved raid index is malformed, resetting to default');
                 autoRaidSelectedIndex = '0';
             }
             else {
@@ -10238,12 +10237,12 @@ class LoveRaidManager {
                     const existsElsewhere = allRaids.find(r => r.trollId === selectedTrollId && String(r.id_girl) === selectedGirlId);
                     if (!existsElsewhere) {
                         if (logging)
-                            logHHAuto('Saved raid is no longer valid, resetting to default');
+                            LogUtils_logHHAuto('Saved raid is no longer valid, resetting to default');
                         autoRaidSelectedIndex = '0';
                     }
                     else {
                         if (logging)
-                            logHHAuto('Selected raid girl not in this filtered list, skipping (not resetting)');
+                            LogUtils_logHHAuto('Selected raid girl not in this filtered list, skipping (not resetting)');
                     }
                 }
             }
@@ -10253,18 +10252,18 @@ class LoveRaidManager {
             const skinsDone = !raid.skin_to_win;
             if (!plusGirlSkins || skinsDone) {
                 if (logging)
-                    logHHAuto(`Raid girl ${raid.id_girl} completed (shards: ${raid.girl_shards}, skins done: ${skinsDone}, +Girl Skins: ${plusGirlSkins}), resetting selector`);
+                    LogUtils_logHHAuto(`Raid girl ${raid.id_girl} completed (shards: ${raid.girl_shards}, skins done: ${skinsDone}, +Girl Skins: ${plusGirlSkins}), resetting selector`);
                 setStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex, "0");
                 autoRaidSelectedIndex = '0';
                 raid = undefined;
             }
             else {
                 if (logging)
-                    logHHAuto(`Raid girl ${raid.id_girl} won but still has skins to collect (+Girl Skins ON)`);
+                    LogUtils_logHHAuto(`Raid girl ${raid.id_girl} won but still has skins to collect (+Girl Skins ON)`);
             }
         }
         if (logging && raid) {
-            logHHAuto(`LoveRaid troll fight: ${raid.trollId} selected with girl ${raid.id_girl} to win`);
+            LogUtils_logHHAuto(`LoveRaid troll fight: ${raid.trollId} selected with girl ${raid.id_girl} to win`);
         }
         // "first" = First ending raid (old default behavior)
         if (autoRaidSelectedIndex === 'first') {
@@ -10276,13 +10275,13 @@ class LoveRaidManager {
                 raid = raids.find(r => r.skin_to_win) || undefined;
             }
             if (logging && raid) {
-                logHHAuto(`LoveRaid first ending raid: troll ${raid.trollId} with girl ${raid.id_girl}`);
+                LogUtils_logHHAuto(`LoveRaid first ending raid: troll ${raid.trollId} with girl ${raid.id_girl}`);
             }
         }
         // Default "Choose a girl" (0) = no automatic fight
         if (autoRaidSelectedIndex === '0') {
             if (logging)
-                logHHAuto('Raid selector is "Choose a girl" — no automatic raid fight');
+                LogUtils_logHHAuto('Raid selector is "Choose a girl" — no automatic raid fight');
             raid = undefined;
         }
         return raid;
@@ -10298,11 +10297,11 @@ class LoveRaidManager {
             try {
                 if ((kkRaid.status === 'ongoing' && !raidNotStarted) || (raidNotStarted && kkRaid.status === 'upcoming')) {
                     if (debugEnabled)
-                        logHHAuto(`parsing raid ${kkRaid.status} ${kkRaid.event_name} module ${kkRaid.raid_module_type}`);
+                        LogUtils_logHHAuto(`parsing raid ${kkRaid.status} ${kkRaid.event_name} module ${kkRaid.raid_module_type}`);
                     // eslint-disable-next-line eqeqeq -- game field may be a truthy non-boolean; loose == true is intentional
                     if (kkRaid.all_is_owned == true) {
                         if (debugEnabled)
-                            logHHAuto(`nothing to win, ignoring raid`);
+                            LogUtils_logHHAuto(`nothing to win, ignoring raid`);
                         continue;
                     }
                     const raid = new LoveRaid();
@@ -10310,7 +10309,7 @@ class LoveRaidManager {
                     raid.girl_shards = Number((_a = kkRaid.girl_data) === null || _a === void 0 ? void 0 : _a.shards);
                     raid.girl_to_win = ((_b = kkRaid.girl_data) === null || _b === void 0 ? void 0 : _b.shards) < 100;
                     if (debugEnabled && ((_c = kkRaid.girl_data) === null || _c === void 0 ? void 0 : _c.shards) >= 100) {
-                        logHHAuto(`Girl won, may have skin to win, ignore for now`);
+                        LogUtils_logHHAuto(`Girl won, may have skin to win, ignore for now`);
                     }
                     // nb_grades = number of star slots (3=rare, 5=legendary, 6=mythic)
                     // Graded is a string of star symbols (e.g. "☆☆☆"), graded = completed awakenings
@@ -10325,7 +10324,7 @@ class LoveRaidManager {
                     raid.end_datetime = kkRaid.end_datetime;
                     raid.shards_left = Number(kkRaid.tranche_data.shards_left);
                     if (kkRaid.status === 'ongoing' && (((_j = (_h = (_g = kkRaid.girl_data) === null || _g === void 0 ? void 0 : _g.source) === null || _h === void 0 ? void 0 : _h.anchor_source) === null || _j === void 0 ? void 0 : _j.disabled) || ((_m = (_l = (_k = kkRaid.girl_data) === null || _k === void 0 ? void 0 : _k.source) === null || _l === void 0 ? void 0 : _l.anchor_win_from) === null || _m === void 0 ? void 0 : _m.disabled))) {
-                        logHHAuto(`Raid source display disabled, still parsing raid (${(_p = (_o = kkRaid.girl_data) === null || _o === void 0 ? void 0 : _o.source) === null || _p === void 0 ? void 0 : _p.sentence})`);
+                        LogUtils_logHHAuto(`Raid source display disabled, still parsing raid (${(_p = (_o = kkRaid.girl_data) === null || _o === void 0 ? void 0 : _o.source) === null || _p === void 0 ? void 0 : _p.sentence})`);
                     }
                     if ($('.raid-card')[index].classList.contains('multiple-girl')) {
                         const girlSkinShards = parseInt($($($('.raid-card')[index].getElementsByClassName('shards'))[1]).attr('skins-shard'), 10);
@@ -10346,14 +10345,14 @@ class LoveRaidManager {
                             break;
                         default:
                             if (debugEnabled)
-                                logHHAuto('Unknown raid type, ingoring raid');
+                                LogUtils_logHHAuto('Unknown raid type, ingoring raid');
                             continue;
                     }
                     raids.push(raid);
                 }
             }
             catch (error) {
-                logHHAuto('Error parsing raid', kkRaid, error);
+                LogUtils_logHHAuto('Error parsing raid', kkRaid, error);
             }
         }
         // console.log('raids', raids);
@@ -10417,7 +10416,7 @@ class LoveRaidManager {
             raid = raids.find(r => r.skin_to_win);
         }
         if (logging && raid) {
-            logHHAuto(`+Raid Stars picked troll ${raid.trollId} with girl ${raid.id_girl} (grade ${raid.girlGrade})`);
+            LogUtils_logHHAuto(`+Raid Stars picked troll ${raid.trollId} with girl ${raid.id_girl} (grade ${raid.girlGrade})`);
         }
         return raid;
     }
@@ -10432,7 +10431,7 @@ class LoveRaidManager {
     }
 }
 
-;// ./src/Module/Booster.ts
+;// CONCATENATED MODULE: ./src/Module/Booster.ts
 var Booster_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -10470,16 +10469,16 @@ class Booster {
     static waitForBattleResponse() {
         if (Booster._battleResponseReady) {
             Booster._battleResponseReady = false;
-            logHHAuto('[SW-DEBUG] waitForBattleResponse: flag was already set, returning immediately');
+            LogUtils_logHHAuto('[SW-DEBUG] waitForBattleResponse: flag was already set, returning immediately');
             return Promise.resolve();
         }
-        logHHAuto('[SW-DEBUG] waitForBattleResponse: waiting for AJAX response (10s timeout)...');
+        LogUtils_logHHAuto('[SW-DEBUG] waitForBattleResponse: waiting for AJAX response (10s timeout)...');
         return new Promise((resolve, reject) => {
             Booster._battleResponseResolve = resolve;
             setTimeout(() => {
                 if (Booster._battleResponseResolve === resolve) {
                     Booster._battleResponseResolve = null;
-                    logHHAuto('[SW-DEBUG] waitForBattleResponse: TIMED OUT after 10s — proceeding anyway');
+                    LogUtils_logHHAuto('[SW-DEBUG] waitForBattleResponse: TIMED OUT after 10s — proceeding anyway');
                     resolve(); // resolve anyway to avoid blocking
                 }
             }, 10000);
@@ -10489,7 +10488,7 @@ class Booster {
      * Resets the battle response flag and resolver. Must be called BEFORE each battle button click.
      */
     static resetBattleResponseFlag() {
-        logHHAuto('[SW-DEBUG] resetBattleResponseFlag: clearing flag and resolver before battle click');
+        LogUtils_logHHAuto('[SW-DEBUG] resetBattleResponseFlag: clearing flag and resolver before battle click');
         Booster._battleResponseReady = false;
         Booster._battleResponseResolve = null;
     }
@@ -10499,13 +10498,13 @@ class Booster {
      */
     static notifyBattleResponseProcessed() {
         if (Booster._battleResponseResolve) {
-            logHHAuto('[SW-DEBUG] notifyBattleResponseProcessed: resolver waiting → resolving promise now');
+            LogUtils_logHHAuto('[SW-DEBUG] notifyBattleResponseProcessed: resolver waiting → resolving promise now');
             const resolve = Booster._battleResponseResolve;
             Booster._battleResponseResolve = null;
             resolve();
         }
         else {
-            logHHAuto('[SW-DEBUG] notifyBattleResponseProcessed: no resolver waiting → setting flag for later');
+            LogUtils_logHHAuto('[SW-DEBUG] notifyBattleResponseProcessed: no resolver waiting → setting flag for later');
             Booster._battleResponseReady = true;
         }
     }
@@ -10535,7 +10534,7 @@ class Booster {
                                 // Track max usages for Sandalwood on equip
                                 if (((_a = clonedData.item) === null || _a === void 0 ? void 0 : _a.identifier) === 'MB1' && clonedData.usages_remaining != null) {
                                     setStoredValue(HHStoredVarPrefixKey + TK.sandalwoodMaxUsages, String(clonedData.usages_remaining));
-                                    logHHAuto(`[SW-DEBUG] Sandalwood equipped via AJAX: usages_remaining=${clonedData.usages_remaining}, saved to TK.sandalwoodMaxUsages`);
+                                    LogUtils_logHHAuto(`[SW-DEBUG] Sandalwood equipped via AJAX: usages_remaining=${clonedData.usages_remaining}, saved to TK.sandalwoodMaxUsages`);
                                 }
                             }
                             else {
@@ -10560,27 +10559,27 @@ class Booster {
                     if (sandalwood && action === 'do_battles_trolls') {
                         const isMultibattle = parseInt(number_of_battles || '') > 1;
                         const dosesBeforeFight = sandalwood.usages_remaining;
-                        logHHAuto(`[SW-DEBUG] AJAX do_battles_trolls: isMultibattle=${isMultibattle}, number_of_battles=${number_of_battles}, dosesBeforeFight=${dosesBeforeFight}`);
+                        LogUtils_logHHAuto(`[SW-DEBUG] AJAX do_battles_trolls: isMultibattle=${isMultibattle}, number_of_battles=${number_of_battles}, dosesBeforeFight=${dosesBeforeFight}`);
                         const { rewards } = response;
                         if (rewards && rewards.data && rewards.data.shards) {
                             let dosesConsumed = 0;
                             rewards.data.shards.forEach(({ previous_value, value }, idx) => {
                                 const shardsDropped = value - previous_value;
-                                logHHAuto(`[SW-DEBUG] shard drop[${idx}]: previous=${previous_value}, value=${value}, shardsDropped=${shardsDropped}`);
+                                LogUtils_logHHAuto(`[SW-DEBUG] shard drop[${idx}]: previous=${previous_value}, value=${value}, shardsDropped=${shardsDropped}`);
                                 if (isMultibattle) {
                                     const isOdd = shardsDropped % 2 === 1;
                                     if (isOdd) {
-                                        logHHAuto(`[SW-DEBUG] shard drop[${idx}]: ODD (${shardsDropped}) → Sandalwood expired mid-batch, all ${dosesBeforeFight} doses consumed`);
+                                        LogUtils_logHHAuto(`[SW-DEBUG] shard drop[${idx}]: ODD (${shardsDropped}) → Sandalwood expired mid-batch, all ${dosesBeforeFight} doses consumed`);
                                         dosesConsumed = dosesBeforeFight;
                                     }
                                     else {
                                         const dosesDelta = Math.floor(shardsDropped / 2);
-                                        logHHAuto(`[SW-DEBUG] shard drop[${idx}]: EVEN (${shardsDropped}) → ${dosesDelta} doses consumed`);
+                                        LogUtils_logHHAuto(`[SW-DEBUG] shard drop[${idx}]: EVEN (${shardsDropped}) → ${dosesDelta} doses consumed`);
                                         dosesConsumed += dosesDelta;
                                     }
                                 }
                                 else {
-                                    logHHAuto(`[SW-DEBUG] shard drop[${idx}]: single battle → 1 dose consumed`);
+                                    LogUtils_logHHAuto(`[SW-DEBUG] shard drop[${idx}]: single battle → 1 dose consumed`);
                                     dosesConsumed++;
                                 }
                             });
@@ -10588,10 +10587,10 @@ class Booster {
                             const uncappedDoses = dosesConsumed;
                             dosesConsumed = Math.min(dosesConsumed, dosesBeforeFight);
                             if (uncappedDoses !== dosesConsumed) {
-                                logHHAuto(`[SW-DEBUG] dose cap applied: uncapped=${uncappedDoses}, capped=${dosesConsumed}`);
+                                LogUtils_logHHAuto(`[SW-DEBUG] dose cap applied: uncapped=${uncappedDoses}, capped=${dosesConsumed}`);
                             }
                             sandalwood.usages_remaining -= dosesConsumed;
-                            logHHAuto(`[SW-DEBUG] Sandalwood dose tracking: before=${dosesBeforeFight}, consumed=${dosesConsumed}, remaining=${sandalwood.usages_remaining}, ended=${sandalwood.usages_remaining <= 0}`);
+                            LogUtils_logHHAuto(`[SW-DEBUG] Sandalwood dose tracking: before=${dosesBeforeFight}, consumed=${dosesConsumed}, remaining=${sandalwood.usages_remaining}, ended=${sandalwood.usages_remaining <= 0}`);
                             mythicUpdated = true;
                             sandalwoodEnded = sandalwood.usages_remaining <= 0;
                         }
@@ -10607,7 +10606,7 @@ class Booster {
                     try {
                         if (sandalwood && mythicUpdated && sandalwoodEnded) {
                             const isMultibattle = parseInt(number_of_battles || '') > 1;
-                            logHHAuto("[SW-DEBUG] sandalwood may be ended, need a new one");
+                            LogUtils_logHHAuto("[SW-DEBUG] sandalwood may be ended, need a new one");
                             const activatedEvent = getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventSandalWood) === "true";
                             const activatedMythic = getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythicSandalWood) === "true";
                             const activatedLoveRaid = LoveRaidManager.isAnyActivated() && getStoredValue(HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood) === "true";
@@ -10620,7 +10619,7 @@ class Booster {
                         }
                     }
                     catch (err) {
-                        logHHAuto('Catch error during equip sandalwood for mythic' + err);
+                        LogUtils_logHHAuto('Catch error during equip sandalwood for mythic' + err);
                     }
                     if (action === 'do_battles_trolls') {
                         Booster.notifyBattleResponseProcessed();
@@ -10676,7 +10675,7 @@ class Booster {
                 continue;
             booster.usages_remaining -= cost;
             changed = true;
-            logHHAuto("Mythic usage tracking: " + ((_c = booster.item) === null || _c === void 0 ? void 0 : _c.identifier) + " -" + cost + " -> " + booster.usages_remaining + " uses left.");
+            LogUtils_logHHAuto("Mythic usage tracking: " + ((_c = booster.item) === null || _c === void 0 ? void 0 : _c.identifier) + " -" + cost + " -> " + booster.usages_remaining + " uses left.");
         }
         return changed;
     }
@@ -10709,7 +10708,7 @@ class Booster {
     static collectBoostersFromMarket() {
         const activeSlots = $('#equiped .booster .slot:not(.empty):not(.mythic)').map((i, el) => $(el).data('d')).toArray();
         const activeMythicSlots = $('#equiped .booster .slot:not(.empty).mythic').map((i, el) => $(el).data('d')).toArray();
-        logHHAuto(`collectBoostersFromMarket: found ${activeSlots.length} normal boosters, ${activeMythicSlots.length} mythic boosters equipped`);
+        LogUtils_logHHAuto(`collectBoostersFromMarket: found ${activeSlots.length} normal boosters, ${activeMythicSlots.length} mythic boosters equipped`);
         const boosterStatus = {
             normal: activeSlots.map((data) => (Object.assign(Object.assign({}, data), { endAt: getHHVars('server_now_ts') + data.expiration }))),
             mythic: activeMythicSlots,
@@ -10761,7 +10760,7 @@ class Booster {
                     name: shopBooster.item.name,
                     rarity: shopBooster.item.rarity
                 };
-                logHHAuto(`getBoosterByIdentifier: "${identifier}" resolved from storeContents → id_item=${resolved.id_item}, name=${resolved.name}`);
+                LogUtils_logHHAuto(`getBoosterByIdentifier: "${identifier}" resolved from storeContents → id_item=${resolved.id_item}, name=${resolved.name}`);
                 return resolved;
             }
         }
@@ -10771,7 +10770,7 @@ class Booster {
         if (entry) {
             // boosterIdMap now stores { id_item, identifier, name, rarity }
             if (typeof entry === 'object' && entry.id_item) {
-                logHHAuto(`getBoosterByIdentifier: "${identifier}" resolved from boosterIdMap → id_item=${entry.id_item}, name=${entry.name}`);
+                LogUtils_logHHAuto(`getBoosterByIdentifier: "${identifier}" resolved from boosterIdMap → id_item=${entry.id_item}, name=${entry.name}`);
                 return Object.assign({}, entry);
             }
             // Backward compat: old format stored just the id_item string
@@ -10780,7 +10779,7 @@ class Booster {
             }
         }
         // No market data available — do NOT fall back to hardcoded IDs
-        logHHAuto(`getBoosterByIdentifier: No market data for "${identifier}". Visit the market first.`);
+        LogUtils_logHHAuto(`getBoosterByIdentifier: No market data for "${identifier}". Visit the market first.`);
         return null;
     }
     static parseEquipSlotConfig() {
@@ -10788,7 +10787,7 @@ class Booster {
         const normalized = raw.replace(/,/g, ';');
         const slots = normalized.split(';').map((s) => s.trim().toUpperCase());
         if (slots.length < 1 || slots.length > 4 || !slots.every((s) => /^B[1-4]$/.test(s))) {
-            logHHAuto("Auto-equip booster config invalid: " + raw + ", falling back to B1;B1;B2;B4");
+            LogUtils_logHHAuto("Auto-equip booster config invalid: " + raw + ", falling back to B1;B1;B2;B4");
             return ['B1', 'B1', 'B2', 'B4'];
         }
         return slots;
@@ -10888,15 +10887,15 @@ class Booster {
             totalDelay = Math.min(normalDelay, randomInterval(45 * 60, 60 * 60));
         }
         if (mythicRecheckSoon && totalDelay < normalDelay) {
-            logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60)
+            LogUtils_logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60)
                 + " min (shortened: a wanted mythic booster is still equippable, not waiting for the normal boosters to expire).");
         }
         else if (conflictWaiting && totalDelay < normalDelay) {
-            logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60)
+            LogUtils_logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60)
                 + " min (capped: a wanted mythic booster waits on a bonus conflict; re-checking hourly).");
         }
         else {
-            logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60) + " min (booster expires in "
+            LogUtils_logHHAuto("Auto-equip: Next check in " + Math.floor(totalDelay / 60) + " min (booster expires in "
                 + Math.floor(longestRemaining / 60) + " min + " + Math.floor(randomDelay / 60) + " min random delay).");
         }
         setTimer('nextAutoEquipBoosterTime', totalDelay);
@@ -10911,15 +10910,15 @@ class Booster {
             // Debug: dump cached booster inventory data
             const cachedIdMap = getStoredJSON(HHStoredVarPrefixKey + TK.boosterIdMap, {});
             const cachedInventory = getStoredJSON(HHStoredVarPrefixKey + TK.haveBooster, {});
-            logHHAuto("Auto-equip: Cached boosterIdMap = " + JSON.stringify(cachedIdMap));
-            logHHAuto("Auto-equip: Cached haveBooster (qty) = " + JSON.stringify(cachedInventory));
+            LogUtils_logHHAuto("Auto-equip: Cached boosterIdMap = " + JSON.stringify(cachedIdMap));
+            LogUtils_logHHAuto("Auto-equip: Cached haveBooster (qty) = " + JSON.stringify(cachedInventory));
             // The normal-slot auto-equip only runs when its own master switch is on.
             // The mythic-slot auto-equip is an independent setting (autoEquipMythicBooster).
             const normalAutoEquipOn = getStoredValue(HHStoredVarPrefixKey + SK.autoEquipBoosters) === "true";
             const mythicPriorityList = Booster.parseMythicBoosterList();
             // Ensure we have booster data from the market before trying to equip
             if (!Booster.hasBoosterDataFromMarket()) {
-                logHHAuto("Auto-equip: No booster data from market. Navigating to market first.");
+                LogUtils_logHHAuto("Auto-equip: No booster data from market. Navigating to market first.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
                 return true; // Signal busy — the market visit will cache the data, next loop will equip
             }
@@ -10927,7 +10926,7 @@ class Booster {
             // the equipped boosters. Without this, getBoostersToEquip() would use stale data
             // and repeatedly try to equip slots that are actually already occupied server-side.
             if (!Booster.hasFreshBoosterStatus()) {
-                logHHAuto("Auto-equip: boosterStatus is stale or missing. Navigating to market to refresh.");
+                LogUtils_logHHAuto("Auto-equip: boosterStatus is stale or missing. Navigating to market to refresh.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
                 return true; // Signal busy — market visit will refresh boosterStatus via collectBoostersFromMarket
             }
@@ -10956,36 +10955,36 @@ class Booster {
             }
             const boostersToEquip = Booster.getBoostersToEquip();
             if (boostersToEquip.length === 0) {
-                logHHAuto("Auto-equip: All booster slots active.");
+                LogUtils_logHHAuto("Auto-equip: All booster slots active.");
                 Booster.scheduleNextEquipCheck(mythicWantedStillEquippable, mythicConflictWaiting);
                 return mythicEquipped;
             }
-            logHHAuto("Auto-equip: Need to equip " + boostersToEquip.length + " booster(s): " + boostersToEquip.join(', '));
+            LogUtils_logHHAuto("Auto-equip: Need to equip " + boostersToEquip.length + " booster(s): " + boostersToEquip.join(', '));
             let anyEquipped = mythicEquipped;
             try {
                 for (const nextBoosterId of boostersToEquip) {
                     const boosterObj = Booster.getBoosterByIdentifier(nextBoosterId);
                     if (!boosterObj) {
-                        logHHAuto("Auto-equip: Could not resolve booster " + nextBoosterId + " from market data, skipping.");
+                        LogUtils_logHHAuto("Auto-equip: Could not resolve booster " + nextBoosterId + " from market data, skipping.");
                         continue;
                     }
                     if (!HeroHelper.haveBoosterInInventory(boosterObj.identifier)) {
-                        logHHAuto("Auto-equip: " + boosterObj.name + " (" + boosterObj.identifier + ") not in inventory, skipping.");
+                        LogUtils_logHHAuto("Auto-equip: " + boosterObj.name + " (" + boosterObj.identifier + ") not in inventory, skipping.");
                         continue;
                     }
                     const equipped = yield HeroHelper.equipBooster(boosterObj);
                     if (equipped) {
-                        logHHAuto("Auto-equip: Successfully equipped " + boosterObj.name);
+                        LogUtils_logHHAuto("Auto-equip: Successfully equipped " + boosterObj.name);
                         anyEquipped = true;
                     }
                     else {
-                        logHHAuto("Auto-equip: Failed to equip " + boosterObj.name + ". Slot may be occupied.");
+                        LogUtils_logHHAuto("Auto-equip: Failed to equip " + boosterObj.name + ". Slot may be occupied.");
                         break;
                     }
                 }
             }
             catch (error) {
-                logHHAuto("Auto-equip: Error during equip loop: " + error);
+                LogUtils_logHHAuto("Auto-equip: Error during equip loop: " + error);
             }
             finally {
                 // Always schedule next check, even on error
@@ -11013,7 +11012,7 @@ class Booster {
             .map((s) => s.trim().toUpperCase())
             .filter((s) => /^MB([1-9]|1[0-2])$/.test(s));
         if (parsed.length === 0) {
-            logHHAuto("Auto-equip mythic: no valid codes in '" + raw + "', treating as off.");
+            LogUtils_logHHAuto("Auto-equip mythic: no valid codes in '" + raw + "', treating as off.");
         }
         return parsed.slice(0, 5);
     }
@@ -11126,47 +11125,47 @@ class Booster {
             let free = Booster.getFreeMythicSlots();
             if (free <= 0) {
                 const reserved = sandalwoodActive && !equippedNow.has(Booster.SANDALWOOD_IDENTIFIER);
-                logHHAuto("Auto-equip mythic: no free mythic slot"
+                LogUtils_logHHAuto("Auto-equip mythic: no free mythic slot"
                     + (reserved ? " (one slot is reserved for the Sandalwood automation)" : "")
                     + ", leaving equipped boosters untouched.");
                 return false;
             }
             // Don't fight a recent equip failure.
             if (Booster.isEquipOnCooldown()) {
-                logHHAuto("Auto-equip mythic: equip on cooldown, skipping.");
+                LogUtils_logHHAuto("Auto-equip mythic: equip on cooldown, skipping.");
                 return false;
             }
             let anyEquipped = false;
             let conflictSeen = false;
             for (const identifier of priorityList) {
                 if (free <= 0) {
-                    logHHAuto("Auto-equip mythic: no free slot left for the remaining list entries.");
+                    LogUtils_logHHAuto("Auto-equip mythic: no free slot left for the remaining list entries.");
                     break;
                 }
                 if (sandalwoodActive && identifier === Booster.SANDALWOOD_IDENTIFIER) {
-                    logHHAuto("Auto-equip mythic: MB1 is managed by the Sandalwood automation, skipping.");
+                    LogUtils_logHHAuto("Auto-equip mythic: MB1 is managed by the Sandalwood automation, skipping.");
                     continue;
                 }
                 if (equippedNow.has(identifier)) {
-                    logHHAuto("Auto-equip mythic: " + identifier + " already equipped, skipping.");
+                    LogUtils_logHHAuto("Auto-equip mythic: " + identifier + " already equipped, skipping.");
                     continue;
                 }
                 if (Booster.isMythicConflictRemembered(identifier)) {
-                    logHHAuto("Auto-equip mythic: " + identifier + " conflicts with the current mythic loadout, skipping until the equipped mythics change.");
+                    LogUtils_logHHAuto("Auto-equip mythic: " + identifier + " conflicts with the current mythic loadout, skipping until the equipped mythics change.");
                     continue;
                 }
                 if (!HeroHelper.haveBoosterInInventory(identifier)) {
-                    logHHAuto("Auto-equip mythic: " + identifier + " not in inventory, skipping.");
+                    LogUtils_logHHAuto("Auto-equip mythic: " + identifier + " not in inventory, skipping.");
                     continue;
                 }
                 const boosterObj = Booster.getBoosterByIdentifier(identifier);
                 if (!boosterObj) {
-                    logHHAuto("Auto-equip mythic: could not resolve " + identifier + " from market data, skipping.");
+                    LogUtils_logHHAuto("Auto-equip mythic: could not resolve " + identifier + " from market data, skipping.");
                     continue;
                 }
                 const equipped = yield HeroHelper.equipBooster(boosterObj);
                 if (equipped) {
-                    logHHAuto("Auto-equip mythic: successfully equipped " + boosterObj.name);
+                    LogUtils_logHHAuto("Auto-equip mythic: successfully equipped " + boosterObj.name);
                     anyEquipped = true;
                     free--;
                     equippedNow.add(identifier);
@@ -11183,11 +11182,11 @@ class Booster {
                     // and keep equipping the rest of the list.
                     Booster.rememberMythicConflict(identifier);
                     conflictSeen = true;
-                    logHHAuto("Auto-equip mythic: " + boosterObj.name + " conflicts with an already equipped mythic booster, skipping it until the equipped mythics change.");
+                    LogUtils_logHHAuto("Auto-equip mythic: " + boosterObj.name + " conflicts with an already equipped mythic booster, skipping it until the equipped mythics change.");
                     continue;
                 }
                 else {
-                    logHHAuto("Auto-equip mythic: failed to equip " + boosterObj.name + ". Slot may be occupied server-side.");
+                    LogUtils_logHHAuto("Auto-equip mythic: failed to equip " + boosterObj.name + ". Slot may be occupied server-side.");
                     break;
                 }
             }
@@ -11198,7 +11197,7 @@ class Booster {
                 // the conflict memory this happens at most once per loadout
                 // change, not every cycle. safeReload waits for in-flight AJAX
                 // (e.g. the equips above) to settle first.
-                logHHAuto("Auto-equip mythic: reloading the page to clear the conflict popup.");
+                LogUtils_logHHAuto("Auto-equip mythic: reloading the page to clear the conflict popup.");
                 safeReload();
             }
             return anyEquipped;
@@ -11227,7 +11226,7 @@ class Booster {
                     // happened server-side and the window is purely
                     // informational, so remove it from the DOM instead.
                     const box = (_a = textEl.closest('[class*="popup"], [id*="popup"], #sliding-popups > *')) !== null && _a !== void 0 ? _a : textEl.parentElement;
-                    logHHAuto("Auto-equip mythic: removing conflict popup ("
+                    LogUtils_logHHAuto("Auto-equip mythic: removing conflict popup ("
                         + (box ? box.tagName + (box.id ? "#" + box.id : "") + (box.className ? "." + String(box.className).split(" ").join(".") : "") : "?") + ").");
                     box === null || box === void 0 ? void 0 : box.remove();
                     return true;
@@ -11249,20 +11248,20 @@ class Booster {
         const activatedEvent = getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventSandalWood) === "true";
         const activatedMythic = getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythicSandalWood) === "true";
         const activatedLoveRaid = LoveRaidManager.isAnyActivated() && getStoredValue(HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood) === "true";
-        logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: troll=${nextTrollChoosen}, activatedEvent=${activatedEvent}, activatedMythic=${activatedMythic}, activatedLoveRaid=${activatedLoveRaid}`);
+        LogUtils_logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: troll=${nextTrollChoosen}, activatedEvent=${activatedEvent}, activatedMythic=${activatedMythic}, activatedLoveRaid=${activatedLoveRaid}`);
         if (!activatedEvent && !activatedMythic && !activatedLoveRaid) {
-            logHHAuto('[SW-DEBUG] needSandalWoodEquipped: no auto-sandalwood activated, skipping');
+            LogUtils_logHHAuto('[SW-DEBUG] needSandalWoodEquipped: no auto-sandalwood activated, skipping');
             return false;
         }
         // Don't try to equip if we're on cooldown from a recent failure
         if (Booster.isEquipOnCooldown()) {
-            logHHAuto("needSandalWoodEquipped: skipping - equip on cooldown");
+            LogUtils_logHHAuto("needSandalWoodEquipped: skipping - equip on cooldown");
             return false;
         }
         // If no market data cached yet, signal that we need a market visit first.
         // Troll.ts will navigate to the shop page, which caches booster data.
         if (!Booster.hasBoosterDataFromMarket()) {
-            logHHAuto("needSandalWoodEquipped: No market data cached. Need market visit to check Sandalwood inventory.");
+            LogUtils_logHHAuto("needSandalWoodEquipped: No market data cached. Need market visit to check Sandalwood inventory.");
             return true;
         }
         let needForEvent = false, needForMythic = false, needForLoveRaid = false;
@@ -11281,14 +11280,14 @@ class Booster {
             }
             needForLoveRaid = Booster.needSandalWoodLoveRaid(nextTrollChoosen, loveRaid);
         }
-        logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
+        LogUtils_logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
         // Proactive depletion check: if Sandalwood is equipped but has 0 doses remaining,
         // remove it from boosterStatus so ownedSandalwoodAndNotEquiped() triggers re-equip.
         if (needForEvent || needForMythic || needForLoveRaid) {
             const dosesRemaining = Booster.getSandalwoodDosesRemaining();
-            logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}`);
+            LogUtils_logHHAuto(`[SW-DEBUG] needSandalWoodEquipped: proactive depletion check, dosesRemaining=${dosesRemaining}`);
             if (dosesRemaining !== null && dosesRemaining <= 0) {
-                logHHAuto('needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
+                LogUtils_logHHAuto('needSandalWoodEquipped: Sandalwood depleted (0 doses), removing from boosterStatus to trigger re-equip');
                 const boosterStatus = Booster.getBoosterFromStorage();
                 boosterStatus.mythic = boosterStatus.mythic.filter(b => { var _a; return ((_a = b.item) === null || _a === void 0 ? void 0 : _a.identifier) !== 'MB1'; });
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(boosterStatus));
@@ -11299,7 +11298,7 @@ class Booster {
     static ownedSandalwoodAndNotEquiped() {
         const ownedSandalwood = HeroHelper.haveBoosterInInventory(Booster.SANDALWOOD_IDENTIFIER);
         const equipedSandalwood = Booster.haveBoosterEquiped(Booster.SANDALWOOD_IDENTIFIER);
-        logHHAuto(`[SW-DEBUG] ownedSandalwoodAndNotEquiped: owned=${ownedSandalwood}, equipped=${equipedSandalwood}, result=${ownedSandalwood && !equipedSandalwood}`);
+        LogUtils_logHHAuto(`[SW-DEBUG] ownedSandalwoodAndNotEquiped: owned=${ownedSandalwood}, equipped=${equipedSandalwood}, result=${ownedSandalwood && !equipedSandalwood}`);
         return ownedSandalwood && !equipedSandalwood;
     }
     static isEquipOnCooldown() {
@@ -11307,7 +11306,7 @@ class Booster {
     }
     static setEquipCooldown(seconds = 5 * 60) {
         setTimer('nextBoosterEquipTime', seconds);
-        logHHAuto(`Booster equip cooldown set for ${seconds} seconds`);
+        LogUtils_logHHAuto(`Booster equip cooldown set for ${seconds} seconds`);
     }
     static markBoosterAsEquippedInStorage(booster) {
         const boosterStatus = Booster.getBoosterFromStorage();
@@ -11325,7 +11324,7 @@ class Booster {
                 // tick still treats the status as stale and navigates to
                 // the shop just to confirm what we already wrote here.
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate, String(Date.now()));
-                logHHAuto('Marked ' + booster.name + ' as equipped in storage (server says already equipped)');
+                LogUtils_logHHAuto('Marked ' + booster.name + ' as equipped in storage (server says already equipped)');
             }
         }
         else {
@@ -11338,7 +11337,7 @@ class Booster {
                 });
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatus, JSON.stringify(boosterStatus));
                 setStoredValue(HHStoredVarPrefixKey + TK.boosterStatusLastUpdate, String(Date.now()));
-                logHHAuto('Marked ' + booster.name + ' as equipped in storage (server says already equipped)');
+                LogUtils_logHHAuto('Marked ' + booster.name + ' as equipped in storage (server says already equipped)');
             }
         }
     }
@@ -11361,7 +11360,7 @@ class Booster {
         const remainingShards = Number(100 - Number(eventGirl.shards));
         const threshold = Booster.getSandalwoodMinShardsThreshold();
         if (remainingShards <= threshold) {
-            logHHAuto(`[SW-DEBUG] Not equipping sandalwood for event, only ${remainingShards} shards remaining (threshold: ${threshold})`);
+            LogUtils_logHHAuto(`[SW-DEBUG] Not equipping sandalwood for event, only ${remainingShards} shards remaining (threshold: ${threshold})`);
         }
         return activated && correctTrollTargetted && remainingShards > threshold;
     }
@@ -11371,7 +11370,7 @@ class Booster {
         const remainingShards = Number(100 - Number(eventMythicGirl.shards));
         const threshold = Booster.getSandalwoodMinShardsThreshold();
         if (remainingShards <= threshold) {
-            logHHAuto(`[SW-DEBUG] Not equipping sandalwood for mythic, only ${remainingShards} shards remaining (threshold: ${threshold})`);
+            LogUtils_logHHAuto(`[SW-DEBUG] Not equipping sandalwood for mythic, only ${remainingShards} shards remaining (threshold: ${threshold})`);
         }
         return activated && correctTrollTargetted && remainingShards > threshold;
     }
@@ -11383,17 +11382,17 @@ class Booster {
         const remainingShards = Number(100 - Number(loveRaid.girl_shards));
         const threshold = Booster.getSandalwoodMinShardsThreshold();
         if (remainingShards <= threshold) {
-            logHHAuto(`[SW-DEBUG] Not equipping sandalwood for love raid, only ${remainingShards} shards remaining (threshold: ${threshold})`);
+            LogUtils_logHHAuto(`[SW-DEBUG] Not equipping sandalwood for love raid, only ${remainingShards} shards remaining (threshold: ${threshold})`);
         }
         return activated && correctTrollTargetted && remainingShards > threshold;
     }
     static equipeSandalWoodIfNeeded(nextTrollChoosen_1) {
         return Booster_awaiter(this, arguments, void 0, function* (nextTrollChoosen, settingKey = SK.plusEventMythicSandalWood) {
-            logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: called for troll ${nextTrollChoosen}, settingKey=${settingKey}`);
+            LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: called for troll ${nextTrollChoosen}, settingKey=${settingKey}`);
             const activatedEvent = getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventSandalWood) === "true";
             const activatedMythic = getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true" && getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythicSandalWood) === "true";
             const activatedLoveRaid = LoveRaidManager.isAnyActivated() && getStoredValue(HHStoredVarPrefixKey + SK.plusEventLoveRaidSandalWood) === "true";
-            logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: activatedEvent=${activatedEvent}, activatedMythic=${activatedMythic}, activatedLoveRaid=${activatedLoveRaid}`);
+            LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: activatedEvent=${activatedEvent}, activatedMythic=${activatedMythic}, activatedLoveRaid=${activatedLoveRaid}`);
             let eventMythicGirl = null, loveRaid = null;
             let needForEvent = false, needForMythic = false, needForLoveRaid = false;
             if (activatedEvent) {
@@ -11420,33 +11419,33 @@ class Booster {
                     settingKey = SK.plusEventLoveRaidSandalWood;
                 }
             }
-            logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
+            LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: needForEvent=${needForEvent}, needForMythic=${needForMythic}, needForLoveRaid=${needForLoveRaid}`);
             try {
                 if (((needForEvent || needForMythic || needForLoveRaid) && Booster.ownedSandalwoodAndNotEquiped())) {
                     // Check cooldown before attempting equip
                     if (Booster.isEquipOnCooldown()) {
-                        logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: on cooldown, skipping equip attempt");
+                        LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: on cooldown, skipping equip attempt");
                         return false;
                     }
                     // Resolve Sandalwood booster from market data
                     const sandalwoodBooster = Booster.getSandalwoodBooster();
                     if (!sandalwoodBooster) {
-                        logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: No market data for Sandalwood. Visit the market first.");
+                        LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: No market data for Sandalwood. Visit the market first.");
                         return false;
                     }
                     // Equip a new one
-                    logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: calling HeroHelper.equipBooster(Sandalwood)");
+                    LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: calling HeroHelper.equipBooster(Sandalwood)");
                     const equiped = yield HeroHelper.equipBooster(sandalwoodBooster);
-                    logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: equipBooster returned ${equiped}`);
+                    LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: equipBooster returned ${equiped}`);
                     if (!equiped) {
                         const numberFailure = HeroHelper.getSandalWoodEquipFailure();
-                        logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: failure #${numberFailure}`);
+                        LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: failure #${numberFailure}`);
                         if (numberFailure >= 3) {
-                            logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: 3rd failure, deactivating auto sandalwood settingKey=" + settingKey);
+                            LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: 3rd failure, deactivating auto sandalwood settingKey=" + settingKey);
                             setStoredValue(HHStoredVarPrefixKey + settingKey, 'false');
                         }
                         else {
-                            logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: marking as already equipped + setting cooldown");
+                            LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: marking as already equipped + setting cooldown");
                             // Server says max boosters equipped - mark it as equipped to prevent retries
                             Booster.markBoosterAsEquippedInStorage(sandalwoodBooster);
                             // Set cooldown to prevent spamming equip attempts
@@ -11455,17 +11454,17 @@ class Booster {
                     }
                     else {
                         // Reset failure counter on success
-                        logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: success, resetting failure counter");
+                        LogUtils_logHHAuto("[SW-DEBUG] equipeSandalWoodIfNeeded: success, resetting failure counter");
                         setStoredValue(HHStoredVarPrefixKey + TK.sandalwoodFailure, 0);
                     }
                     return equiped;
                 }
                 else {
-                    logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: conditions not met, no equip needed`);
+                    LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: conditions not met, no equip needed`);
                 }
             }
             catch (error) {
-                logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: caught error: ${error}`);
+                LogUtils_logHHAuto(`[SW-DEBUG] equipeSandalWoodIfNeeded: caught error: ${error}`);
                 return Promise.resolve(false);
             }
             return Promise.resolve(false);
@@ -11500,7 +11499,7 @@ Booster.MYTHIC_CONFLICT_TEXT = /conflicts? with another mythic booster/i;
  *  equip. A class field so tests can shorten it. */
 Booster.MYTHIC_CONFLICT_POPUP_WAIT_MS = 2000;
 
-;// ./src/Module/Events/Season.ts
+;// CONCATENATED MODULE: ./src/Module/Events/Season.ts
 var Season_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -11613,7 +11612,7 @@ class Season {
         const needBoosterToFight = getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonBoostedOnly) === "true";
         const haveBoosterEquiped = Booster.haveBoosterEquiped();
         if (checkTimer('nextSeasonTime') && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
-            logHHAuto('Time for season but no booster equipped');
+            LogUtils_logHHAuto('Time for season but no booster equipped');
         }
         return (checkTimer('nextSeasonTime') && energyAboveThreshold && (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight)) || paranoiaSpending;
     }
@@ -11624,7 +11623,7 @@ class Season {
             const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
             if (!autoRun && !dispalyPowerCalc) {
                 if (debugEnabled)
-                    logHHAuto("Auto season : Display power calc is disabled, not simulating fight.");
+                    LogUtils_logHHAuto("Auto season : Display power calc is disabled, not simulating fight.");
                 return -1;
             }
             const hero_data = unsafeWindow.hero_data;
@@ -11637,7 +11636,7 @@ class Season {
             // with an opaque "Could not display season score" message every tick.
             // Guard up front with a clear log instead.
             if (!Array.isArray(opponentDatas) || opponentDatas.length < 3) {
-                logHHAuto(`Season : expected 3 opponents but got ${Array.isArray(opponentDatas) ? opponentDatas.length : 'none'}, skipping simulation.`);
+                LogUtils_logHHAuto(`Season : expected 3 opponents but got ${Array.isArray(opponentDatas) ? opponentDatas.length : 'none'}, skipping simulation.`);
                 return -1;
             }
             try {
@@ -11685,13 +11684,13 @@ class Season {
                         $('div.matchRatingNew', opponentBlock).append(`<img id="powerLevelScouterChosen" src=${ConfigHelper.getHHScriptVars("powerCalcImages").chosen}>`);
                     }
                     catch (_d) {
-                        logHHAuto('Error when dispaly chosen opponent');
+                        LogUtils_logHHAuto('Error when dispaly chosen opponent');
                     }
                 }
                 return chosenIndex < 0 ? chosenIndex : chosenID;
             }
             catch (err) {
-                logHHAuto("Catched error : Could not display season score : " + err);
+                LogUtils_logHHAuto("Catched error : Could not display season score : " + err);
                 return -1;
             }
         });
@@ -11825,12 +11824,12 @@ class Season {
     }
     static run() {
         return Season_awaiter(this, void 0, void 0, function* () {
-            logHHAuto("Performing auto Season.");
+            LogUtils_logHHAuto("Performing auto Season.");
             // Confirm if on correct screen.
             const Hero = getHero();
             var page = getPage();
             if (page === ConfigHelper.getHHScriptVars("pagesIDSeasonArena")) {
-                logHHAuto("On season arena page.");
+                LogUtils_logHHAuto("On season arena page.");
                 Season.stylesBattle();
                 const isMaxTierSet = getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonMaxTier) === "true";
                 const maxTier = getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonMaxTierNb) || Season.LAST_SEASON_LEVEL;
@@ -11843,12 +11842,12 @@ class Season {
                 const maxTierHard = getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonMaxTierHard) === "true";
                 const maxTierReached = isMaxTierSet && Season.getTierLevel() >= maxTier;
                 if (maxTierReached && (maxTierHard || !focusOnGirls)) {
-                    logHHAuto(`Max tier reached (${Season.getTierLevel()} >= ${maxTier}), not fighting anymore in season.`);
+                    LogUtils_logHHAuto(`Max tier reached (${Season.getTierLevel()} >= ${maxTier}), not fighting anymore in season.`);
                     setTimer('nextSeasonTime', randomInterval(30 * 60, 35 * 60));
                     return true;
                 }
                 if (maxTierReached && focusOnGirls) {
-                    logHHAuto(`Max tier reached (${Season.getTierLevel()} >= ${maxTier}) but Season focus "${seasonFocus}" enabled and MT hard off, will check for event girls.`);
+                    LogUtils_logHHAuto(`Max tier reached (${Season.getTierLevel()} >= ${maxTier}) but Season focus "${seasonFocus}" enabled and MT hard off, will check for event girls.`);
                 }
                 var chosenID = yield Season.moduleSimSeasonBattle(true);
                 if (chosenID === undefined || chosenID === null) {
@@ -11856,7 +11855,7 @@ class Season {
                     // number (opponent id, -1 or -2). A null/undefined result means the
                     // simulation did not run (e.g. a poisoned callItOnce wrapper). Retry
                     // shortly instead of arming the 30 min "no opponent" timer.
-                    logHHAuto("Season : opponent simulation returned no result, retrying shortly.");
+                    LogUtils_logHHAuto("Season : opponent simulation returned no result, retrying shortly.");
                     setTimer('nextSeasonTime', randomInterval(5, 10));
                     return false;
                 }
@@ -11868,7 +11867,7 @@ class Season {
                             class: 'Arena',
                             action: 'arena_reload'
                         };
-                        logHHAuto("Three red opponents, paying for refresh.");
+                        LogUtils_logHHAuto("Three red opponents, paying for refresh.");
                         getHHAjax()(params, function (data) {
                             Hero.update("hard_currency", data.hard_currency, false);
                             // C1: route through safeReload so any in-flight
@@ -11877,13 +11876,13 @@ class Season {
                         });
                     }
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                    logHHAuto("setting autoloop to false");
+                    LogUtils_logHHAuto("setting autoloop to false");
                     setTimer('nextSeasonTime', 5);
                     setTimeout(refreshOpponents, randomInterval(800, 1600));
                     return true;
                 }
                 else if (chosenID === -1) {
-                    logHHAuto("Season : was not able to choose opponent.");
+                    LogUtils_logHHAuto("Season : was not able to choose opponent.");
                     setTimer('nextSeasonTime', randomInterval(30 * 60, 35 * 60));
                 }
                 else {
@@ -11891,24 +11890,24 @@ class Season {
                     const opponentBlock = $('.season_arena_opponent_container[data-opponent=' + chosenID + ']');
                     const girlShardsReward = $(".slot.girl_ico[data-rewards]", opponentBlock);
                     if (girlShardsReward.length > 0) {
-                        logHHAuto("Girl shard reward found for chosen opponent");
+                        LogUtils_logHHAuto("Girl shard reward found for chosen opponent");
                     }
                     let hasWantedGirlReward = girlShardsReward.length > 0;
                     if (hasWantedGirlReward && seasonFocus === "girl") {
                         const dataRewardsList = girlShardsReward.map((_index, slot) => $(slot).attr('data-rewards') || '').get();
                         if (Season.isRewardSkinOnly(dataRewardsList)) {
-                            logHHAuto("Season focus 'girl': girl already won, remaining fight reward is her skin.");
+                            LogUtils_logHHAuto("Season focus 'girl': girl already won, remaining fight reward is her skin.");
                             hasWantedGirlReward = false;
                         }
                     }
                     if (focusOnGirls && !hasWantedGirlReward) {
                         if (maxTierHard || !isMaxTierSet || maxTierReached) {
-                            logHHAuto("Ignoring season fights as no girl to win on fight reward");
+                            LogUtils_logHHAuto("Ignoring season fights as no girl to win on fight reward");
                             setTimer('nextSeasonTime', randomInterval(30 * 60, 35 * 60));
                             return false;
                         }
                         else {
-                            logHHAuto("Below max tier (MT hard off), fighting regardless of event girls.");
+                            LogUtils_logHHAuto("Below max tier (MT hard off), fighting regardless of event girls.");
                         }
                     }
                     if (runThreshold > 0) {
@@ -11916,7 +11915,7 @@ class Season {
                     }
                     const toGoTo = $(".opponent_perform_button_container :first-child", opponentBlock).first().attr('href') || '';
                     if (toGoTo === '') {
-                        logHHAuto('Season : Error getting opponent location');
+                        LogUtils_logHHAuto('Season : Error getting opponent location');
                         setTimer('nextSeasonTime', randomInterval(30 * 60, 35 * 60));
                         return false;
                     }
@@ -11924,7 +11923,7 @@ class Season {
                     // (e.g. a parallel autoLoop tick) gets to finish before
                     // the URL change cancels open XHRs (issue #1598).
                     safeNavigateHref(addNutakuSession(toGoTo));
-                    logHHAuto(`Going to crush : ${$(".personal_info div.player-name", opponentBlock).text()} (${chosenID})`);
+                    LogUtils_logHHAuto(`Going to crush : ${$(".personal_info div.player-name", opponentBlock).text()} (${chosenID})`);
                     setTimer('nextSeasonTime', 5);
                     return true;
                 }
@@ -11932,9 +11931,9 @@ class Season {
             else {
                 const current_kisses = Season.getEnergy();
                 // Switch to the correct screen
-                logHHAuto("Remaining kisses : " + current_kisses);
+                LogUtils_logHHAuto("Remaining kisses : " + current_kisses);
                 if (current_kisses > 0) {
-                    logHHAuto("Switching to Season Arena screen.");
+                    LogUtils_logHHAuto("Switching to Season Arena screen.");
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeasonArena"));
                 }
                 else {
@@ -11961,7 +11960,7 @@ class Season {
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
             const errName = err instanceof Error ? err.name : 'Error';
-            logHHAuto(`ERROR in display Season rewards: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`ERROR in display Season rewards: ${errName}, ${message}`);
         }
     }
     static getNotClaimedRewards() {
@@ -11979,10 +11978,10 @@ class Season {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDSeason")) {
             Season.getRemainingTime();
             const seasonEnd = getSecondsLeft("SeasonRemainingTime");
-            logHHAuto("Season end in " + TimeHelper.debugDate(seasonEnd));
+            LogUtils_logHHAuto("Season end in " + TimeHelper.debugDate(seasonEnd));
             if (checkTimer('nextSeasonCollectAllTime') && seasonEnd < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonCollectAll) === "true") {
                 if ($(ConfigHelper.getHHScriptVars("selectorClaimAllRewards")).length > 0) {
-                    logHHAuto("Going to collect all Season item at once.");
+                    LogUtils_logHHAuto("Going to collect all Season item at once.");
                     setTimeout(function () {
                         $(ConfigHelper.getHHScriptVars("selectorClaimAllRewards"))[0].click();
                         setTimer('nextSeasonCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180)); // Add timer to check again later if there is new items to collect
@@ -11995,8 +11994,8 @@ class Season {
                 }
             }
             if (checkTimer('nextSeasonCollectTime') && getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonCollect) === "true") {
-                logHHAuto("Going to collect Season.");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("Going to collect Season.");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 let limitClassPass = "";
                 if ($("div#gsp_btn_holder:visible").length) {
@@ -12004,18 +12003,18 @@ class Season {
                 }
                 const buttonsToCollect = [];
                 const listSeasonTiersToClaim = $("#seasons_tab_container .rewards_pair .reward_wrapper.reward_is_claimable" + limitClassPass);
-                logHHAuto('Found ' + listSeasonTiersToClaim.length + ' rewards available for collection before filtering');
+                LogUtils_logHHAuto('Found ' + listSeasonTiersToClaim.length + ' rewards available for collection before filtering');
                 for (let currentReward = 0; currentReward < listSeasonTiersToClaim.length; currentReward++) {
                     const currentRewardSlot = RewardHelper.getRewardTypeBySlot($(".slot, .shards_girl_ico", listSeasonTiersToClaim[currentReward])[0]);
                     const currentTier = $(".tier_number", $(listSeasonTiersToClaim[currentReward]).parent())[0].innerText;
                     //console.log(currentRewardSlot);
                     if (rewardsToCollect.includes(currentRewardSlot)) {
                         if (listSeasonTiersToClaim[currentReward].className.indexOf('pass-reward') > 0) {
-                            logHHAuto("Adding for collection tier n°" + currentTier + " reward (paid) : " + currentRewardSlot);
+                            LogUtils_logHHAuto("Adding for collection tier n°" + currentTier + " reward (paid) : " + currentRewardSlot);
                             buttonsToCollect.push({ reward: currentRewardSlot, button: listSeasonTiersToClaim[currentReward], tier: currentTier, paid: true });
                         }
                         else {
-                            logHHAuto("Adding for collection n°" + currentTier + " reward (free) : " + currentRewardSlot);
+                            LogUtils_logHHAuto("Adding for collection n°" + currentTier + " reward (free) : " + currentRewardSlot);
                             buttonsToCollect.push({ reward: currentRewardSlot, button: listSeasonTiersToClaim[currentReward], tier: currentTier, paid: false });
                         }
                     }
@@ -12033,29 +12032,29 @@ class Season {
                                     && rewardsToCollect.includes(currentSelectedRewardType)
                                     && currentSelectedRewardType === currentToCollect.reward
                                     && currentTier === currentToCollect.tier) {
-                                    logHHAuto("Collecting tier n°" + currentToCollect.tier + " : " + currentSelectedRewardType);
+                                    LogUtils_logHHAuto("Collecting tier n°" + currentToCollect.tier + " : " + currentSelectedRewardType);
                                     setTimeout(function () { $("#claim_btn_s")[0].click(); }, 500);
                                 }
                                 else {
-                                    logHHAuto(`Issue collecting n°${currentToCollect.tier} : ${currentToCollect.reward} : \n`
+                                    LogUtils_logHHAuto(`Issue collecting n°${currentToCollect.tier} : ${currentToCollect.reward} : \n`
                                         + `rewardPlaceHolder.length : ${rewardPlaceHolder.length}\n`
                                         + `rewardsToCollect.includes(currentSelectedRewardType) : ${rewardsToCollect.includes(currentSelectedRewardType)}\n`
                                         + `currentSelectedRewardType : ${currentSelectedRewardType} / currentToCollect.reward : ${currentToCollect.reward} => ${currentSelectedRewardType === currentToCollect.reward}\n`
                                         + `currentTier : ${currentTier} / currentToCollect.tier : ${currentToCollect.tier} => ${currentTier === currentToCollect.tier}`);
-                                    logHHAuto("Proceeding with next one.");
+                                    LogUtils_logHHAuto("Proceeding with next one.");
                                 }
                                 buttonsToCollect.shift();
                                 setTimeout(collectSeasonRewards, 1000);
                                 return;
                             }
                             else {
-                                logHHAuto("Selecting reward n°" + currentToCollect.tier + " : " + currentToCollect.reward);
+                                LogUtils_logHHAuto("Selecting reward n°" + currentToCollect.tier + " : " + currentToCollect.reward);
                                 currentToCollect.button.click();
                                 setTimeout(function () { collectSeasonRewards(true); }, randomInterval(300, 500));
                             }
                         }
                         else {
-                            logHHAuto("Season collection finished.");
+                            LogUtils_logHHAuto("Season collection finished.");
                             setTimer('nextSeasonCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         }
@@ -12064,7 +12063,7 @@ class Season {
                     return true;
                 }
                 else {
-                    logHHAuto("No season collection to do.");
+                    LogUtils_logHHAuto("No season collection to do.");
                     setTimer('nextSeasonCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     setTimer('nextSeasonCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -12074,7 +12073,7 @@ class Season {
             return false;
         }
         else {
-            logHHAuto("Switching to Season Rewards screen.");
+            LogUtils_logHHAuto("Switching to Season Rewards screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeason"));
             return true;
         }
@@ -12154,7 +12153,7 @@ class Season {
 Season.LAST_SEASON_LEVEL = 63;
 Season.MIN_MOJO_FIGHT = 8;
 
-;// ./src/Module/League.pure.ts
+;// CONCATENATED MODULE: ./src/Module/League.pure.ts
 // League.pure.ts -- Pure decision logic for league automation.
 //
 // Extracted from LeagueHelper.isTimeToFight to enable direct unit tests
@@ -12206,7 +12205,7 @@ function decideShouldFight(state) {
     return ((timerExpired && energyAboveThreshold && boosterCheck) || paranoiaOverride);
 }
 
-;// ./src/model/LeagueOpponent.ts
+;// CONCATENATED MODULE: ./src/model/LeagueOpponent.ts
 // Model for a league opponent displayed in the league battle screen.
 // Holds the opponent's ID, nickname, power level, and the pre-computed
 // battle simulation result used to decide whether to fight.
@@ -12231,7 +12230,7 @@ class LeagueOpponent {
     }
 }
 
-;// ./src/Module/League.ts
+;// CONCATENATED MODULE: ./src/Module/League.ts
 var League_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -12419,7 +12418,7 @@ class LeagueHelper {
         const league_end = LeagueHelper.getLeagueEndTime();
         if (league_end > 0 && league_end <= (60 * 60)) {
             // Last league hour //TODO
-            logHHAuto("Last League hour");
+            LogUtils_logHHAuto("Last League hour");
         }
         const energy = LeagueHelper.getEnergy();
         const paranoiaSpending = ParanoiaService.checkParanoiaSpendings('challenge');
@@ -12442,7 +12441,7 @@ class LeagueHelper {
         const energyAboveThreshold = (humanLikeRun && energy > threshold) ||
             energy > Math.max(threshold, runThreshold - 1);
         if (timerExpired && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
-            logHHAuto('Time for league but no booster equipped');
+            LogUtils_logHHAuto('Time for league but no booster equipped');
         }
         return decideShouldFight(state);
     }
@@ -12474,7 +12473,7 @@ class LeagueHelper {
             const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
             const opponents_list = getHHVars("opponents_list");
             if (!opponents_list) {
-                logHHAuto('ERROR: Can\'t find opponent list');
+                LogUtils_logHHAuto('ERROR: Can\'t find opponent list');
                 return;
             }
             else {
@@ -12489,7 +12488,7 @@ class LeagueHelper {
                             return;
                         }
                         if (debugEnabled)
-                            logHHAuto('Simulating league opponents, remaining to simulate: ' + opponentsToSimulate.length);
+                            LogUtils_logHHAuto('Simulating league opponents, remaining to simulate: ' + opponentsToSimulate.length);
                         let opponentsPowerList = LeagueHelper._getTempLeagueOpponentList();
                         let opponentsPowerListChanged = false;
                         for (let opponentIndex = 0; opponentIndex < opponentsToSimulate.length; opponentIndex++) {
@@ -12497,7 +12496,7 @@ class LeagueHelper {
                             let simu;
                             let leagueOpponent;
                             if (debugEnabled)
-                                logHHAuto(`Simulating opponent ${opponentIndex + 1}/${opponentsToSimulate.length} - id: ${opponents.player.id_fighter}, nickname: ${opponents.nickname}`);
+                                LogUtils_logHHAuto(`Simulating opponent ${opponentIndex + 1}/${opponentsToSimulate.length} - id: ${opponents.player.id_fighter}, nickname: ${opponents.nickname}`);
                             if (opponentsPowerList && opponentsPowerList.opponentsList.length > 0) {
                                 try {
                                     leagueOpponent = opponentsPowerList.opponentsList.find((el) => el.opponent_id == opponents.player.id_fighter);
@@ -12505,9 +12504,9 @@ class LeagueHelper {
                                         simu = leagueOpponent.simu;
                                 }
                                 catch (error) {
-                                    logHHAuto("Error when getting oppo " + opponents.player.id_fighter + "from storage");
+                                    LogUtils_logHHAuto("Error when getting oppo " + opponents.player.id_fighter + "from storage");
                                     if (debugEnabled)
-                                        logHHAuto(error);
+                                        LogUtils_logHHAuto(error);
                                 }
                             }
                             if (!simu) {
@@ -12529,7 +12528,7 @@ class LeagueHelper {
                             yield TimeHelper.sleep(randomInterval(10, 30)); // Allow browser to render
                         }
                         if (opponentsPowerListChanged) {
-                            logHHAuto('Save opponent list for later');
+                            LogUtils_logHHAuto('Save opponent list for later');
                             setStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList, JSON.stringify(opponentsPowerList));
                         }
                     });
@@ -12585,7 +12584,7 @@ class LeagueHelper {
         }
         catch (err) {
             const { errName, message } = (err !== null && err !== void 0 ? err : {});
-            logHHAuto(`Error module Sim League: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`Error module Sim League: ${errName}, ${message}`);
         }
     }
     static moduleSimLeagueHideBeatenOppo() {
@@ -12686,7 +12685,7 @@ class LeagueHelper {
             opponentsPowerList.expirationDate = new Date().getTime() + maxLeagueListDurationSecs * 1000;
         }
         else {
-            logHHAuto('Found valid opponent list in storage, reuse it');
+            LogUtils_logHHAuto('Found valid opponent list in storage, reuse it');
         }
         return opponentsPowerList;
     }
@@ -12702,10 +12701,10 @@ class LeagueHelper {
         let usePowerCalc = sortMode === LeagueHelper.SORT_POWERCALC;
         const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
         if (debugEnabled)
-            logHHAuto(`Storting method: ${sortMode}`);
+            LogUtils_logHHAuto(`Storting method: ${sortMode}`);
         const hasScriptChangedPowerBefore = !LeagueHelper.hasVanillaPowerColumn();
         if (hasScriptChangedPowerBefore)
-            logHHAuto('Power columned changed from vanilla game, can be HH++ BDSM or other script');
+            LogUtils_logHHAuto('Power columned changed from vanilla game, can be HH++ BDSM or other script');
         const tableRow = $(".data-list .data-row.body-row");
         /*var getPowerOrPoints = function (hasHHBdsmChangeBefore, oppoRow)
         {
@@ -12717,7 +12716,7 @@ class LeagueHelper {
                 return parsePrice($('.data-column[column="power"]', oppoRow).text());
             }
         }*/
-        logHHAuto('Number of player in league:' + tableRow.length + '. Number of opponent not fought in league:' + $('.data-list .data-row.body-row a').length);
+        LogUtils_logHHAuto('Number of player in league:' + tableRow.length + '. Number of opponent not fought in league:' + $('.data-list .data-row.body-row a').length);
         const opponents_list = getHHVars("opponents_list");
         let heroFighter;
         if (usePowerCalc) {
@@ -12726,9 +12725,9 @@ class LeagueHelper {
                 heroFighter = opponents_list === null || opponents_list === void 0 ? void 0 : opponents_list.find((el) => el.player.id_fighter == HeroHelper.getPlayerId()).player;
             }
             catch (error) {
-                logHHAuto('Error, falback to not use powercalc');
+                LogUtils_logHHAuto('Error, falback to not use powercalc');
                 if (debugEnabled)
-                    logHHAuto(error);
+                    LogUtils_logHHAuto(error);
                 usePowerCalc = false;
             }
         }
@@ -12744,7 +12743,7 @@ class LeagueHelper {
                         leagueOpponent = opponentsPowerList.opponentsList.find((el) => el.opponent_id == opponent_id);
                     }
                     catch (error) {
-                        logHHAuto("Error when getting oppo " + opponent_id + " from storage");
+                        LogUtils_logHHAuto("Error when getting oppo " + opponent_id + " from storage");
                     }
                 }
                 if (!leagueOpponent) {
@@ -12757,7 +12756,7 @@ class LeagueHelper {
                             expectedPoints = Number(NumberHelper.nRounding(simu.expectedValue, 1, -1));
                         }
                         catch (error) {
-                            logHHAuto("Error in simu for oppo " + opponent_id + ", falback to not use powercalc");
+                            LogUtils_logHHAuto("Error in simu for oppo " + opponent_id + ", falback to not use powercalc");
                             canUseSimu = false;
                         }
                     }
@@ -12780,17 +12779,17 @@ class LeagueHelper {
             }
         });
         if (opponentsPowerListChanged) {
-            logHHAuto('Save updated opponent list for later');
+            LogUtils_logHHAuto('Save updated opponent list for later');
             setStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList, JSON.stringify(opponentsPowerList));
         }
         const hasScriptChangedPowerAfter = !LeagueHelper.hasVanillaPowerColumn();
         if (!hasScriptChangedPowerBefore && hasScriptChangedPowerAfter) {
             if (isFirstCall) {
-                logHHAuto('User script edited power column during computation, try again');
+                LogUtils_logHHAuto('User script edited power column during computation, try again');
                 return LeagueHelper.getLeagueOpponentListData(false);
             }
             else {
-                logHHAuto('User script edited power column during computation twice, stop');
+                LogUtils_logHHAuto('User script edited power column during computation twice, stop');
                 return [];
             }
         }
@@ -12806,7 +12805,7 @@ class LeagueHelper {
         } // sortMode === LeagueHelper.SORT_DISPLAYED // No sorting, keep html order
         //}
         if (usePowerCalc) {
-            logHHAuto('Save opponent list for later');
+            LogUtils_logHHAuto('Save opponent list for later');
             setStoredValue(HHStoredVarPrefixKey + TK.LeagueOpponentList, JSON.stringify({ expirationDate: opponentsPowerList.expirationDate, opponentsList: Data }));
         }
         return Data;
@@ -12833,18 +12832,18 @@ class LeagueHelper {
                 // CrushThemFights(); // TODO ??? // now managed by doBattle
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDLeaderboard")) {
-                logHHAuto("On leaderboard page.");
+                LogUtils_logHHAuto("On leaderboard page.");
                 if (getStoredValue(HHStoredVarPrefixKey + SK.autoLeaguesCollect) === "true") {
                     if ($('#leagues .forced_info button[rel="claim"]').length > 0) {
                         $('#leagues .forced_info button[rel="claim"]').trigger('click'); //click reward
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDLeaderboard"));
                     }
                 }
-                logHHAuto('parsing enemies');
+                LogUtils_logHHAuto('parsing enemies');
                 var Data = LeagueHelper.getLeagueOpponentListData();
                 const league_end = LeagueHelper.getLeagueEndTime();
                 if (currentPower < 1 && Data.length > 0) {
-                    logHHAuto("No power for leagues.");
+                    LogUtils_logHHAuto("No power for leagues.");
                     //prevent paranoia to wait for league
                     setStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked, "true");
                     const next_refresh = getHHVars('Hero.energies.challenge.next_refresh_ts');
@@ -12852,21 +12851,21 @@ class LeagueHelper {
                     return;
                 }
                 if (Data.length == 0) {
-                    logHHAuto('No valid targets!');
+                    LogUtils_logHHAuto('No valid targets!');
                     //prevent paranoia to wait for league
                     setStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked, "true");
                     if ($('#leagues .forced_info').length > 0) {
                         setTimer('nextLeaguesTime', randomInterval(30 * 60, 35 * 60));
                     }
                     else {
-                        logHHAuto('Set timer to league ends.');
+                        LogUtils_logHHAuto('Set timer to league ends.');
                         setTimer('nextLeaguesTime', randomInterval(league_end - 5 * 60, league_end));
                     }
                 }
                 else {
                     var getPlayerCurrentLevel = LeagueHelper.getLeagueCurrentLevel();
                     if (isNaN(getPlayerCurrentLevel)) {
-                        logHHAuto("Could not get current Rank, stopping League.");
+                        LogUtils_logHHAuto("Could not get current Rank, stopping League.");
                         //prevent paranoia to wait for league
                         setStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked, "true");
                         setTimer('nextLeaguesTime', randomInterval(30 * 60, 35 * 60));
@@ -12885,7 +12884,7 @@ class LeagueHelper {
                         if (currentRank > (totalOpponents - 15)) {
                             rankDemote = totalOpponents - 15;
                         }
-                        logHHAuto("Current league above target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to demote. max rank : " + rankDemote + "/" + totalOpponents);
+                        LogUtils_logHHAuto("Current league above target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to demote. max rank : " + rankDemote + "/" + totalOpponents);
                         let getRankDemote = $(".data-list .data-row.body-row .data-column[column='place']:contains(" + rankDemote + ")").filter(function () {
                             return Number($(this).text().trim()) === rankDemote;
                         });
@@ -12895,14 +12894,14 @@ class LeagueHelper {
                         else {
                             maxDemote = 0;
                         }
-                        logHHAuto("Current league above target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to demote. Score should not be higher than : " + maxDemote);
+                        LogUtils_logHHAuto("Current league above target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to demote. Score should not be higher than : " + maxDemote);
                         if (currentScore + leagueScoreSecurityThreshold >= maxDemote) {
                             if (league_end <= (60 * 60)) {
-                                logHHAuto("Can't do league as could go above demote, as last hour setting timer to 5 mins");
+                                LogUtils_logHHAuto("Can't do league as could go above demote, as last hour setting timer to 5 mins");
                                 setTimer('nextLeaguesTime', randomInterval(5 * 60, 8 * 60));
                             }
                             else {
-                                logHHAuto("Can't do league as could go above demote, setting timer to 30 mins");
+                                LogUtils_logHHAuto("Can't do league as could go above demote, setting timer to 30 mins");
                                 setTimer('nextLeaguesTime', randomInterval(30 * 60, 35 * 60));
                             }
                             //prevent paranoia to wait for league
@@ -12928,7 +12927,7 @@ class LeagueHelper {
                         if (currentRank > promotionCount) {
                             rankStay = promotionCount;
                         }
-                        logHHAuto("Current league is target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to stay. Promotion cutoff (higher of 15%/top20): " + promotionCount + ", max rank : " + rankStay);
+                        LogUtils_logHHAuto("Current league is target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to stay. Promotion cutoff (higher of 15%/top20): " + promotionCount + ", max rank : " + rankStay);
                         let getRankStay = $(".data-list .data-row.body-row .data-column[column='place']:contains(" + rankStay + ")").filter(function () {
                             return Number($(this).text().trim()) === rankStay;
                         });
@@ -12938,9 +12937,9 @@ class LeagueHelper {
                         else {
                             maxStay = 0;
                         }
-                        logHHAuto("Current league is target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to stay. Score should not be higher than : " + maxStay);
+                        LogUtils_logHHAuto("Current league is target (" + Number(getPlayerCurrentLevel) + "/" + leagueTargetValue + "), needs to stay. Score should not be higher than : " + maxStay);
                         if (currentScore + leagueScoreSecurityThreshold >= maxStay && getStoredValue(HHStoredVarPrefixKey + SK.autoLeaguesAllowWinCurrent) !== "true") {
-                            logHHAuto("Can't do league as could go above stay, setting timer to 30 mins");
+                            LogUtils_logHHAuto("Can't do league as could go above stay, setting timer to 30 mins");
                             setTimer('nextLeaguesTime', randomInterval(30 * 60, 35 * 60));
                             //prevent paranoia to wait for league
                             setStoredValue(HHStoredVarPrefixKey + TK.paranoiaLeagueBlocked, "true");
@@ -12948,9 +12947,9 @@ class LeagueHelper {
                             return;
                         }
                     }
-                    logHHAuto(Data.length + ' valid targets!');
+                    LogUtils_logHHAuto(Data.length + ' valid targets!');
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                    logHHAuto("setting autoloop to false");
+                    LogUtils_logHHAuto("setting autoloop to false");
                     const runThreshold = Number(getStoredValue(HHStoredVarPrefixKey + SK.autoLeaguesRunThreshold)) || 0;
                     if (runThreshold > 0) {
                         setStoredValue(HHStoredVarPrefixKey + TK.LeagueHumanLikeRun, "true");
@@ -12959,23 +12958,23 @@ class LeagueHelper {
                     const opponents_list = getHHVars("opponents_list");
                     const opponentDataFromList = opponents_list === null || opponents_list === void 0 ? void 0 : opponents_list.find((obj) => obj.player.id_fighter == nextOpponent.opponent_id);
                     if (debugEnabled && opponentDataFromList)
-                        logHHAuto("opponentDataFromList ", JSON.stringify(opponentDataFromList));
+                        LogUtils_logHHAuto("opponentDataFromList ", JSON.stringify(opponentDataFromList));
                     if (!opponentDataFromList)
-                        logHHAuto(`ERROR opponent ${nextOpponent.opponent_id} not found in JS list`);
-                    logHHAuto(`Going to fight ${nextOpponent.nickname} (${nextOpponent.opponent_id}) with power ${nextOpponent.power}. Can fight: ${opponentDataFromList === null || opponentDataFromList === void 0 ? void 0 : opponentDataFromList.can_fight}`);
+                        LogUtils_logHHAuto(`ERROR opponent ${nextOpponent.opponent_id} not found in JS list`);
+                    LogUtils_logHHAuto(`Going to fight ${nextOpponent.nickname} (${nextOpponent.opponent_id}) with power ${nextOpponent.power}. Can fight: ${opponentDataFromList === null || opponentDataFromList === void 0 ? void 0 : opponentDataFromList.can_fight}`);
                     if (debugEnabled)
-                        logHHAuto(JSON.stringify(nextOpponent));
+                        LogUtils_logHHAuto(JSON.stringify(nextOpponent));
                     // change referer
                     window.history.replaceState(null, '', addNutakuSession(ConfigHelper.getHHScriptVars("pagesURLLeaguPreBattle") + '?id_opponent=' + nextOpponent.opponent_id));
                     const numberOfFightAvailable = LeagueHelper.numberOfFightAvailable(opponentDataFromList);
                     let numberOfBattle = 1;
                     if (numberOfFightAvailable > 1 && currentPower >= (numberOfFightAvailable + leagueThreshold)) {
                         if (maxStay > 0 && currentScore + (numberOfFightAvailable * leagueScoreSecurityThreshold) >= maxStay)
-                            logHHAuto('Can\'t do ' + numberOfFightAvailable + ' fights in league as could go above stay');
+                            LogUtils_logHHAuto('Can\'t do ' + numberOfFightAvailable + ' fights in league as could go above stay');
                         else
                             numberOfBattle = numberOfFightAvailable;
                     }
-                    logHHAuto("Going to fight " + numberOfBattle + " times (Number fights available from opponent:" + numberOfFightAvailable + ")");
+                    LogUtils_logHHAuto("Going to fight " + numberOfBattle + " times (Number fights available from opponent:" + numberOfFightAvailable + ")");
                     // Schedule the next league fight *before* triggering
                     // the battle. Three cases:
                     //
@@ -13056,17 +13055,17 @@ class LeagueHelper {
                 if (lastActionPerformed !== undefined
                     && lastActionPerformed !== "none"
                     && lastActionPerformed !== "league") {
-                    logHHAuto("Skip switching to leagues screen, busy with: " + lastActionPerformed);
+                    LogUtils_logHHAuto("Skip switching to leagues screen, busy with: " + lastActionPerformed);
                     return;
                 }
-                logHHAuto("Switching to leagues screen.");
+                LogUtils_logHHAuto("Switching to leagues screen.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDLeaderboard"));
                 return;
             }
         }
         catch (err) {
             const { errName, message } = (err !== null && err !== void 0 ? err : {});
-            logHHAuto(`Error do League: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`Error do League: ${errName}, ${message}`);
             setTimer('nextLeaguesTime', randomInterval(30 * 60, 35 * 60));
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
         }
@@ -13087,7 +13086,7 @@ LeagueHelper.SORT_DISPLAYED = LEAGUE_SORT.DISPLAYED;
 LeagueHelper.SORT_POWER = LEAGUE_SORT.POWER;
 LeagueHelper.SORT_POWERCALC = LEAGUE_SORT.POWERCALC;
 
-;// ./src/Module/DailyGoals.ts
+;// CONCATENATED MODULE: ./src/Module/DailyGoals.ts
 // DailyGoals.ts -- Automates daily goals: claims rewards and tracks refresh timers.
 //
 // The game offers daily goals with rewards upon completion. This module
@@ -13116,7 +13115,7 @@ class DailyGoals {
             const goalsTimer = Number(convertTimeToInt($(timerRequest).text()));
             return goalsTimer;
         }
-        logHHAuto('ERROR: can\'t get Daily goals timer, default to maxCollectionDelay');
+        LogUtils_logHHAuto('ERROR: can\'t get Daily goals timer, default to maxCollectionDelay');
         return ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
     }
     static styles() {
@@ -13168,7 +13167,7 @@ class DailyGoals {
             //console.log(getPage());
             if (getPage() === ConfigHelper.getHHScriptVars("pagesIDDailyGoals")) {
                 try {
-                    logHHAuto("Checking Daily Goals for collectable rewards. Setting autoloop to false");
+                    LogUtils_logHHAuto("Checking Daily Goals for collectable rewards. Setting autoloop to false");
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     const nextDailyGoalsTimer = DailyGoals.getNewGoalsTimer();
                     let buttonsToCollect = [];
@@ -13182,7 +13181,7 @@ class DailyGoals {
                             const currentRewardsList = currentChest.length > 0 ? currentChest.data("rewards") : [];
                             //console.log("checking tier : "+currentTierNb);
                             if (nextDailyGoalsTimer <= ConfigHelper.getHHScriptVars("dailyRewardMaxRemainingTime") && nextDailyGoalsTimer > 0) {
-                                logHHAuto("Force adding for collection chest n° " + currentTierNb);
+                                LogUtils_logHHAuto("Force adding for collection chest n° " + currentTierNb);
                                 buttonsToCollect.push(currentButton[0]);
                             }
                             else {
@@ -13190,14 +13189,14 @@ class DailyGoals {
                                 for (let reward of currentRewardsList) {
                                     const rewardType = RewardHelper.getRewardTypeByData(reward);
                                     if (!rewardsToCollect.includes(rewardType)) {
-                                        logHHAuto(`Not adding for collection chest n° ${currentTierNb} because ${rewardType} is not in immediate collection list.`);
+                                        LogUtils_logHHAuto(`Not adding for collection chest n° ${currentTierNb} because ${rewardType} is not in immediate collection list.`);
                                         validToCollect = false;
                                         break;
                                     }
                                 }
                                 if (validToCollect) {
                                     buttonsToCollect.push(currentButton[0]);
-                                    logHHAuto("Adding for collection chest n° " + currentTierNb);
+                                    LogUtils_logHHAuto("Adding for collection chest n° " + currentTierNb);
                                 }
                             }
                         }
@@ -13205,13 +13204,13 @@ class DailyGoals {
                     if (buttonsToCollect.length > 0 || potionsNum < 100) {
                         function collectDailyGoalsRewards() {
                             if (buttonsToCollect.length > 0) {
-                                logHHAuto("Collecting chest n° " + buttonsToCollect[0].getAttribute('tier'));
+                                LogUtils_logHHAuto("Collecting chest n° " + buttonsToCollect[0].getAttribute('tier'));
                                 buttonsToCollect[0].click();
                                 buttonsToCollect.shift();
                                 setTimeout(collectDailyGoalsRewards, randomInterval(300, 500));
                             }
                             else {
-                                logHHAuto("Daily Goals collection finished.");
+                                LogUtils_logHHAuto("Daily Goals collection finished.");
                                 setTimer('nextDailyGoalsCollectTime', randomInterval(30 * 60, 35 * 60));
                                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                             }
@@ -13220,7 +13219,7 @@ class DailyGoals {
                         return true;
                     }
                     else {
-                        logHHAuto("No Daily Goals reward to collect.");
+                        LogUtils_logHHAuto("No Daily Goals reward to collect.");
                         setTimer('nextDailyGoalsCollectTime', nextDailyGoalsTimer + randomInterval(3600, 4000));
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         return false;
@@ -13234,13 +13233,13 @@ class DailyGoals {
                     // both safely; the message extraction stays defensive so a
                     // primitive throw still produces a readable log line.
                     const errMessage = err instanceof Error ? err.message : String(err);
-                    logHHAuto(`ERROR during daily goals run: ${errMessage}, retry in 1h`);
+                    LogUtils_logHHAuto(`ERROR during daily goals run: ${errMessage}, retry in 1h`);
                     setTimer('nextDailyGoalsCollectTime', randomInterval(3600, 4000));
                     return false;
                 }
             }
             else {
-                logHHAuto("Switching to Daily Goals screen.");
+                LogUtils_logHHAuto("Switching to Daily Goals screen.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDDailyGoals"));
                 return true;
             }
@@ -13281,7 +13280,7 @@ class DailyGoals {
                 }
         }
         setStoredValue(HHStoredVarPrefixKey + TK.dailyGoalsList, JSON.stringify(supportedGoals));
-        logHHAuto("Daily Goals", supportedGoals);
+        LogUtils_logHHAuto("Daily Goals", supportedGoals);
         return supportedGoals;
     }
     static _isDailyGoalType(anchor, update) {
@@ -13322,7 +13321,7 @@ class DailyGoalsIcon {
         const ocdhelp = $('#worship_data');
         if (ocdhelp.length > 0) {
             if ($('.daily_goals_potion_icn', ocdhelp).length <= 0) {
-                logHHAuto('displayPantheon');
+                LogUtils_logHHAuto('displayPantheon');
                 GM_addStyle('#worship_data .daily_goals_potion_icn.hhauto {'
                     + 'background-size: 15px;'
                     + 'width: 15px;'
@@ -13342,7 +13341,7 @@ class DailyGoalsIcon {
     }
 }
 
-;// ./src/Module/Pantheon.pure.ts
+;// CONCATENATED MODULE: ./src/Module/Pantheon.pure.ts
 // Pantheon.pure.ts -- Pure decision logic for the pantheon auto module.
 //
 // Extracted from Pantheon.isEnabled and Pantheon.isTimeToFight so the
@@ -13395,7 +13394,7 @@ function Pantheon_pure_decideShouldFight(state) {
     return (timerExpired && energyAboveThreshold && boosterCheck) || paranoiaOverride;
 }
 
-;// ./src/Module/Pantheon.ts
+;// CONCATENATED MODULE: ./src/Module/Pantheon.ts
 // Pantheon.ts -- Automates Pantheon fights: opponent selection and energy management.
 //
 // The Pantheon is a PvP arena with its own energy system. This module selects
@@ -13478,7 +13477,7 @@ class Pantheon {
         const energyAboveThreshold = (humanLikeRun && energy > threshold)
             || energy > Math.max(threshold, runThreshold - 1);
         if (timerExpired && energyAboveThreshold && needBoosterToFight && !haveBoosterEquipped) {
-            logHHAuto('Time for pantheon but no booster equipped');
+            LogUtils_logHHAuto('Time for pantheon but no booster equipped');
         }
         return Pantheon_pure_decideShouldFight({
             energy,
@@ -13493,13 +13492,13 @@ class Pantheon {
         });
     }
     static run() {
-        logHHAuto("Performing auto Pantheon.");
+        LogUtils_logHHAuto("Performing auto Pantheon.");
         // Confirm if on correct screen.
         var page = getPage();
         var current_worship = Pantheon.getEnergy();
         if (page === ConfigHelper.getHHScriptVars("pagesIDPantheon")) {
-            logHHAuto("On pantheon page.");
-            logHHAuto("Remaining worship : " + current_worship);
+            LogUtils_logHHAuto("On pantheon page.");
+            LogUtils_logHHAuto("Remaining worship : " + current_worship);
             if (current_worship > 0) {
                 const runThreshold = Number(getStoredValue(HHStoredVarPrefixKey + SK.autoPantheonRunThreshold)) || 0;
                 if (runThreshold > 0) {
@@ -13508,13 +13507,13 @@ class Pantheon {
                 let pantheonButton = $("#pantheon_tab_container .bottom-container .blue_button_L.pantheon-pre-battle-btn");
                 let templeID = queryStringGetParam(new URL(pantheonButton[0].getAttribute("href") || '', window.location.origin).search, 'id_opponent');
                 if (pantheonButton.length > 0 && templeID !== null) {
-                    logHHAuto("Going to fight Temple : " + templeID);
+                    LogUtils_logHHAuto("Going to fight Temple : " + templeID);
                     if (DailyGoals.isAutoDailyGoalsActivated() && DailyGoals.incrementPantheonDailyGoal())
-                        logHHAuto('Increment pantheon daily goals');
+                        LogUtils_logHHAuto('Increment pantheon daily goals');
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDPantheonPreBattle"), { id_opponent: templeID });
                 }
                 else {
-                    logHHAuto("Issue to find templeID retry in 60secs.");
+                    LogUtils_logHHAuto("Issue to find templeID retry in 60secs.");
                     setTimer('nextPantheonTime', randomInterval(60, 70));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                 }
@@ -13532,18 +13531,18 @@ class Pantheon {
             return;
         }
         else if (page === ConfigHelper.getHHScriptVars("pagesIDPantheonPreBattle")) {
-            logHHAuto("On pantheon-pre-battle page.");
+            LogUtils_logHHAuto("On pantheon-pre-battle page.");
             let templeID = queryStringGetParam(window.location.search, 'id_opponent');
-            logHHAuto("Go and fight temple :" + templeID);
+            LogUtils_logHHAuto("Go and fight temple :" + templeID);
             let pantheonTempleBattleButton = $("#pre-battle .battle-buttons .green_button_L.battle-action-button.pantheon-single-battle-button[data-pantheon-id='" + templeID + "']");
             if (pantheonTempleBattleButton.length > 0) {
                 //replaceCheatClick();
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("setting autoloop to false");
                 pantheonTempleBattleButton[0].click();
             }
             else {
-                logHHAuto("Issue to find temple battle button retry in 60secs. Disabling pantheon battle.");
+                LogUtils_logHHAuto("Issue to find temple battle button retry in 60secs. Disabling pantheon battle.");
                 setStoredValue(HHStoredVarPrefixKey + SK.autoPantheon, "false");
                 setTimer('nextPantheonTime', randomInterval(60, 70));
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -13551,9 +13550,9 @@ class Pantheon {
         }
         else {
             // Switch to the correct screen
-            logHHAuto("Remaining worship : " + current_worship);
+            LogUtils_logHHAuto("Remaining worship : " + current_worship);
             if (current_worship > 0) {
-                logHHAuto("Switching to pantheon screen.");
+                LogUtils_logHHAuto("Switching to pantheon screen.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDPantheon"));
                 return;
             }
@@ -13572,7 +13571,7 @@ class Pantheon {
     }
 }
 
-;// ./src/Module/PlaceOfPower.ts
+;// CONCATENATED MODULE: ./src/Module/PlaceOfPower.ts
 var PlaceOfPower_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -13618,7 +13617,7 @@ class PlaceOfPower {
         const onPowerplacePage = getPage() === ConfigHelper.getHHScriptVars("pagesIDPowerplacemain");
         const enoughGirl = Harem.getGirlCount() >= 10;
         if (!enoughGirl) {
-            logHHAuto('ERROR: not enough girl for POP');
+            LogUtils_logHHAuto('ERROR: not enough girl for POP');
         }
         // unlocked and the end of world 2
         const enoughProgress = getHHVars('Hero.infos.questing.id_world') > 2 && enoughGirl;
@@ -13689,7 +13688,7 @@ class PlaceOfPower {
     static addPopToUnableToStart(popIndex, message) {
         var _a;
         var popUnableToStart = (_a = getStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart)) !== null && _a !== void 0 ? _a : "";
-        logHHAuto(message);
+        LogUtils_logHHAuto(message);
         if (popUnableToStart === "") {
             setStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart, String(popIndex));
         }
@@ -13728,17 +13727,17 @@ class PlaceOfPower {
                 PlaceOfPower.removePopFromPopToStart(lockedPopIndex);
             }
             if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDPowerplacemain")) {
-                logHHAuto("Navigating to powerplaces main page.");
+                LogUtils_logHHAuto("Navigating to powerplaces main page.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDPowerplacemain"));
                 // return busy
                 return true;
             }
             else {
-                logHHAuto("On powerplaces main page.");
+                LogUtils_logHHAuto("On powerplaces main page.");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.Totalpops, $("div.pop_list div[pop_id]").length); //Count how many different POPs there are and store them locally
-                logHHAuto("totalpops : " + getStoredValue(HHStoredVarPrefixKey + TK.Totalpops));
+                LogUtils_logHHAuto("totalpops : " + getStoredValue(HHStoredVarPrefixKey + TK.Totalpops));
                 var newFilter = "";
                 if (getStoredValue(HHStoredVarPrefixKey + SK.autoPowerPlacesInverted) === "true") {
                     // starting from last one.
@@ -13761,14 +13760,14 @@ class PlaceOfPower {
                     // accounts with very large rosters). If another caller
                     // already holds the mutex we yield this tick.
                     if (!acquirePostMutex('pop:claim')) {
-                        logHHAuto('PoP: another POST in flight, deferring claim');
+                        LogUtils_logHHAuto('PoP: another POST in flight, deferring claim');
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                         return true;
                     }
                     const claimedPopId = $(buttonClaimQuery).first().parent().attr('pop_id');
                     const claimStart = Date.now();
                     $(buttonClaimQuery).first().trigger('click');
-                    logHHAuto("Claimed reward for PoP : " + claimedPopId);
+                    LogUtils_logHHAuto("Claimed reward for PoP : " + claimedPopId);
                     // The claim click fires an ajax.php POST. We must wait for
                     // that POST to complete before changing the page, otherwise
                     // window.location.href cancels the request (NS_BINDING_ABORTED)
@@ -13780,9 +13779,9 @@ class PlaceOfPower {
                     // bail out if the wait times out. Navigating anyway would
                     // cancel the still-open POST and re-introduce the race the
                     // wait is meant to prevent. AutoLoop will retry next tick.
-                    const claimIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                    const claimIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                     if (!claimIdle) {
-                        logHHAuto('PoP: claim AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, deferring popup/navigation');
+                        LogUtils_logHHAuto('PoP: claim AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, deferring popup/navigation');
                         releasePostMutex();
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                         return true;
@@ -13790,9 +13789,9 @@ class PlaceOfPower {
                     const claimDuration = Date.now() - claimStart;
                     RewardHelper.closeRewardPopupIfAny(); // Will refresh the page
                     // Wait again in case closing the popup itself fires a request.
-                    const popupIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                    const popupIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                     if (!popupIdle) {
-                        logHHAuto('PoP: popup-close AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, deferring navigation');
+                        LogUtils_logHHAuto('PoP: popup-close AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, deferring navigation');
                         releasePostMutex();
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                         return true;
@@ -13875,7 +13874,7 @@ class PlaceOfPower {
                 if (PopToStart.length === 0) {
                     deleteStoredValue(HHStoredVarPrefixKey + TK.PopUnableToStart);
                 }
-                logHHAuto("build popToStart : " + PopToStart);
+                LogUtils_logHHAuto("build popToStart : " + PopToStart);
                 setStoredValue(HHStoredVarPrefixKey + TK.PopToStart, JSON.stringify(PopToStart));
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                 setTimeout(autoLoop, Number(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili)));
@@ -13916,7 +13915,7 @@ class PlaceOfPower {
                     deleteStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);
                 }
                 else {
-                    logHHAuto("Navigating to powerplace" + index + " page.");
+                    LogUtils_logHHAuto("Navigating to powerplace" + index + " page.");
                     // Issue #1782: the game's 7.x optimization update renamed the
                     // Place-of-Power query param from `index` to `pop_id`
                     // (/activities.html?tab=pop&pop_id=N). Navigating with the old
@@ -13929,14 +13928,14 @@ class PlaceOfPower {
                 return true;
             }
             else {
-                logHHAuto("On powerplace" + index + " page.");
+                LogUtils_logHHAuto("On powerplace" + index + " page.");
                 deleteStoredValue(HHStoredVarPrefixKey + TK.PopTargeted);
                 const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
                 //getting reward in case failed on main page
                 var querySelectorText = "button[rel='pop_claim']:not([style*='display:none']):not([style*='display: none'])";
                 if ($(querySelectorText).length > 0) {
                     $(querySelectorText).trigger("click");
-                    logHHAuto("Claimed powerplace" + index);
+                    LogUtils_logHHAuto("Claimed powerplace" + index);
                     yield TimeHelper.sleep(randomInterval(200, 500));
                     if (getStoredValue(HHStoredVarPrefixKey + SK.autoPowerPlacesAll) !== "true") {
                         PlaceOfPower.cleanTempPopToStart();
@@ -13958,9 +13957,9 @@ class PlaceOfPower {
                     if (document.getElementsByClassName("pop_remaining").length > 0) {
                         if (document.getElementsByClassName("pop_remaining")[0].children.length > 0) {
                             const remainText = document.getElementsByClassName("pop_remaining")[0].children[0].innerText;
-                            logHHAuto("PoP remainText: " + remainText);
+                            LogUtils_logHHAuto("PoP remainText: " + remainText);
                             if (debugEnabled)
-                                logHHAuto("PoP acting-power-text: " + $('.acting-power-text').text());
+                                LogUtils_logHHAuto("PoP acting-power-text: " + $('.acting-power-text').text());
                             const hasRemainDays = remainText.includes("d");
                             // If for some reason we cannot parse the text, set time too high to start
                             // This may cause undesirable loops but for now is considered better than having girls stuck in PoP for days
@@ -13976,7 +13975,7 @@ class PlaceOfPower {
                                 querySelectorText = "button.blue_button_L[rel='pop_action']:not([disabled])";
                                 if ($(querySelectorText).length > 0) {
                                     document.querySelector(querySelectorText).click();
-                                    logHHAuto("Started powerplace" + index);
+                                    LogUtils_logHHAuto("Started powerplace" + index);
                                     yield TimeHelper.sleep(randomInterval(1000, 2000));
                                 }
                                 ;
@@ -13990,22 +13989,22 @@ class PlaceOfPower {
                 else {
                     if ($("div.grid_view div.not_selected").length === 1) {
                         $("div.grid_view div.not_selected").trigger("click");
-                        logHHAuto("Only one girl available for powerplace n°" + index + " assigning her.");
+                        LogUtils_logHHAuto("Only one girl available for powerplace n°" + index + " assigning her.");
                         yield TimeHelper.sleep(randomInterval(1200, 2000));
                     }
                     else {
                         querySelectorText = "button.blue_button_L[rel='pop_auto_assign']:not([disabled])";
                         if ($(querySelectorText).length > 0) {
                             document.querySelector(querySelectorText).click();
-                            logHHAuto("Autoassigned powerplace" + index);
+                            LogUtils_logHHAuto("Autoassigned powerplace" + index);
                             yield TimeHelper.sleep(randomInterval(1500, 2000));
                         }
                         else
-                            logHHAuto("No autoassign button for powerplace" + index);
+                            LogUtils_logHHAuto("No autoassign button for powerplace" + index);
                     }
                     querySelectorText = "button.blue_button_L[rel='pop_action']:not([disabled])";
                     if ($(querySelectorText).length > 0) {
-                        logHHAuto("Starting powerplace" + index);
+                        LogUtils_logHHAuto("Starting powerplace" + index);
                         // Issue #1782: the old code waited for an ajax whose data
                         // matched "PlaceOfPower&action=start". The game's 7.x update
                         // changed the start request signature, so that wait never
@@ -14015,9 +14014,9 @@ class PlaceOfPower {
                         // independent, timeout-bounded wait the claim path above uses,
                         // so a changed signature can never hang the loop again.
                         $(querySelectorText).trigger('click');
-                        const startIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                        const startIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                         if (!startIdle) {
-                            logHHAuto("PoP: start AJAX still busy after " + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + "ms for powerplace" + index);
+                            LogUtils_logHHAuto("PoP: start AJAX still busy after " + AJAX_IDLE_TIMEOUT_MS + "ms for powerplace" + index);
                         }
                     }
                     else if ($("button.blue_button_L[rel='pop_action'][disabled]").length > 0 && $("div.grid_view div.pop_selected").length > 0) {
@@ -14085,8 +14084,8 @@ class PlaceOfPower {
         const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
         let startTime = 0;
         if (debugEnabled) {
-            logHHAuto("PoP debug is enabled");
-            logHHAuto("PoP power needed:" + powerText);
+            LogUtils_logHHAuto("PoP debug is enabled");
+            LogUtils_logHHAuto("PoP power needed:" + powerText);
             startTime = performance.now();
         }
         let girlOptions = [];
@@ -14128,20 +14127,20 @@ class PlaceOfPower {
         });
         if (debugEnabled) {
             const endTime = performance.now();
-            logHHAuto("PoP precision: calculating this team took " + (endTime - startTime) + "ms");
+            LogUtils_logHHAuto("PoP precision: calculating this team took " + (endTime - startTime) + "ms");
             let teamPower = 0;
             chosenTeam.forEach((girl) => {
                 teamPower += girl.power;
             });
-            logHHAuto("PoP teamPower:" + teamPower);
-            logHHAuto("PoP teamScore:" + teamScore);
-            logHHAuto("PoP chosenTeam (" + chosenTeam.length + " girls):" + JSON.stringify(chosenTeam));
+            LogUtils_logHHAuto("PoP teamPower:" + teamPower);
+            LogUtils_logHHAuto("PoP teamScore:" + teamScore);
+            LogUtils_logHHAuto("PoP chosenTeam (" + chosenTeam.length + " girls):" + JSON.stringify(chosenTeam));
         }
         return chosenTeam;
     }
 }
 
-;// ./src/Module/Quest.ts
+;// CONCATENATED MODULE: ./src/Module/Quest.ts
 // Quest.ts -- Automates questing: accepts quests, handles quest steps, and buys
 // energy if configured.
 //
@@ -14190,8 +14189,16 @@ class QuestHelper {
         const id_quest = Number(getHHVars('Hero.infos.questing.id_quest'));
         const lastQuestId = ConfigHelper.getHHScriptVars("lastQuestId", false);
         const trollz = ConfigHelper.getHHScriptVars("trollzList");
-        if (id_world < (trollz.length) || lastQuestId > 0 && id_quest != lastQuestId) {
-            // Fix when KK quest url is world url
+        // Fix when KK quest url is world url: force the direct /quest/<id>
+        // URL only while the player still has a known next main quest ahead.
+        // Use `<` (not `!=`) against lastQuestId: once id_quest reaches or
+        // passes our last-known quest id, trust the game's current_url (a world
+        // url at end-of-content) instead of forcing navigation into the newest
+        // quest screen. A stale lastQuestId (game added quests we do not know
+        // about yet) otherwise force-navigates onto that end-of-content screen,
+        // where the unrecognized button trips the unknownQuestButton path and
+        // switches auto main/side quest off (regression of the issue #1773 fix).
+        if (id_world < (trollz.length) || (lastQuestId > 0 && id_quest < lastQuestId)) {
             mainQuestUrl = "/quest/" + id_quest;
         }
         return mainQuestUrl;
@@ -14206,11 +14213,11 @@ class QuestHelper {
             var quests = $('.side-quest:has(.slot) .side-quest-button');
             let navOk;
             if (quests.length > 0) {
-                logHHAuto("Navigating to side quest.");
+                LogUtils_logHHAuto("Navigating to side quest.");
                 navOk = gotoPage(quests.attr('href'));
             }
             else {
-                logHHAuto("All quests finished, setting timer to check back later!");
+                LogUtils_logHHAuto("All quests finished, setting timer to check back later!");
                 if (checkTimer('nextMainQuestAttempt')) {
                     setTimer('nextMainQuestAttempt', 604800);
                 } // 1 week delay
@@ -14235,7 +14242,7 @@ class QuestHelper {
                 navOk = gotoPage(nextQuestUrl);
             }
             else {
-                logHHAuto("All quests finished, setting timer to check back later!");
+                LogUtils_logHHAuto("All quests finished, setting timer to check back later!");
                 if (checkTimer('nextMainQuestAttempt')) {
                     setTimer('nextMainQuestAttempt', 604800); // 1 week delay
                 }
@@ -14253,7 +14260,7 @@ class QuestHelper {
         // new import cycles (RewardHelper -> EventModule -> ... -> Quest).
         const rewardConfirm = $('div#rewards_popup button.blue_button_L:not([disabled]):visible, div#rewards_popup button.purple_button_L:not([disabled]):visible');
         if (rewardConfirm.length > 0) {
-            logHHAuto("Close reward popup blocking the quest.");
+            LogUtils_logHHAuto("Close reward popup blocking the quest.");
             rewardConfirm.first().trigger('click');
             return true;
         }
@@ -14261,7 +14268,7 @@ class QuestHelper {
         var proceedButtonMatch = $("#controls button:not([class*='ad_']):not([style*='display:none']):not([style*='display: none'])");
         if (proceedButtonMatch.length === 0) {
             // Choice button 
-            logHHAuto("Search for choice buttons");
+            LogUtils_logHHAuto("Search for choice buttons");
             proceedButtonMatch = $(".buttons-container button:not([class*='ad_']):not([style*='display:none']):not([style*='display: none'])").first();
         }
         if (proceedButtonMatch.length === 0) {
@@ -14270,15 +14277,15 @@ class QuestHelper {
         var proceedType = proceedButtonMatch.attr("id");
         //console.log("DebugQuest proceedType : "+proceedType);
         if (proceedButtonMatch.length === 0) {
-            logHHAuto("Could not find resume button.");
+            LogUtils_logHHAuto("Could not find resume button.");
             return true;
         }
         else if (proceedButtonMatch.attr('disabled') && proceedType != "end_play") {
-            logHHAuto("Button is disabled for animation wait a bit.");
+            LogUtils_logHHAuto("Button is disabled for animation wait a bit.");
             return true;
         }
         if (proceedType === "free") {
-            logHHAuto("Proceeding for free.");
+            LogUtils_logHHAuto("Proceeding for free.");
             //setStoredValue"HHAuto_Temp_autoLoop", "false");
             //logHHAuto("setting autoloop to false");
             //proceedButtonMatch.click();
@@ -14295,10 +14302,10 @@ class QuestHelper {
                 // console.log("DebugQuest ENERGY for : "+proceedCost + " / " + energyCurrent);
                 if (proceedCost <= energyCurrent) {
                     // We have energy.
-                    logHHAuto("Spending " + proceedCost + " Energy to proceed.");
+                    LogUtils_logHHAuto("Spending " + proceedCost + " Energy to proceed.");
                 }
                 else {
-                    logHHAuto("Quest requires " + proceedCost + " Energy to proceed.");
+                    LogUtils_logHHAuto("Quest requires " + proceedCost + " Energy to proceed.");
                     setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "*" + proceedCost);
                     return true;
                 }
@@ -14307,10 +14314,10 @@ class QuestHelper {
                 console.log("DebugQuest MONEY for : " + proceedCost);
                 if (proceedCost <= moneyCurrent) {
                     // We have money.
-                    logHHAuto("Spending " + proceedCost + " Money to proceed.");
+                    LogUtils_logHHAuto("Spending " + proceedCost + " Money to proceed.");
                 }
                 else {
-                    logHHAuto("Need " + proceedCost + " Money to proceed.");
+                    LogUtils_logHHAuto("Need " + proceedCost + " Money to proceed.");
                     setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "$" + proceedCost);
                     return true;
                 }
@@ -14320,13 +14327,13 @@ class QuestHelper {
             //logHHAuto("setting autoloop to false");
         }
         else if (proceedType === "use_item") {
-            logHHAuto("Proceeding by using X" + Number($("#controls .item span").text()) + " of the required item.");
+            LogUtils_logHHAuto("Proceeding by using X" + Number($("#controls .item span").text()) + " of the required item.");
             //proceedButtonMatch.click();
             //setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "false");
             //logHHAuto("setting autoloop to false");
         }
         else if (proceedType === "battle") {
-            logHHAuto("Quest need battle...");
+            LogUtils_logHHAuto("Quest need battle...");
             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "battle");
             // Proceed to battle troll.
             //proceedButtonMatch.click();
@@ -14334,10 +14341,10 @@ class QuestHelper {
             //logHHAuto("setting autoloop to false");
         }
         else if (proceedType === "finish") {
-            logHHAuto("Reached end of current side quest. Proceeding to next.");
+            LogUtils_logHHAuto("Reached end of current side quest. Proceeding to next.");
         }
         else if (proceedType === "end_archive") {
-            logHHAuto("Reached end of current archive. Proceeding to next archive.");
+            LogUtils_logHHAuto("Reached end of current archive. Proceeding to next archive.");
             //setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "false");
             //logHHAuto("setting autoloop to false");
             //proceedButtonMatch.click();
@@ -14345,31 +14352,31 @@ class QuestHelper {
         else if (proceedType === "end_play") {
             let rewards = $('#popups[style="display: block;"]>#rewards_popup[style="display: block;"] button.blue_button_L[confirm_blue_button]');
             if (proceedButtonMatch.attr('disabled') && rewards.length > 0) {
-                logHHAuto("Reached end of current archive. Claim reward.");
+                LogUtils_logHHAuto("Reached end of current archive. Claim reward.");
                 rewards.click();
                 return true;
             }
-            logHHAuto("Reached end of current play. Proceeding to next play.");
+            LogUtils_logHHAuto("Reached end of current play. Proceeding to next play.");
             //setStoredValue(HHStoredVarPrefixKey+TK.autoLoop, "false");
             //logHHAuto("setting autoloop to false");
             //proceedButtonMatch.click();
         }
         else if (proceedType === "outfit") {
-            logHHAuto("Change outfit needed.");
+            LogUtils_logHHAuto("Change outfit needed.");
             // TODO manage ?
             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "outfit");
         }
         else {
-            logHHAuto("Could not identify given resume button.");
+            LogUtils_logHHAuto("Could not identify given resume button.");
             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "unknownQuestButton");
             return true;
         }
         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-        logHHAuto("setting autoloop to false");
+        LogUtils_logHHAuto("setting autoloop to false");
         setTimeout(function () {
             proceedButtonMatch.click();
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-            logHHAuto("setting autoloop to true");
+            LogUtils_logHHAuto("setting autoloop to true");
             setTimeout(autoLoop, randomInterval(800, 1200));
         }, randomInterval(500, 800));
         //setTimeout(function () {location.reload();},randomInterval(800,1500));
@@ -14378,7 +14385,7 @@ class QuestHelper {
 }
 QuestHelper.SITE_QUEST_PAGE = '/side-quests.html';
 
-;// ./src/Service/ParanoiaService.ts
+;// CONCATENATED MODULE: ./src/Service/ParanoiaService.ts
 // ParanoiaService.ts
 //
 // Anti-detection system that alternates between "burst" (active) and
@@ -14456,14 +14463,14 @@ class ParanoiaService {
                 let currValue = currentPSpendings.get(inSpendingFunction) || 0;
                 currValue -= inSpent;
                 if (currValue > 0) {
-                    logHHAuto("Spent " + inSpent + " " + inSpendingFunction + ", remains " + currValue + " before Paranoia.");
+                    LogUtils_logHHAuto("Spent " + inSpent + " " + inSpendingFunction + ", remains " + currValue + " before Paranoia.");
                     currentPSpendings.set(inSpendingFunction, currValue);
                 }
                 else {
                     currentPSpendings.delete(inSpendingFunction);
                 }
             }
-            logHHAuto("Remains to spend before Paranoia : " + JSON.stringify(currentPSpendings, replacerMap));
+            LogUtils_logHHAuto("Remains to spend before Paranoia : " + JSON.stringify(currentPSpendings, replacerMap));
             setStoredValue(HHStoredVarPrefixKey + TK.paranoiaSpendings, JSON.stringify(currentPSpendings, replacerMap));
         }
     }
@@ -14490,10 +14497,10 @@ class ParanoiaService {
                     if (totalPointsEndParanoia >= maxEnergy) {
                         paranoiaSpend = totalPointsEndParanoia - maxEnergy + 1;
                         paranoiaSpendings.set("challenge", paranoiaSpend);
-                        logHHAuto("Setting Paranoia spendings for league : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
+                        LogUtils_logHHAuto("Setting Paranoia spendings for league : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
                     }
                     else {
-                        logHHAuto("Setting Paranoia spendings for league : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
+                        LogUtils_logHHAuto("Setting Paranoia spendings for league : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
                     }
                 }
             }
@@ -14508,10 +14515,10 @@ class ParanoiaService {
                     if (totalPointsEndParanoia >= maxEnergy) {
                         paranoiaSpend = totalPointsEndParanoia - maxEnergy + 1;
                         paranoiaSpendings.set("quest", paranoiaSpend);
-                        logHHAuto("Setting Paranoia spendings for quest : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
+                        LogUtils_logHHAuto("Setting Paranoia spendings for quest : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
                     }
                     else {
-                        logHHAuto("Setting Paranoia spendings for quest : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
+                        LogUtils_logHHAuto("Setting Paranoia spendings for quest : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
                     }
                 }
             }
@@ -14525,17 +14532,17 @@ class ParanoiaService {
                 if (totalPointsEndParanoia >= maxEnergy) {
                     paranoiaSpend = totalPointsEndParanoia - maxEnergy + 1;
                     paranoiaSpendings.set("fight", paranoiaSpend);
-                    logHHAuto("Setting Paranoia spendings for troll : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
+                    LogUtils_logHHAuto("Setting Paranoia spendings for troll : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
                 }
                 else {
-                    logHHAuto("Setting Paranoia spendings for troll : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
+                    LogUtils_logHHAuto("Setting Paranoia spendings for troll : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
                 }
             }
             //if autoSeason is on
             if (ConfigHelper.getHHScriptVars('isEnabledSeason', false) && getStoredValue(HHStoredVarPrefixKey + SK.autoSeason) === "true") {
                 const seasonFocus = getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonFocus);
                 if (seasonFocus === "girl" || seasonFocus === "girlAndSkin") {
-                    logHHAuto('Season auto is on but Season focus restricts fights, no spending kisses.');
+                    LogUtils_logHHAuto('Season auto is on but Season focus restricts fights, no spending kisses.');
                 }
                 else {
                     maxPointsDuringParanoia = Math.ceil((toNextSwitch - Number(getHHVars('Hero.energies.kiss.next_refresh_ts'))) / Number(getHHVars('Hero.energies.kiss.seconds_per_point')));
@@ -14546,10 +14553,10 @@ class ParanoiaService {
                     if (totalPointsEndParanoia >= maxEnergy) {
                         paranoiaSpend = totalPointsEndParanoia - maxEnergy + 1;
                         paranoiaSpendings.set("kiss", paranoiaSpend);
-                        logHHAuto("Setting Paranoia spendings for Season : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
+                        LogUtils_logHHAuto("Setting Paranoia spendings for Season : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
                     }
                     else {
-                        logHHAuto("Setting Paranoia spendings for Season : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
+                        LogUtils_logHHAuto("Setting Paranoia spendings for Season : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
                     }
                 }
             }
@@ -14563,13 +14570,13 @@ class ParanoiaService {
                 if (totalPointsEndParanoia >= maxEnergy) {
                     paranoiaSpend = totalPointsEndParanoia - maxEnergy + 1;
                     paranoiaSpendings.set("worship", paranoiaSpend);
-                    logHHAuto("Setting Paranoia spendings for Pantheon : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
+                    LogUtils_logHHAuto("Setting Paranoia spendings for Pantheon : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") spending " + paranoiaSpend);
                 }
                 else {
-                    logHHAuto("Setting Paranoia spendings for Pantheon : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
+                    LogUtils_logHHAuto("Setting Paranoia spendings for Pantheon : " + currentEnergy + "+" + maxPointsDuringParanoia + " max gained in " + toNextSwitch + " secs => (" + totalPointsEndParanoia + "/" + maxEnergy + ") No spending ");
                 }
             }
-            logHHAuto("Setting paranoia spending to : " + JSON.stringify(paranoiaSpendings, replacerMap));
+            LogUtils_logHHAuto("Setting paranoia spending to : " + JSON.stringify(paranoiaSpendings, replacerMap));
             setStoredValue(HHStoredVarPrefixKey + TK.paranoiaSpendings, JSON.stringify(paranoiaSpendings, replacerMap));
         }
     }
@@ -14590,7 +14597,7 @@ class ParanoiaService {
             toNextSwitch = nextSwitchVal ? Number((Number(nextSwitchVal) - new Date().getTime()) / 1000) : randomInterval(Number(periods[period][0]), Number(periods[period][1]));
             //match mythic new wave with end of sleep
             if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollMythicByPassParanoia) === "true" && getTimer("eventMythicNextWave") !== -1 && toNextSwitch > getSecondsLeft("eventMythicNextWave")) {
-                logHHAuto("Forced rest only until next mythic wave.");
+                LogUtils_logHHAuto("Forced rest only until next mythic wave.");
                 toNextSwitch = getSecondsLeft("eventMythicNextWave");
             }
             //bypass Paranoia if ongoing mythic
@@ -14605,7 +14612,7 @@ class ParanoiaService {
                     //mythic onGoing and still have some fight above threshold
                     if (Troll.getEnergy() > 0) //trollThreshold)
                      {
-                        logHHAuto("Forced bypass Paranoia for mythic (can fight).");
+                        LogUtils_logHHAuto("Forced bypass Paranoia for mythic (can fight).");
                         setTimer('paranoiaSwitch', 60);
                         return;
                     }
@@ -14613,7 +14620,7 @@ class ParanoiaService {
                     // const Hero=getHero();
                     // var price=Hero.get_recharge_cost("fight");
                     if (Troll.canBuyFight(eventMythicGirl).canBuy && Troll.getEnergy() == 0) {
-                        logHHAuto("Forced bypass Paranoia for mythic (can buy).");
+                        LogUtils_logHHAuto("Forced bypass Paranoia for mythic (can buy).");
                         setTimer('paranoiaSwitch', 60);
                         return;
                     }
@@ -14636,14 +14643,14 @@ class ParanoiaService {
                 ParanoiaService.countParanoiaLoop++;
                 // logHHAuto(`checkParanoiaSpendings() = ${checkParanoiaSpendings()}, reached ${ParanoiaService.countParanoiaLoop} times`);
                 if (ParanoiaService.countParanoiaLoop > ParanoiaService.MAX_LOOP) {
-                    logHHAuto(`10 times flip without actions, clearParanoiaSpending and update (count: ${ParanoiaService.countParanoiaClear++}) `);
+                    LogUtils_logHHAuto(`10 times flip without actions, clearParanoiaSpending and update (count: ${ParanoiaService.countParanoiaClear++}) `);
                     ParanoiaService.clearParanoiaSpendings();
                     ParanoiaService.setParanoiaSpendings();
                 }
                 if (ParanoiaService.countParanoiaClear < ParanoiaService.MAX_LOOP)
                     return;
                 else
-                    logHHAuto(`10 times clearParanoiaSpending and update, let flip continue`);
+                    LogUtils_logHHAuto(`10 times clearParanoiaSpending and update, let flip continue`);
             }
             else {
                 //refresh remaining
@@ -14656,14 +14663,14 @@ class ParanoiaService {
             //if (getPage()!=ConfigHelper.getHHScriptVars("pagesIDHome")) return;
             //going to work
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("setting autoloop to false");
+            LogUtils_logHHAuto("setting autoloop to false");
             setStoredValue(HHStoredVarPrefixKey + TK.burst, "true");
             var b = S1[0][0][0].split('-');
             toNextSwitch = randomInterval(Number(b[0]), Number(b[1]));
         }
         var ND = new Date().getTime() + toNextSwitch * 1000;
         var message = period + (burst ? " rest" : " burst");
-        logHHAuto("PARANOIA: " + message);
+        LogUtils_logHHAuto("PARANOIA: " + message);
         setStoredValue(HHStoredVarPrefixKey + TK.pinfo, message);
         setTimer('paranoiaSwitch', toNextSwitch);
         //force recheck non completed event after paranoia
@@ -14713,7 +14720,7 @@ function reviverMap(key, value) {
     return value;
 }
 
-;// ./src/Module/PentaDrill.ts
+;// CONCATENATED MODULE: ./src/Module/PentaDrill.ts
 var PentaDrill_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -14812,7 +14819,7 @@ class PentaDrill {
         const needBoosterToFight = getStoredValue(HHStoredVarPrefixKey + SK.autoPentaDrillBoostedOnly) === "true";
         const haveBoosterEquiped = Booster.haveBoosterEquiped();
         if (checkTimer('nextPentaDrillTime') && energyAboveThreshold && needBoosterToFight && !haveBoosterEquiped) {
-            logHHAuto('Time for PentaDrill but no booster equipped');
+            LogUtils_logHHAuto('Time for PentaDrill but no booster equipped');
         }
         return (checkTimer('nextPentaDrillTime') && energyAboveThreshold && (needBoosterToFight && haveBoosterEquiped || !needBoosterToFight)) || paranoiaSpending;
     }
@@ -14822,12 +14829,12 @@ class PentaDrill {
         try {
             const opponents = unsafeWindow.opponents_list;
             if (!opponents || opponents.length === 0) {
-                logHHAuto("PentaDrill : no opponents available to choose from.");
+                LogUtils_logHHAuto("PentaDrill : no opponents available to choose from.");
                 return undefined;
             }
             const lowestPowerOpponent = [...opponents].sort((a, b) => a.player.total_power - b.player.total_power)[0];
             if (debugEnabled) {
-                logHHAuto(`Lowest Penta drill opponent is ${lowestPowerOpponent.player.nickname} with power ${lowestPowerOpponent.player.total_power}`);
+                LogUtils_logHHAuto(`Lowest Penta drill opponent is ${lowestPowerOpponent.player.nickname} with power ${lowestPowerOpponent.player.total_power}`);
             }
             const opponentButton = $('.opponent-info-container .change-team-container a[href*=' + ((_a = lowestPowerOpponent.player) === null || _a === void 0 ? void 0 : _a.id_fighter) + ']');
             const opponentBlock = opponentButton.parent().parent();
@@ -14836,21 +14843,21 @@ class PentaDrill {
             return lowestPowerOpponent;
         }
         catch (err) {
-            logHHAuto("Catched error : Could not choose Penta drill opponent : " + err);
+            LogUtils_logHHAuto("Catched error : Could not choose Penta drill opponent : " + err);
         }
         return undefined;
     }
     static run() {
         return PentaDrill_awaiter(this, void 0, void 0, function* () {
-            logHHAuto("Performing auto PentaDrill.");
+            LogUtils_logHHAuto("Performing auto PentaDrill.");
             // Confirm if on correct screen.
             //const Hero = getHero();
             const page = getPage();
             if (page === ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena")) {
-                logHHAuto("On PentaDrill arena page.");
+                LogUtils_logHHAuto("On PentaDrill arena page.");
                 const chosenOpponent = PentaDrill.moduleSimPentaDrillBattle();
                 if (chosenOpponent === undefined) {
-                    logHHAuto("PentaDrill : was not able to choose opponent.");
+                    LogUtils_logHHAuto("PentaDrill : was not able to choose opponent.");
                     setTimer('nextPentaDrillTime', randomInterval(30 * 60, 35 * 60));
                     return false;
                 }
@@ -14863,11 +14870,11 @@ class PentaDrill {
                     }
                     const toGoTo = opponentButton.attr('href') || '';
                     if (toGoTo === '') {
-                        logHHAuto('PentaDrill : Error getting opponent location');
+                        LogUtils_logHHAuto('PentaDrill : Error getting opponent location');
                         setTimer('nextPentaDrillTime', randomInterval(30 * 60, 35 * 60));
                         return false;
                     }
-                    logHHAuto(`Going to crush : ${chosenOpponent.player.nickname} (${chosenID})`);
+                    LogUtils_logHHAuto(`Going to crush : ${chosenOpponent.player.nickname} (${chosenID})`);
                     // C1: safeNavigateHref handles autoLoop disable + AJAX-idle
                     // wait + URL change atomically. The duplicate setStoredValue
                     // and log line is removed because safeNavigateHref does that
@@ -14878,16 +14885,16 @@ class PentaDrill {
                 }
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDPentaDrillPreBattle")) {
-                logHHAuto("On PentaDrill pre battle page.");
+                LogUtils_logHHAuto("On PentaDrill pre battle page.");
                 const performButton = $('#perform_opponent:not([disabled])');
                 if (performButton.length === 0) {
-                    logHHAuto('PentaDrill : Perform button is disabled, can\'t fight now.');
+                    LogUtils_logHHAuto('PentaDrill : Perform button is disabled, can\'t fight now.');
                     setTimer('nextPentaDrillTime', randomInterval(30 * 60, 35 * 60));
                     return false;
                 }
                 performButton.trigger('click');
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("setting autoloop to false");
                 yield TimeHelper.sleep(PentaDrill.getActionDelayMs());
                 //setTimer('nextPentaDrillTime',10);
                 return true;
@@ -14895,9 +14902,9 @@ class PentaDrill {
             else {
                 const current_drill = PentaDrill.getEnergy();
                 // Switch to the correct screen
-                logHHAuto("Remaining drill : " + current_drill);
+                LogUtils_logHHAuto("Remaining drill : " + current_drill);
                 if (current_drill > 0) {
-                    logHHAuto("Switching to PentaDrill Arena screen.");
+                    LogUtils_logHHAuto("Switching to PentaDrill Arena screen.");
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"));
                 }
                 else {
@@ -14923,7 +14930,7 @@ class PentaDrill {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            logHHAuto(`ERROR in display PentaDrill rewards: ${message}`);
+            LogUtils_logHHAuto(`ERROR in display PentaDrill rewards: ${message}`);
         }
     }
     static getNotClaimedRewards() {
@@ -14941,10 +14948,10 @@ class PentaDrill {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPentaDrill")) {
             PentaDrill.getRemainingTime();
             const PentaDrillEnd = getSecondsLeft("pentaDrillRemainingTime");
-            logHHAuto("PentaDrill end in " + TimeHelper.debugDate(PentaDrillEnd));
+            LogUtils_logHHAuto("PentaDrill end in " + TimeHelper.debugDate(PentaDrillEnd));
             if (checkTimer('nextPentaDrillCollectAllTime') && PentaDrillEnd < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoPentaDrillCollectAll) === "true") {
                 if ($(ConfigHelper.getHHScriptVars("selectorClaimAllRewards")).length > 0) {
-                    logHHAuto("Going to collect all PentaDrill item at once.");
+                    LogUtils_logHHAuto("Going to collect all PentaDrill item at once.");
                     setTimeout(function () {
                         $(ConfigHelper.getHHScriptVars("selectorClaimAllRewards"))[0].click();
                         setTimer('nextPentaDrillCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180)); // Add timer to check again later if there is new items to collect
@@ -14957,15 +14964,15 @@ class PentaDrill {
                 }
             }
             if (checkTimer('nextPentaDrillCollectTime') && getStoredValue(HHStoredVarPrefixKey + SK.autoPentaDrillCollect) === "true") {
-                logHHAuto("Going to collect PentaDrill.");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("Going to collect PentaDrill.");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 const isPassPaid = $("#get_penta_pass_btn:visible").length === 0;
                 const freeSlotQuery = ".free_reward .slot";
                 const paidSlotQuery = ".pass_reward .slot";
                 const buttonsToCollect = [];
                 const listPentaDrillTiersToClaim = $(".rewards_container_penta_drill .rewards_pair:has(.btn_claim)");
-                logHHAuto('Found ' + listPentaDrillTiersToClaim.length + ' rewards available for collection before filtering');
+                LogUtils_logHHAuto('Found ' + listPentaDrillTiersToClaim.length + ' rewards available for collection before filtering');
                 for (let currentTier = 0; currentTier < listPentaDrillTiersToClaim.length; currentTier++) {
                     const currentButton = $("button[rel='claim']", listPentaDrillTiersToClaim[currentTier])[0];
                     const currentTierNb = currentButton.getAttribute("tier");
@@ -14977,22 +14984,22 @@ class PentaDrill {
                             const paidSlotType = RewardHelper.getRewardTypeBySlot($(paidSlotQuery, listPentaDrillTiersToClaim[currentTier])[0]);
                             if (rewardsToCollect.includes(paidSlotType)) {
                                 buttonsToCollect.push(currentButton);
-                                logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
+                                LogUtils_logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
                             }
                             else {
-                                logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
+                                LogUtils_logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
                             }
                         }
                         else {
                             buttonsToCollect.push(currentButton);
-                            logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
+                            LogUtils_logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
                         }
                     }
                 }
                 if (buttonsToCollect.length > 0) {
                     function collectPentaDrillRewards() {
                         function collectionFinished() {
-                            logHHAuto("PentaDrill collection finished.");
+                            LogUtils_logHHAuto("PentaDrill collection finished.");
                             setTimer('nextPentaDrillCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         }
@@ -15003,7 +15010,7 @@ class PentaDrill {
                             }
                             function collectNextTier() {
                                 if (buttonsToCollect.length > 0) {
-                                    logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
+                                    LogUtils_logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
                                     buttonsToCollect[0].click();
                                     buttonsToCollect.shift();
                                     setTimeout(closeRewardAndCollectagain, randomInterval(300, 500));
@@ -15021,7 +15028,7 @@ class PentaDrill {
                     return true;
                 }
                 else {
-                    logHHAuto("No PentaDrill collection to do.");
+                    LogUtils_logHHAuto("No PentaDrill collection to do.");
                     setTimer('nextPentaDrillCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     setTimer('nextPentaDrillCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -15031,7 +15038,7 @@ class PentaDrill {
             return false;
         }
         else {
-            logHHAuto("Switching to PentaDrill Rewards screen.");
+            LogUtils_logHHAuto("Switching to PentaDrill Rewards screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrill"));
             return true;
         }
@@ -15056,7 +15063,7 @@ class PentaDrill {
     }
 }
 
-;// ./src/Module/Contest.ts
+;// CONCATENATED MODULE: ./src/Module/Contest.ts
 // Contest.ts -- Handles contest reward claiming and "wait for contest" logic.
 //
 // Contests are timed competitive events with milestone rewards. This module
@@ -15085,20 +15092,20 @@ class Contest {
     }
     static run() {
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDContests")) {
-            logHHAuto("Navigating to contests page.");
+            LogUtils_logHHAuto("Navigating to contests page.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));
             // return busy
             return true;
         }
         else {
-            logHHAuto("On contests page.");
-            logHHAuto("Collecting finished contests's reward.");
+            LogUtils_logHHAuto("On contests page.");
+            LogUtils_logHHAuto("Collecting finished contests's reward.");
             const contest_list = Contest.getClaimsButton();
-            logHHAuto(`Found ${contest_list.length} contest to be collected`);
+            LogUtils_logHHAuto(`Found ${contest_list.length} contest to be collected`);
             if (contest_list.length > 0) {
                 const firstContestEnded = contest_list.first();
                 const contestContainer = firstContestEnded.parents('.contest');
-                logHHAuto(`Collected contest id : ${contestContainer === null || contestContainer === void 0 ? void 0 : contestContainer.attr('id_contest')}.`);
+                LogUtils_logHHAuto(`Collected contest id : ${contestContainer === null || contestContainer === void 0 ? void 0 : contestContainer.attr('id_contest')}.`);
                 firstContestEnded.trigger('click');
                 // Remove the claimed contest from the DOM so setTimers() won't
                 // see stale claim buttons and create an infinite collect loop.
@@ -15121,7 +15128,7 @@ class Contest {
     }
     static setTimers() {
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDContests")) {
-            logHHAuto("Navigating to contests page.");
+            LogUtils_logHHAuto("Navigating to contests page.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDContests"));
             // return busy
             return true;
@@ -15158,7 +15165,7 @@ class Contest {
                 }
             }
             catch (err) {
-                logHHAuto('ERROR getting next contest timers, ignore...');
+                LogUtils_logHHAuto('ERROR getting next contest timers, ignore...');
                 setTimer('contestRemainingTime', 3600);
                 setTimer('nextContestTime', 4000);
                 setTimer('nextContestCollectTime', 4000);
@@ -15201,7 +15208,7 @@ class Contest {
     }
 }
 
-;// ./src/Module/Labyrinth.pure.ts
+;// CONCATENATED MODULE: ./src/Module/Labyrinth.pure.ts
 // Labyrinth.pure.ts -- Pure decision logic for the labyrinth path pipeline
 // and the "find better option" selector.
 //
@@ -15403,7 +15410,7 @@ function decideBetterOption(state) {
     return chosenOption;
 }
 
-;// ./src/Module/RelicManager.ts
+;// CONCATENATED MODULE: ./src/Module/RelicManager.ts
 var RelicManager_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -15533,10 +15540,10 @@ class RelicManager {
                     // Marker not present yet: derive the same choice and use its slot.
                     const relics = this.parseRelics();
                     if (this.debugEnabled)
-                        logHHAuto('relics', relics);
+                        LogUtils_logHHAuto('relics', relics);
                     const relic = this.chooseRelic(relics);
                     if (this.debugEnabled)
-                        logHHAuto('Selecting', relic);
+                        LogUtils_logHHAuto('Selecting', relic);
                     chosenContainer = relic.slot;
                 }
                 const claimBtn = $('.relic-card-buttons .claim-relic-btn', chosenContainer).first();
@@ -15544,14 +15551,14 @@ class RelicManager {
                     throw new Error('no claim button in chosen relic container');
                 }
                 if (this.debugEnabled)
-                    logHHAuto('Claiming relic-id', claimBtn.attr('relic-id'));
+                    LogUtils_logHHAuto('Claiming relic-id', claimBtn.attr('relic-id'));
                 // Native click: a jQuery .trigger('click') does not actuate the
                 // game's per-card claim and the leftmost relic gets claimed instead
                 // (issue #1716). A real DOM click on the marked card's button does.
                 claimBtn[0].click();
             }
             catch (err) {
-                logHHAuto('Error selecting relics, select first no girl relic');
+                LogUtils_logHHAuto('Error selecting relics, select first no girl relic');
                 (_a = $('#labyrinth_reward_popup #reward_holder .relic-container:not(.large-card) .relic-card-buttons .claim-relic-btn').get(0)) === null || _a === void 0 ? void 0 : _a.click();
             }
             yield TimeHelper.sleep(randomInterval(800, 1300));
@@ -15566,7 +15573,7 @@ class RelicManager {
     }
 }
 
-;// ./src/Module/Labyrinth.ts
+;// CONCATENATED MODULE: ./src/Module/Labyrinth.ts
 var Labyrinth_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -15619,7 +15626,7 @@ class Labyrinth {
         if (floorDom.length > 0) {
             floor = Number($('#labyrinth-tabs .tab-switcher-fade-in .floor-number-text').text());
             if (isNaN(floor) || floor === 0) {
-                logHHAuto("Error getting floor");
+                LogUtils_logHHAuto("Error getting floor");
                 floor = 0;
             }
         }
@@ -15664,7 +15671,7 @@ class Labyrinth {
                     }
                 }
                 catch (_a) {
-                    logHHAuto('Error during changing low power girls');
+                    LogUtils_logHHAuto('Error during changing low power girls');
                 }
             }
         });
@@ -15678,7 +15685,7 @@ class Labyrinth {
             // 5   3
             //   4
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("setting autoloop to false");
+            LogUtils_logHHAuto("setting autoloop to false");
             $(`.${Labyrinth.BUILD_BUTTON_ID}`).attr('disabled', 'disabled');
             // Fill any empty slots via the game's auto-fill first, then optimize
             // positions below; class swaps alone cannot guarantee a full team.
@@ -15718,7 +15725,7 @@ class Labyrinth {
                 yield Labyrinth._selectGirl(6, backGirls[backGirlIndex++]);
             $(`.${Labyrinth.BUILD_BUTTON_ID}`).removeAttr('disabled');
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-            logHHAuto("setting autoloop to true");
+            LogUtils_logHHAuto("setting autoloop to true");
         });
     }
     static isSelectedGirl(girlId, position = 0) {
@@ -15762,12 +15769,12 @@ class Labyrinth {
         for (let i = 0; i < girls.length && hardCoreGirls.length <= numberOfGirls; i++) {
             const tooltipData = $('.girl_img', $(girls[i])).attr(ConfigHelper.getHHScriptVars('girlToolTipData')) || '';
             if (tooltipData === '') {
-                logHHAuto('ERROR, no girl information found');
+                LogUtils_logHHAuto('ERROR, no girl information found');
                 continue;
             }
             const obj = safeJsonParse(tooltipData, null);
             if (obj === null) {
-                logHHAuto('ERROR, failed to parse girl information');
+                LogUtils_logHHAuto('ERROR, failed to parse girl information');
                 continue;
             }
             const remainingEgo = Number($('.ego-bar-container span', $(girls[i])).text().replace('%', ''));
@@ -15785,7 +15792,7 @@ class Labyrinth {
             const id_girl = $(haremGirls[i]).attr('id_girl');
             const remainingEgo = Number($('.ego-bar-container span', $(haremGirls[i])).text().replace('%', ''));
             if (remainingEgo > 0 && remainingEgo < 30) {
-                logHHAuto(`Adding low power girl ${id_girl}`);
+                LogUtils_logHHAuto(`Adding low power girl ${id_girl}`);
                 lowPowerGirls.push($(teamGirlSelector + '[data-girl-id="' + id_girl + '"]'));
             }
         }
@@ -15798,9 +15805,9 @@ class Labyrinth {
                 const relicManager = new RelicManager();
                 const relics = relicManager.parseRelics();
                 if (relics.length > 1) {
-                    logHHAuto("relics", relics);
+                    LogUtils_logHHAuto("relics", relics);
                     const relic = relicManager.chooseRelic(relics);
-                    logHHAuto("relic", relic);
+                    LogUtils_logHHAuto("relic", relic);
                     GM_addStyle('.relicChosen {width: 25px; top: 0px; position: absolute; left: 197px;}');
                     relic.slot.append(`<img class="relicChosen" src=${ConfigHelper.getHHScriptVars("powerCalcImages").chosen}>`);
                 }
@@ -15808,7 +15815,7 @@ class Labyrinth {
             if ($('.labChosen').length > 0 || Labyrinth.isEnded()) {
                 return;
             }
-            logHHAuto("On Labyrinth page.");
+            LogUtils_logHHAuto("On Labyrinth page.");
             GM_addStyle('.labChosen {width: 25px; top: 55px; position: relative; left: 35px;}');
             GM_addStyle('.pathChosen {border: 1px solid green; border-radius: 40px;}');
             const NB_ROW = 11;
@@ -15825,7 +15832,7 @@ class Labyrinth {
                 }
                 const choosenOption = Labyrinth.findBetter(options);
                 if (choosenOption) {
-                    logHHAuto("Row " + currentLevel + ". chosen " + JSON.stringify(choosenOption));
+                    LogUtils_logHHAuto("Row " + currentLevel + ". chosen " + JSON.stringify(choosenOption));
                     Labyrinth.appendChoosenTag(choosenOption);
                     break;
                 }
@@ -15883,7 +15890,7 @@ class Labyrinth {
             //logHHAuto('labyrinthTimer', labyrinthTimer);
             return labyrinthTimer;
         }
-        logHHAuto('ERROR: can\'t get labyrinth reset time, default to maxCollectionDelay');
+        LogUtils_logHHAuto('ERROR: can\'t get labyrinth reset time, default to maxCollectionDelay');
         return ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
     }
     static findBetter(options) {
@@ -15891,11 +15898,11 @@ class Labyrinth {
         const haveGirlWounded = (unsafeWindow.girl_squad || []).filter((girl) => girl.remaining_ego_percent < 100).length > 0;
         const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
         if (debugEnabled)
-            logHHAuto("Options " + JSON.stringify(options));
+            LogUtils_logHHAuto("Options " + JSON.stringify(options));
         if (debugEnabled)
-            logHHAuto("haveGirlWounded " + haveGirlWounded);
+            LogUtils_logHHAuto("haveGirlWounded " + haveGirlWounded);
         if (debugEnabled)
-            logHHAuto("chooseMoreReward " + chooseMoreReward);
+            LogUtils_logHHAuto("chooseMoreReward " + chooseMoreReward);
         const liteOptions = options.map(option => ({
             opponentDifficulty: option.opponentDifficulty,
             isTreasure: option.isTreasure,
@@ -15913,7 +15920,7 @@ class Labyrinth {
             floor: Labyrinth.getCurrentFloorNumber(),
         });
         if (debugEnabled)
-            logHHAuto("Options after filter (handled by Labyrinth.pure)");
+            LogUtils_logHHAuto("Options after filter (handled by Labyrinth.pure)");
         return chosen === null ? null : chosen.__orig;
     }
     static appendChoosenTag(option) {
@@ -15951,7 +15958,7 @@ class Labyrinth {
 Labyrinth.HAREM_SELECTED_GIRLS = '.harem-panel-girls .harem-girl-container.selected'; // in my squad
 Labyrinth.BUILD_BUTTON_ID = 'hhAutoLabyTeam';
 
-;// ./src/Service/BlockDisabledState.ts
+;// CONCATENATED MODULE: ./src/Service/BlockDisabledState.ts
 // BlockDisabledState.ts -- read/clear the watchdog auto-disable + failure-count
 // state of the block scheduler (v7.37.0, ADR-001 R5.6).
 //
@@ -15996,7 +16003,7 @@ function reactivateBlock(blockId) {
         setStoredValue(HHStoredVarPrefixKey + TK.blockFailureCount, JSON.stringify(counts));
 }
 
-;// ./src/Service/InfoService.ts
+;// CONCATENATED MODULE: ./src/Service/InfoService.ts
 // InfoService.ts
 //
 // Renders the floating "pInfo" overlay panel that shows the current
@@ -16090,7 +16097,7 @@ function updateData() {
     });
     const pInfo = document.getElementById('pInfo');
     if (pInfo == null) {
-        logHHAuto('ERROR pInfo element not found');
+        LogUtils_logHHAuto('ERROR pInfo element not found');
         return;
     }
     if (getStoredValue(HHStoredVarPrefixKey + SK.showInfo) == "true") // && busy==false // && getPage()==ConfigHelper.getHHScriptVars("pagesIDHome")
@@ -16210,7 +16217,7 @@ function updateData() {
     }
 }
 
-;// ./src/Service/MouseService.ts
+;// CONCATENATED MODULE: ./src/Service/MouseService.ts
 // MouseService.ts
 //
 // Pauses automation while the user is actively interacting with the
@@ -16294,7 +16301,7 @@ function bindMouseEvents() {
     document.onmouseup = function () { makeMouseBusy(mouseTimeoutVal); };
 }
 
-;// ./src/Service/AutoLoop.pure.ts
+;// CONCATENATED MODULE: ./src/Service/AutoLoop.pure.ts
 // AutoLoop.pure.ts -- Pure decision logic for the auto-loop scheduler.
 //
 // Two helpers:
@@ -16336,7 +16343,7 @@ function shouldRunStandardHandler(g) {
     return true;
 }
 
-;// ./src/Module/Spreadsheet.ts
+;// CONCATENATED MODULE: ./src/Module/Spreadsheet.ts
 var Spreadsheet_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -16392,7 +16399,7 @@ Spreadsheet.LINK_CLASS = 'hhauto-spreadsheet-link';
 Spreadsheet.BDSMPP_CLASS = 'script-blessing-spreadsheet-link';
 Spreadsheet.POPUP_SELECTOR = '#blessings_popup .blessings_wrapper';
 
-;// ./src/Service/BlessingService.ts
+;// CONCATENATED MODULE: ./src/Service/BlessingService.ts
 // BlessingService.ts -- Loads and caches weekly blessing data.
 //
 // Blessings change weekly and affect girl stats. This service loads
@@ -16418,17 +16425,17 @@ class BlessingService {
     static fetchAndCache() {
         const ajax = getHHAjax();
         if (!ajax) {
-            logHHAuto('BlessingService: hh_ajax not available');
+            LogUtils_logHHAuto('BlessingService: hh_ajax not available');
             return;
         }
-        logHHAuto('BlessingService: fetching blessings...');
+        LogUtils_logHHAuto('BlessingService: fetching blessings...');
         ajax({ action: 'get_girls_blessings' }, (response) => {
             if (!response || !response.success) {
-                logHHAuto('BlessingService: fetch failed: ' + JSON.stringify(response));
+                LogUtils_logHHAuto('BlessingService: fetch failed: ' + JSON.stringify(response));
                 return;
             }
-            logHHAuto('BlessingService: response keys: ' + Object.keys(response).join(', '));
-            logHHAuto('BlessingService: raw (500 chars): ' + JSON.stringify(response).substring(0, 500));
+            LogUtils_logHHAuto('BlessingService: response keys: ' + Object.keys(response).join(', '));
+            LogUtils_logHHAuto('BlessingService: raw (500 chars): ' + JSON.stringify(response).substring(0, 500));
             const blessingData = {
                 timestamp: Date.now(),
                 raw: response,
@@ -16437,7 +16444,7 @@ class BlessingService {
                 blessedElement: BlessingService.parseElement(response),
             };
             setStoredValue(HHStoredVarPrefixKey + TK.blessingsCache, JSON.stringify(blessingData));
-            logHHAuto('BlessingService: cached. Traits: ' + blessingData.blessedTraits.join(', ') + ', Element: ' + (blessingData.blessedElement || 'unknown'));
+            LogUtils_logHHAuto('BlessingService: cached. Traits: ' + blessingData.blessedTraits.join(', ') + ', Element: ' + (blessingData.blessedElement || 'unknown'));
         });
     }
     static getCached() {
@@ -16656,7 +16663,7 @@ class BlessingService {
                 const ratio = topCount / group.length;
                 const lead = secondCount === 0 ? Infinity : topCount / secondCount;
                 if (ratio >= 0.8 || lead >= 3) {
-                    logHHAuto('BlessingService: resolved ' + blessedCategory + ' -> hex="' + topVal + '" (' + topCount + '/' + group.length + ' girls, lead=' + (lead === Infinity ? 'inf' : lead.toFixed(1)) + ')');
+                    LogUtils_logHHAuto('BlessingService: resolved ' + blessedCategory + ' -> hex="' + topVal + '" (' + topCount + '/' + group.length + ' girls, lead=' + (lead === Infinity ? 'inf' : lead.toFixed(1)) + ')');
                     return topVal;
                 }
             }
@@ -16892,7 +16899,7 @@ class BlessingService {
     }
 }
 
-;// ./src/model/Champion.ts
+;// CONCATENATED MODULE: ./src/model/Champion.ts
 // Model representing a Champion (boss encounter) in the game.
 // Tracks the champion's index, timer state, whether it has been started,
 // impression level, filter membership, and associated event girls.
@@ -16912,7 +16919,7 @@ class ChampionModel {
     }
 }
 
-;// ./src/Module/Champion.pure.ts
+;// CONCATENATED MODULE: ./src/Module/Champion.pure.ts
 // Champion.pure.ts -- Pure decision logic for the champions auto module.
 //
 // Extracted from Champion.findNextChamptionTime so the timer scan can be
@@ -16991,7 +16998,7 @@ function isEventGirlAvailableOnLockedStage(parsedFirstLockedStage, targetGirlIds
     return false;
 }
 
-;// ./src/Module/Champion.ts
+;// CONCATENATED MODULE: ./src/Module/Champion.ts
 var Champion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -17092,7 +17099,7 @@ class Champion {
                 const $girl = $('.girl-box__draggable ', $(girlBox));
                 const girlData = champTeam[girlIndex];
                 if (girlData.id_girl != $girl.attr('id_girl')) {
-                    logHHAuto('Invalid girls ' + girlData.id_girl + 'vs' + $girl.attr('id_girl'));
+                    LogUtils_logHHAuto('Invalid girls ' + girlData.id_girl + 'vs' + $girl.attr('id_girl'));
                     return;
                 }
                 const poseNumber = girlData.figure;
@@ -17141,7 +17148,7 @@ class Champion {
                     const $girl = $('.girl-box__draggable ', $(girlBox));
                     const girlData = champTeam[girlIndex];
                     if (girlData.id_girl != $girl.attr('id_girl')) {
-                        logHHAuto('Invalid girls ' + girlData.id_girl + 'vs' + $girl.attr('id_girl'));
+                        LogUtils_logHHAuto('Invalid girls ' + girlData.id_girl + 'vs' + $girl.attr('id_girl'));
                         return;
                     }
                     const poseNumber = girlData.figure;
@@ -17179,7 +17186,7 @@ class Champion {
                         }
                     }
                 }
-                logHHAuto('Team of girls ' + teamGirls);
+                LogUtils_logHHAuto('Team of girls ' + teamGirls);
                 var toggleSelectGirl = function (girlId, girlDraggable, timer = 1000) {
                     setTimeout(function () {
                         console.log("click " + girlId, girlDraggable);
@@ -17192,7 +17199,7 @@ class Champion {
                     const selectedGirlId = $(girlBox).attr('id_girl');
                     if (teamGirls.indexOf(selectedGirlId) < 0) {
                         girlsClicked = true;
-                        logHHAuto("Unselected as out of the team :" + selectedGirlId);
+                        LogUtils_logHHAuto("Unselected as out of the team :" + selectedGirlId);
                         toggleSelectGirl(selectedGirlId, $(girlBox), randomInterval(300, 600));
                     }
                 });
@@ -17202,11 +17209,11 @@ class Champion {
                         var girlDraggable = $('.girl-box__draggable[id_girl="' + teamGirls[i] + '"]');
                         if (!girlDraggable.hasClass('selected')) {
                             girlsClicked = true;
-                            logHHAuto("Girl not selected :" + teamGirls[i]);
+                            LogUtils_logHHAuto("Girl not selected :" + teamGirls[i]);
                             toggleSelectGirl(teamGirls[i], girlDraggable, randomInterval(800, 1200));
                         }
                         else {
-                            logHHAuto("Girl already selected :" + teamGirls[i]);
+                            LogUtils_logHHAuto("Girl already selected :" + teamGirls[i]);
                         }
                     }
                 }
@@ -17216,21 +17223,21 @@ class Champion {
                         if ($(newDraftButtonQuery).length === 0)
                             return;
                         if (!acquirePostMutex('champion:newDraft')) {
-                            logHHAuto('Champion: another POST in flight, skipping new-draft click this iteration');
+                            LogUtils_logHHAuto('Champion: another POST in flight, skipping new-draft click this iteration');
                             return;
                         }
                         const newDraftStart = Date.now();
                         $(newDraftButtonQuery).trigger('click');
-                        const newDraftIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                        const newDraftIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                         const newDraftDuration = Date.now() - newDraftStart;
                         releasePostMutex();
                         if (newDraftIdle)
                             yield awaitServerSettleAfterPost(newDraftDuration);
                         else
-                            logHHAuto('Champion: new-draft AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                            LogUtils_logHHAuto('Champion: new-draft AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                     });
                 }, newDraftInterval);
-                logHHAuto("Free drafts remanings :" + freeDrafts);
+                LogUtils_logHHAuto("Free drafts remanings :" + freeDrafts);
                 counterLoop++;
                 if (freeDrafts > 0 && counterLoop <= maxLoops) {
                     setTimeout(selectGirls, randomInterval(6000, 9000)); // Wait animation
@@ -17242,26 +17249,26 @@ class Champion {
                         if (acquirePostMutex('champion:confirmDraft')) {
                             const confirmStart = Date.now();
                             $(confirmDraftButtonQuery).trigger('click');
-                            const confirmIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                            const confirmIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                             const confirmDuration = Date.now() - confirmStart;
                             releasePostMutex();
                             if (confirmIdle)
                                 yield awaitServerSettleAfterPost(confirmDuration);
                             else
-                                logHHAuto('Champion: confirm AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                                LogUtils_logHHAuto('Champion: confirm AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                         }
                         else {
-                            logHHAuto('Champion: another POST in flight, falling back to direct confirm click');
+                            LogUtils_logHHAuto('Champion: another POST in flight, falling back to direct confirm click');
                             $(confirmDraftButtonQuery).trigger('click');
                         }
                     }
                     if (getStoredValue(HHStoredVarPrefixKey + SK.autoBuildChampsTeam) === "true") {
-                        logHHAuto('Auto team ended, sort girls after build');
+                        LogUtils_logHHAuto('Auto team ended, sort girls after build');
                         yield TimeHelper.sleep(randomInterval(800, 1200));
                         Champion.orderTeam(champTeam);
                     }
                     else {
-                        logHHAuto("Auto team ended, refresh page, restarting autoloop");
+                        LogUtils_logHHAuto("Auto team ended, refresh page, restarting autoloop");
                         // safeReload waits for any in-flight champion AJAX to
                         // settle before reloading. Direct reload cancels open
                         // XHRs and can trigger the Forbidden race (issue #1598).
@@ -17272,12 +17279,12 @@ class Champion {
         };
         var findBestTeam = function () {
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("setting autoloop to false");
+            LogUtils_logHHAuto("setting autoloop to false");
             maxLoops = getChampMaxLoop();
             keepSecondLineGirls = getChampSecondLine();
             $('#updateChampTeamButton').attr('disabled', 'disabled').text('Starting soon...');
             Champion.ChamppUpdateAutoTeamPopup('Starting soon...', maxLoops, (maxLoops) * 2);
-            logHHAuto("keep second line : " + keepSecondLineGirls);
+            LogUtils_logHHAuto("keep second line : " + keepSecondLineGirls);
             counterLoop = 0;
             if ($(changeDraftButtonQuery).length > 0)
                 $(changeDraftButtonQuery).click();
@@ -17291,7 +17298,7 @@ class Champion {
             GM_registerMenuCommand(getTextForUI("updateChampTeamButton", "elementText"), findBestTeam);
         }
         else {
-            logHHAuto("No more free draft available");
+            LogUtils_logHHAuto("No more free draft available");
         }
     }
     static getChampionListFromMap() {
@@ -17342,7 +17349,7 @@ class Champion {
             var switchGirls = function (targettedTeam) {
                 return Champion_awaiter(this, void 0, void 0, function* () {
                     if (!acquirePostMutex('champion:reorder')) {
-                        logHHAuto('Champion: another POST in flight, deferring reorder request');
+                        LogUtils_logHHAuto('Champion: another POST in flight, deferring reorder request');
                         return false;
                     }
                     const reorderStart = Date.now();
@@ -17355,11 +17362,11 @@ class Champion {
                         };
                         getHHAjax()(params, function (data) {
                             if (data.success == false) {
-                                logHHAuto('Error occured during champion team reorder', data);
+                                LogUtils_logHHAuto('Error occured during champion team reorder', data);
                             }
                             resolve(data.success || true);
                         }, function (err) {
-                            logHHAuto('Error occured during champion team reorder', err);
+                            LogUtils_logHHAuto('Error occured during champion team reorder', err);
                             resolve(false);
                         });
                     });
@@ -17370,7 +17377,7 @@ class Champion {
                 });
             };
             let currentGirlOrder = [...champTeam.map((g) => g.id_girl)]; // To be stored as string
-            logHHAuto('Ordering champion team', currentGirlOrder);
+            LogUtils_logHHAuto('Ordering champion team', currentGirlOrder);
             let oneGirlSwitched = false;
             const getGirlId = (position) => {
                 const girlBox = $('.girl-box__draggable:has(".hhgirlOrder.best:contains(\'' + position + '\')")');
@@ -17394,31 +17401,31 @@ class Champion {
                     if (girlId != currentGirlOrder[i - 1]) {
                         $('div[id_girl="' + girlId + '"]').addClass('switching');
                         $('div[id_girl="' + currentGirlOrder[i - 1] + '"]').addClass('switching');
-                        logHHAuto(`Switching girls to reorder team ${girlId} - ${currentGirlOrder[i - 1]}`);
+                        LogUtils_logHHAuto(`Switching girls to reorder team ${girlId} - ${currentGirlOrder[i - 1]}`);
                         const oldGirlIndex = currentGirlOrder.findIndex(g => g == girlId);
                         const targettedTeam = [...currentGirlOrder];
                         [targettedTeam[i - 1], targettedTeam[oldGirlIndex]] = [targettedTeam[oldGirlIndex], targettedTeam[i - 1]];
-                        logHHAuto('Ordering champion targettedTeam', targettedTeam);
+                        LogUtils_logHHAuto('Ordering champion targettedTeam', targettedTeam);
                         if (yield switchGirls(targettedTeam)) {
                             oneGirlSwitched = true;
                             // Update current girls order after success switch
                             currentGirlOrder = targettedTeam;
                         }
                         else {
-                            logHHAuto('ERROR: Switch failed, try to continue');
+                            LogUtils_logHHAuto('ERROR: Switch failed, try to continue');
                         }
                         $('div[id_girl]').removeClass('switching');
                         yield TimeHelper.sleep(randomInterval(800, 1200));
                     }
                     else {
-                        logHHAuto('Girl already in the right position :' + girlId);
+                        LogUtils_logHHAuto('Girl already in the right position :' + girlId);
                     }
                 }
                 else {
-                    logHHAuto('Could not find girlId for position ' + i);
+                    LogUtils_logHHAuto('Could not find girlId for position ' + i);
                 }
             }
-            logHHAuto('Finished ordering champion team');
+            LogUtils_logHHAuto('Finished ordering champion team');
             $("#orderTeam").removeAttr('disabled');
             //if(oneGirlSwitched)
             // Use safeReload so the final reorder POST can complete before
@@ -17432,9 +17439,9 @@ class Champion {
             var page = getPage();
             if (page == ConfigHelper.getHHScriptVars("pagesIDChampionsPage")) {
                 const champTeamId = Number(getHHVars('championData.champion.id'));
-                logHHAuto('on champion ' + champTeamId + ' page');
+                LogUtils_logHHAuto('on champion ' + champTeamId + ' page');
                 if ($('button[rel=perform].blue_button_L').length == 0) {
-                    logHHAuto('Something is wrong!');
+                    LogUtils_logHHAuto('Something is wrong!');
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                     return true;
                 }
@@ -17445,9 +17452,9 @@ class Champion {
                     const impressionDone = ((safeJsonParse(tooltipData, {})).impression_info || '0/1').split('/')[0] || '0';
                     var TCount = Number($('div.input-field > span')[1].innerText.split(' / ')[1]);
                     var ECount = QuestHelper.getEnergy();
-                    logHHAuto("T:" + TCount + " E:" + ECount + " " + (getStoredValue(HHStoredVarPrefixKey + SK.autoChampsUseEne) === "true") + " Imp:" + impressionDone);
+                    LogUtils_logHHAuto("T:" + TCount + " E:" + ECount + " " + (getStoredValue(HHStoredVarPrefixKey + SK.autoChampsUseEne) === "true") + " Imp:" + impressionDone);
                     if (TCount == 0) {
-                        logHHAuto("No tickets!");
+                        LogUtils_logHHAuto("No tickets!");
                         const nextTime = randomInterval(3600, 4000);
                         setTimer('nextChampionTime', nextTime);
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoClubChamp) === "true") {
@@ -17463,13 +17470,13 @@ class Champion {
                                 deleteStoredValue(HHStoredVarPrefixKey + TK.champBuildTeam);
                             }
                             else {
-                                logHHAuto("Build team before start");
+                                LogUtils_logHHAuto("Build team before start");
                                 if ($("#updateChampTeamButton").length == 0) {
                                     Champion.moduleSimChampions();
                                     yield TimeHelper.sleep(randomInterval(200, 500));
                                 }
                                 if ($("#updateChampTeamButton").attr("disabled") === "disabled") {
-                                    logHHAuto('Cannot build team, no free draft available. Starting champion without building team');
+                                    LogUtils_logHHAuto('Cannot build team, no free draft available. Starting champion without building team');
                                 }
                                 else {
                                     $("#updateChampTeamButton").trigger("click"); // Auto loop false
@@ -17480,26 +17487,26 @@ class Champion {
                             }
                         }
                         if (!acquirePostMutex('champion:useTicket')) {
-                            logHHAuto('Champion: another POST in flight, deferring ticket use');
+                            LogUtils_logHHAuto('Champion: another POST in flight, deferring ticket use');
                             return true;
                         }
-                        logHHAuto("Using ticket");
+                        LogUtils_logHHAuto("Using ticket");
                         const ticketStart = Date.now();
                         $('button[rel=perform].blue_button_L').trigger('click');
-                        const ticketIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                        const ticketIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                         const ticketDuration = Date.now() - ticketStart;
                         releasePostMutex();
                         if (ticketIdle)
                             yield awaitServerSettleAfterPost(ticketDuration);
                         else
-                            logHHAuto('Champion: ticket AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                            LogUtils_logHHAuto('Champion: ticket AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDChampionsMap"));
                         return true;
                     }
                 }
             }
             else if (page == ConfigHelper.getHHScriptVars("pagesIDChampionsMap")) {
-                logHHAuto('on champion map');
+                LogUtils_logHHAuto('on champion map');
                 const championMap = Champion.getChampionListFromMap();
                 const autoChampsForceStartEventGirl = getStoredValue(HHStoredVarPrefixKey + SK.autoChampsForceStartEventGirl) === "true";
                 const autoChampsEventGirls = getStoredJSON(HHStoredVarPrefixKey + TK.autoChampsEventGirls, []);
@@ -17532,7 +17539,7 @@ class Champion {
                                     }
                                 }
                                 if (!autoChampGirlOnChamp) {
-                                    logHHAuto("Seems Girl is no more available at Champion " + Number(i + 1) + ". Going to event page.");
+                                    LogUtils_logHHAuto("Seems Girl is no more available at Champion " + Number(i + 1) + ". Going to event page.");
                                     EventModule.parseEventPage(autoChampGirlsEventsID);
                                     return true;
                                 }
@@ -17540,20 +17547,20 @@ class Champion {
                         }
                     }
                     const eventGirlForced = autoChampGirlOnChamp;
-                    logHHAuto("Champion " + (i + 1) + " [" + championMap[i].impression + "]"
+                    LogUtils_logHHAuto("Champion " + (i + 1) + " [" + championMap[i].impression + "]"
                         + (championMap[i].started ? " Started;" : " Not started;")
                         + (autoChampsForceStart ? " Force start;" : " Not force start;")
                         + (OnTimer ? " on timer;" : " not on timer;")
                         + (championMap[i].inFilter ? " Included in filter;" : " Excluded from filter;")
                         + (eventGirlForced ? " Forced for event" : " Not event forced"));
                     if ((championMap[i].started || eventGirlForced || autoChampsForceStart) && !OnTimer && championMap[i].inFilter) {
-                        logHHAuto("Let's do him!");
+                        LogUtils_logHHAuto("Let's do him!");
                         gotoPage('/champions/' + Number(i + 1));
                         //window.location = window.location.origin + '/champions/'+(i+1);
                         return true;
                     }
                 }
-                logHHAuto("No good candidate");
+                LogUtils_logHHAuto("No good candidate");
                 Champion.findNextChamptionTime(championMap);
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                 return false;
@@ -17573,16 +17580,16 @@ class Champion {
             const { minTime, minTimeEnded } = decideNextChampionTime(championMap, autoChampsForceStart);
             //fetching min
             let nextChampionTime;
-            logHHAuto('minTimeEnded: ' + minTimeEnded + ', minTime:' + minTime);
+            LogUtils_logHHAuto('minTimeEnded: ' + minTimeEnded + ', minTime:' + minTime);
             if (minTime === -1 && minTimeEnded === -1) {
                 nextChampionTime = randomInterval(3600, 4000);
             }
             else if (minTime === -1) {
-                logHHAuto('Champion ended, next time: ' + minTimeEnded);
+                LogUtils_logHHAuto('Champion ended, next time: ' + minTimeEnded);
                 nextChampionTime = randomInterval(minTimeEnded, 180 + minTimeEnded);
             }
             else {
-                logHHAuto('Champion next time: ' + minTime);
+                LogUtils_logHHAuto('Champion next time: ' + minTime);
                 const maxTime = minTime > 0 ? 180 + minTime : 0.5;
                 nextChampionTime = randomInterval(minTime, maxTime);
             }
@@ -17608,7 +17615,7 @@ class Champion {
     }
 }
 
-;// ./src/Module/Club.ts
+;// CONCATENATED MODULE: ./src/Module/Club.ts
 // Club.ts -- Detects club membership and enables or disables club-related features.
 //
 // Checks whether the player is currently in a club and toggles visibility of
@@ -17637,7 +17644,7 @@ class Club {
             chatVars = getHHVars("Chat_vars.CLUB_INFO.id_club", false);
         }
         catch (e) {
-            logHHAuto("Catched error : Couldn't parse CLUB_INFO : " + e);
+            LogUtils_logHHAuto("Catched error : Couldn't parse CLUB_INFO : " + e);
         }
         if (chatVars === null || chatVars === false) {
             HHEnvVariables[ConfigHelper.getHHScriptVars("HHGameName")].isEnabledClubChamp = false;
@@ -17645,7 +17652,7 @@ class Club {
     }
 }
 
-;// ./src/Module/ClubChampion.pure.ts
+;// CONCATENATED MODULE: ./src/Module/ClubChampion.pure.ts
 // ClubChampion.pure.ts -- Pure decision logic for the club-champion auto module.
 //
 // Extracted from ClubChampion.updateClubChampionTimer and
@@ -17723,7 +17730,7 @@ function decideAlignedClubChampionTimer(state) {
     return state.proposedTime;
 }
 
-;// ./src/Module/ClubChampion.ts
+;// CONCATENATED MODULE: ./src/Module/ClubChampion.ts
 var ClubChampion_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -17765,20 +17772,20 @@ class ClubChampion {
             let restChampionFilter = 'div.club_champions_details_container div.champion_rest_timer span[rel="expires"]';
             if ($(restTeamFilter).length > 0) {
                 SecsToNextTimer = Number(convertTimeToInt($(restTeamFilter).text()));
-                logHHAuto("Team is resting for : " + TimeHelper.toHHMMSS(SecsToNextTimer));
+                LogUtils_logHHAuto("Team is resting for : " + TimeHelper.toHHMMSS(SecsToNextTimer));
             }
             else if ($(restChampionFilter).length > 0) {
                 SecsToNextTimer = Number(convertTimeToInt($(restChampionFilter).text()));
-                logHHAuto("Champion is resting for : " + TimeHelper.toHHMMSS(SecsToNextTimer));
+                LogUtils_logHHAuto("Champion is resting for : " + TimeHelper.toHHMMSS(SecsToNextTimer));
                 if (ClubChampion.hasGirlReward()) {
                     SecsToNextTimer = randomInterval(30 * 60, 35 * 60);
-                    logHHAuto("Champion has girl reward");
+                    LogUtils_logHHAuto("Champion has girl reward");
                 }
             }
             else {
-                logHHAuto('No timer found');
+                LogUtils_logHHAuto('No timer found');
             }
-            logHHAuto('on clubs, next timer:' + SecsToNextTimer);
+            LogUtils_logHHAuto('on clubs, next timer:' + SecsToNextTimer);
             return SecsToNextTimer;
         }
         return 0; // -1 is only when no timer on club page
@@ -17786,7 +17793,7 @@ class ClubChampion {
     static updateClubChampionTimer() {
         var page = getPage();
         if (page == ConfigHelper.getHHScriptVars("pagesIDClub")) {
-            logHHAuto('on clubs');
+            LogUtils_logHHAuto('on clubs');
             const secsToNextTimer = ClubChampion.getNextClubChampionTimer();
             const noTimer = (secsToNextTimer === -1);
             const decision = decideNextClubChampionTime({
@@ -17816,7 +17823,7 @@ class ClubChampion {
             && getStoredValue(HHStoredVarPrefixKey + SK.autoClubChamp) === "true") {
             const champTimeLeft = getSecondsLeft('nextClubChampionTime');
             if (champTimeLeft > 60) {
-                logHHAuto("Club champion seems available, reduce next timer to 30-60s.");
+                LogUtils_logHHAuto("Club champion seems available, reduce next timer to 30-60s.");
                 ClubChampion._setTimer(randomInterval(30, 60));
             }
         }
@@ -17825,15 +17832,15 @@ class ClubChampion {
         return ClubChampion_awaiter(this, void 0, void 0, function* () {
             var page = getPage();
             if (page == ConfigHelper.getHHScriptVars("pagesIDClubChampion")) {
-                logHHAuto('on club_champion page');
+                LogUtils_logHHAuto('on club_champion page');
                 if ($('button[rel=perform].blue_button_L').length == 0) {
                     if ($('.champions-bottom__rest').length > 0) {
-                        logHHAuto('Girls are resting');
+                        LogUtils_logHHAuto('Girls are resting');
                         const restTime = ClubChampion.getRemainingRestTime();
                         ClubChampion._setTimer(randomInterval(restTime + 10, restTime + 2 * 60));
                     }
                     else {
-                        logHHAuto('Something is wrong!');
+                        LogUtils_logHHAuto('Something is wrong!');
                         ClubChampion._setTimer(randomInterval(15 * 60, 17 * 60));
                     }
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -17847,9 +17854,9 @@ class ClubChampion {
                     const playerStarted = clubChamptionFightActive && userStarted && userStarted.challenge_count > 0;
                     var TCount = Number($('div.input-field > span')[1].innerText.split(' / ')[1]);
                     var ECount = QuestHelper.getEnergy();
-                    logHHAuto(`T:${TCount} E:${ECount} Player challenge :${(userStarted === null || userStarted === void 0 ? void 0 : userStarted.challenge_count) || 0}`);
+                    LogUtils_logHHAuto(`T:${TCount} E:${ECount} Player challenge :${(userStarted === null || userStarted === void 0 ? void 0 : userStarted.challenge_count) || 0}`);
                     if (TCount == 0) {
-                        logHHAuto("No tickets!");
+                        LogUtils_logHHAuto("No tickets!");
                         const nextTime = randomInterval(3600, 4000);
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoChamps) === "true") {
                             // No ticket for boths
@@ -17865,13 +17872,13 @@ class ClubChampion {
                                 deleteStoredValue(HHStoredVarPrefixKey + TK.champBuildTeam);
                             }
                             else {
-                                logHHAuto("Build team before start");
+                                LogUtils_logHHAuto("Build team before start");
                                 if ($("#updateChampTeamButton").length == 0) {
                                     Champion.moduleSimChampions();
                                     yield TimeHelper.sleep(randomInterval(200, 500));
                                 }
                                 if ($("#updateChampTeamButton").attr("disabled") === "disabled") {
-                                    logHHAuto('Cannot build team, no free draft available. Starting champion without building team');
+                                    LogUtils_logHHAuto('Cannot build team, no free draft available. Starting champion without building team');
                                 }
                                 else {
                                     $("#updateChampTeamButton").trigger("click"); // Auto loop false
@@ -17882,7 +17889,7 @@ class ClubChampion {
                             }
                         }
                         if (TCount != 0) {
-                            logHHAuto("Using ticket");
+                            LogUtils_logHHAuto("Using ticket");
                             $('button[rel=perform].blue_button_L').trigger('click');
                             ClubChampion._setTimer(randomInterval(15 * 60, 17 * 60));
                         }
@@ -17893,10 +17900,10 @@ class ClubChampion {
             }
             else if (page == ConfigHelper.getHHScriptVars("pagesIDClub")) {
                 deleteStoredValue(HHStoredVarPrefixKey + TK.clubChampLimitReached);
-                logHHAuto('on clubs');
+                LogUtils_logHHAuto('on clubs');
                 const onChampTab = $("div.club-champion-members-challenges:visible").length === 1;
                 if (!onChampTab) {
-                    logHHAuto('Click champions tab');
+                    LogUtils_logHHAuto('Click champions tab');
                     $("#club_champions_tab").trigger('click');
                 }
                 let Started = $("div.club-champion-members-challenges .player-row").length === 1;
@@ -17911,12 +17918,12 @@ class ClubChampion {
                     let maxTickets = Number(getStoredValue(HHStoredVarPrefixKey + SK.autoClubChampMax));
                     //console.log(maxTickets, ticketUsed);
                     if (maxTickets > ticketUsed) {
-                        logHHAuto("Let's do him!");
+                        LogUtils_logHHAuto("Let's do him!");
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDClubChampion"));
                         return true;
                     }
                     else {
-                        logHHAuto("Max tickets to use on Club Champ reached.");
+                        LogUtils_logHHAuto("Max tickets to use on Club Champ reached.");
                         setStoredValue(HHStoredVarPrefixKey + TK.clubChampLimitReached, "true");
                         setTimer('nextClubChampionTime', randomInterval(4 * 60 * 60, 5 * 60 * 60));
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -17949,7 +17956,7 @@ class ClubChampion {
     }
 }
 
-;// ./src/Module/Events/LivelyScene.pure.ts
+;// CONCATENATED MODULE: ./src/Module/Events/LivelyScene.pure.ts
 // LivelyScene.pure.ts -- Pure decision logic for the Lively Scene event.
 //
 // Extracted from LivelyScene.parse and LivelyScene.parseClaimableRewards
@@ -18015,7 +18022,7 @@ function selectClaimablePieces(pieces, state) {
     return claimable;
 }
 
-;// ./src/Module/Events/LivelyScene.ts
+;// CONCATENATED MODULE: ./src/Module/Events/LivelyScene.ts
 var LivelyScene_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -18096,7 +18103,7 @@ class LivelyScene {
             needToCollectAll,
             manualCollectAll,
         }).map((p) => p.__orig);
-        logHHAuto('claimablePieces', claimablePieces);
+        LogUtils_logHHAuto('claimablePieces', claimablePieces);
         return claimablePieces;
     }
     static goAndCollect(remainingTime_1) {
@@ -18106,8 +18113,8 @@ class LivelyScene {
                 if (manualCollectAll)
                     setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'true');
                 if (rewards.length > 0) {
-                    logHHAuto("Going to collect rewards.");
-                    logHHAuto("setting autoloop to false");
+                    LogUtils_logHHAuto("Going to collect rewards.");
+                    LogUtils_logHHAuto("setting autoloop to false");
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     for (let currentReward = 0; currentReward < rewards.length; currentReward++) {
                         const reward = rewards[currentReward];
@@ -18127,7 +18134,7 @@ class LivelyScene {
                     }
                 }
                 else {
-                    logHHAuto("No (more) LivelyScene reward to collect .");
+                    LogUtils_logHHAuto("No (more) LivelyScene reward to collect .");
                     setTimer('nextLivelySceneEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'false');
                     //gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -18138,7 +18145,7 @@ class LivelyScene {
             }
             catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
-                logHHAuto(`ERROR during collect LivelyScene rewards: ${message}`);
+                LogUtils_logHHAuto(`ERROR during collect LivelyScene rewards: ${message}`);
                 setStoredValue(HHStoredVarPrefixKey + TK.lseManualCollectAll, 'false');
             }
             return false;
@@ -18176,7 +18183,7 @@ class LivelyScene {
                         if ($puzzlePiece.length > 0 && iconHref) {
                             const image = LivelyScene._makeSVGImage($puzzlePiece, iconHref);
                             document.getElementById(`puzzle_piece_${puzzlePiece.id_piece}`).appendChild(image);
-                            logHHAuto(`Add icon for ${rewardType} to #puzzle_piece_${puzzlePiece.id_piece}`);
+                            LogUtils_logHHAuto(`Add icon for ${rewardType} to #puzzle_piece_${puzzlePiece.id_piece}`);
                         }
                     }
                 }
@@ -18199,7 +18206,7 @@ class LivelyScene {
     }
 }
 
-;// ./src/Module/Events/PathOfAttraction.ts
+;// CONCATENATED MODULE: ./src/Module/Events/PathOfAttraction.ts
 var PathOfAttraction_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -18267,12 +18274,12 @@ class PathOfAttraction {
         const eventID = hhEvent.eventId;
         PathOfAttraction.getRemainingTime();
         const poAEnd = getSecondsLeft("PoARemainingTime");
-        logHHAuto("PoA end in " + TimeHelper.debugDate(poAEnd));
+        LogUtils_logHHAuto("PoA end in " + TimeHelper.debugDate(poAEnd));
         let refreshTimerPoa = ConfigHelper.getHHScriptVars('maxCollectionDelay');
         if (poAEnd < Math.max(refreshTimerPoa, getLimitTimeBeforeEnd()) && getStoredValue(HHStoredVarPrefixKey + SK.autoPoACollectAll) === "true") {
             refreshTimerPoa = Math.min(refreshTimerPoa, getLimitTimeBeforeEnd());
         }
-        logHHAuto("PoA next refres in " + TimeHelper.debugDate(refreshTimerPoa));
+        LogUtils_logHHAuto("PoA next refres in " + TimeHelper.debugDate(refreshTimerPoa));
         eventList[eventID] = {};
         eventList[eventID]["id"] = eventID;
         eventList[eventID]["type"] = hhEvent.eventType;
@@ -18283,7 +18290,7 @@ class PathOfAttraction {
     static run() {
         return PathOfAttraction_awaiter(this, void 0, void 0, function* () {
             if (getPage() === ConfigHelper.getHHScriptVars("pagesIDEvent") && window.location.search.includes("tab=" + ConfigHelper.getHHScriptVars('poaEventIDReg'))) {
-                logHHAuto("On path of attraction event.");
+                LogUtils_logHHAuto("On path of attraction event.");
                 if (ConfigHelper.getHHScriptVars("isEnabledClubChamp", false)) {
                     if ($(".hh-club-poa").length <= 0) {
                         const championsGoal = $('#poa-content .buttons:has(button[data-href="/champions-map.html"])');
@@ -18329,7 +18336,7 @@ class PathOfAttraction {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            logHHAuto(`ERROR in display POA rewards: ${message}`);
+            LogUtils_logHHAuto(`ERROR in display POA rewards: ${message}`);
         }
     }
     static getNotClaimedRewards() {
@@ -18387,13 +18394,13 @@ class PathOfAttraction {
                 setStoredValue(HHStoredVarPrefixKey + TK.poaManualCollectAll, 'true');
             if (needToCollect || needToCollectAllBeforeEnd || manualCollectAll) {
                 const rewardsToCollect = getStoredJSON(HHStoredVarPrefixKey + SK.autoPoACollectablesList, []);
-                logHHAuto("Checking Path of Attraction for collectable rewards.");
+                LogUtils_logHHAuto("Checking Path of Attraction for collectable rewards.");
                 const numberTiers = $(PathOfAttraction.rewardPairTierPath).length;
                 const freeClaimableRewards = PathOfAttraction.getFreeClaimableRewards();
                 const paidClaimableRewards = PathOfAttraction.getPaidClaimableRewards();
                 function getReward(reward) {
                     return PathOfAttraction_awaiter(this, void 0, void 0, function* () {
-                        logHHAuto("Going to get " + JSON.stringify(reward));
+                        LogUtils_logHHAuto("Going to get " + JSON.stringify(reward));
                         reward.slot.trigger('click');
                         yield TimeHelper.sleep(randomInterval(300, 800));
                         $(PathOfAttraction.getRewardButtonPath).trigger('click');
@@ -18404,15 +18411,15 @@ class PathOfAttraction {
                         yield TimeHelper.sleep(randomInterval(1000, 1500));
                     });
                 }
-                logHHAuto("numberTiers: " + numberTiers);
+                LogUtils_logHHAuto("numberTiers: " + numberTiers);
                 if (debugEnabled) {
-                    logHHAuto("freeClaimableRewards", freeClaimableRewards);
-                    logHHAuto("paidClaimableRewards", paidClaimableRewards);
+                    LogUtils_logHHAuto("freeClaimableRewards", freeClaimableRewards);
+                    LogUtils_logHHAuto("paidClaimableRewards", paidClaimableRewards);
                 }
                 const freeClaimableTiers = Object.keys(freeClaimableRewards);
                 const paidClaimableTiers = Object.keys(paidClaimableRewards);
                 if (numberTiers > 0 && (freeClaimableTiers.length > 0 || paidClaimableTiers.length > 0)) {
-                    logHHAuto(`Collecting rewards, ${freeClaimableTiers.length + paidClaimableTiers.length} rewards to collect , setting autoloop to false`);
+                    LogUtils_logHHAuto(`Collecting rewards, ${freeClaimableTiers.length + paidClaimableTiers.length} rewards to collect , setting autoloop to false`);
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     $(".scroll-area.poa").animate({ scrollLeft: 0 });
                     yield TimeHelper.sleep(randomInterval(300, 800));
@@ -18430,13 +18437,13 @@ class PathOfAttraction {
                             }
                         }
                     }
-                    logHHAuto("Path of Attraction collection finished.");
+                    LogUtils_logHHAuto("Path of Attraction collection finished.");
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                     setTimeout(autoLoop, Number(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili)));
                     return true;
                 }
                 else {
-                    logHHAuto("No Path of Attraction reward to collect.");
+                    LogUtils_logHHAuto("No Path of Attraction reward to collect.");
                     setStoredValue(HHStoredVarPrefixKey + TK.poaManualCollectAll, 'false');
                 }
             }
@@ -18477,7 +18484,7 @@ PathOfAttraction.freeSlotPath = "#nc-poa-tape-rewards .nc-poa-reward-pair .nc-po
 PathOfAttraction.paidSlotPath = "#nc-poa-tape-rewards .nc-poa-reward-pair .nc-poa-locked-reward";
 PathOfAttraction.getRewardButtonPath = "#poa-content .objective .reward button.purple_button_L";
 
-;// ./src/Module/Events/PathOfGlory.ts
+;// CONCATENATED MODULE: ./src/Module/Events/PathOfGlory.ts
 // PathOfGlory.ts -- Path of Glory (PoG) event: tier collection and reward tracking.
 //
 // Path of Glory is a tiered event where the player earns points through
@@ -18531,12 +18538,12 @@ class PathOfGlory {
                     const passPlusSlotType = RewardHelper.getRewardTypeBySlot(paidSlots[1]);
                     if (rewardsToCollect.includes(passSlotType) && (paidSlots.length > 1 ? rewardsToCollect.includes(passPlusSlotType) : true)) {
                         buttonsToCollect.push(currentButton);
-                        logHHAuto(`Adding for collection tier (with paid) : ${currentTierNb} (Free: ${freeSlotType}, Pass: ${passSlotType}, Pass+: ${paidSlots.length > 1 ? passPlusSlotType : 'locked'})`);
+                        LogUtils_logHHAuto(`Adding for collection tier (with paid) : ${currentTierNb} (Free: ${freeSlotType}, Pass: ${passSlotType}, Pass+: ${paidSlots.length > 1 ? passPlusSlotType : 'locked'})`);
                     }
                 }
                 else {
                     buttonsToCollect.push(currentButton);
-                    logHHAuto(`Adding for collection tier (only free) : ${currentTierNb} (${freeSlotType})`);
+                    LogUtils_logHHAuto(`Adding for collection tier (only free) : ${currentTierNb} (${freeSlotType})`);
                 }
             }
         }
@@ -18546,10 +18553,10 @@ class PathOfGlory {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPoG")) {
             PathOfGlory.getRemainingTime();
             const pogEnd = getSecondsLeft("PoGRemainingTime");
-            logHHAuto("PoG end in " + TimeHelper.debugDate(pogEnd));
+            LogUtils_logHHAuto("PoG end in " + TimeHelper.debugDate(pogEnd));
             if (checkTimer('nextPoGCollectAllTime') && pogEnd < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoPoGCollectAll) === "true") {
                 if ($(ConfigHelper.getHHScriptVars("selectorClaimAllRewards")).length > 0) {
-                    logHHAuto("Going to collect all POG item at once.");
+                    LogUtils_logHHAuto("Going to collect all POG item at once.");
                     setTimeout(function () {
                         $(ConfigHelper.getHHScriptVars("selectorClaimAllRewards"))[0].click();
                         setTimer('nextPoGCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180)); // Add timer to check again later if there is new items to collect
@@ -18562,20 +18569,20 @@ class PathOfGlory {
                 }
             }
             if (checkTimer('nextPoGCollectTime') && (getStoredValue(HHStoredVarPrefixKey + SK.autoPoGCollect) === "true" || getStoredValue(HHStoredVarPrefixKey + SK.autoPoGCollectAll) === "true")) {
-                logHHAuto("Checking Path of Glory for collectable rewards.");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("Checking Path of Glory for collectable rewards.");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 let buttonsToCollect = PathOfGlory.getRewardButtonToCollect();
                 if (buttonsToCollect.length > 0) {
                     function collectPoGRewards() {
                         if (buttonsToCollect.length > 0) {
-                            logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
+                            LogUtils_logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
                             buttonsToCollect[0].click();
                             buttonsToCollect.shift();
                             setTimeout(collectPoGRewards, randomInterval(300, 500));
                         }
                         else {
-                            logHHAuto("Path of Glory collection finished.");
+                            LogUtils_logHHAuto("Path of Glory collection finished.");
                             setTimer('nextPoGCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         }
@@ -18584,7 +18591,7 @@ class PathOfGlory {
                     return true;
                 }
                 else {
-                    logHHAuto("No Path of Glory reward to collect.");
+                    LogUtils_logHHAuto("No Path of Glory reward to collect.");
                     setTimer('nextPoGCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     setTimer('nextPoGCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -18594,7 +18601,7 @@ class PathOfGlory {
             return false;
         }
         else {
-            logHHAuto("Switching to Path of Glory screen.");
+            LogUtils_logHHAuto("Switching to Path of Glory screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDPoG"));
             return true;
         }
@@ -18606,7 +18613,7 @@ class PathOfGlory {
     }
 }
 
-;// ./src/Module/Events/PathOfValue.ts
+;// CONCATENATED MODULE: ./src/Module/Events/PathOfValue.ts
 // PathOfValue.ts -- Path of Value (PoV) event: tier collection and reward tracking.
 //
 // Path of Value is a tiered event similar to Path of Glory and Path of
@@ -18660,12 +18667,12 @@ class PathOfValue {
                     const passPlusSlotType = RewardHelper.getRewardTypeBySlot(paidSlots[1]);
                     if (rewardsToCollect.includes(passSlotType) && (paidSlots.length > 1 ? rewardsToCollect.includes(passPlusSlotType) : true)) {
                         buttonsToCollect.push(currentButton);
-                        logHHAuto(`Adding for collection tier (with paid) : ${currentTierNb} (Free: ${freeSlotType}, Pass: ${passSlotType}, Pass+: ${paidSlots.length > 1 ? passPlusSlotType : 'locked'})`);
+                        LogUtils_logHHAuto(`Adding for collection tier (with paid) : ${currentTierNb} (Free: ${freeSlotType}, Pass: ${passSlotType}, Pass+: ${paidSlots.length > 1 ? passPlusSlotType : 'locked'})`);
                     }
                 }
                 else {
                     buttonsToCollect.push(currentButton);
-                    logHHAuto(`Adding for collection tier (only free) : ${currentTierNb} (${freeSlotType})`);
+                    LogUtils_logHHAuto(`Adding for collection tier (only free) : ${currentTierNb} (${freeSlotType})`);
                 }
             }
         }
@@ -18675,10 +18682,10 @@ class PathOfValue {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPoV")) {
             PathOfValue.getRemainingTime();
             const povEnd = getSecondsLeft("PoVRemainingTime");
-            logHHAuto("PoV end in " + TimeHelper.debugDate(povEnd));
+            LogUtils_logHHAuto("PoV end in " + TimeHelper.debugDate(povEnd));
             if (checkTimer('nextPoVCollectAllTime') && povEnd < getLimitTimeBeforeEnd() && getStoredValue(HHStoredVarPrefixKey + SK.autoPoVCollectAll) === "true") {
                 if ($(ConfigHelper.getHHScriptVars("selectorClaimAllRewards")).length > 0) {
-                    logHHAuto("Going to collect all POV item at once.");
+                    LogUtils_logHHAuto("Going to collect all POV item at once.");
                     setTimeout(function () {
                         $(ConfigHelper.getHHScriptVars("selectorClaimAllRewards"))[0].click();
                         setTimer('nextPoVCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180)); // Add timer to check again later if there is new items to collect
@@ -18691,20 +18698,20 @@ class PathOfValue {
                 }
             }
             if (checkTimer('nextPoVCollectTime') && getStoredValue(HHStoredVarPrefixKey + SK.autoPoVCollect) === "true") {
-                logHHAuto("Checking Path of Valor for collectable rewards.");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("Checking Path of Valor for collectable rewards.");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 let buttonsToCollect = PathOfValue.getRewardButtonToCollect();
                 if (buttonsToCollect.length > 0) {
                     function collectPoVRewards() {
                         if (buttonsToCollect.length > 0) {
-                            logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
+                            LogUtils_logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
                             buttonsToCollect[0].click();
                             buttonsToCollect.shift();
                             setTimeout(collectPoVRewards, randomInterval(300, 500));
                         }
                         else {
-                            logHHAuto("Path of Valor collection finished.");
+                            LogUtils_logHHAuto("Path of Valor collection finished.");
                             setTimer('nextPoVCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                         }
@@ -18713,7 +18720,7 @@ class PathOfValue {
                     return true;
                 }
                 else {
-                    logHHAuto("No Path of Valor reward to collect.");
+                    LogUtils_logHHAuto("No Path of Valor reward to collect.");
                     setTimer('nextPoVCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     setTimer('nextPoVCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -18723,7 +18730,7 @@ class PathOfValue {
             return false;
         }
         else {
-            logHHAuto("Switching to Path of Valor screen.");
+            LogUtils_logHHAuto("Switching to Path of Valor screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDPoV"));
             return true;
         }
@@ -18735,7 +18742,7 @@ class PathOfValue {
     }
 }
 
-;// ./src/Module/Events/Seasonal.ts
+;// CONCATENATED MODULE: ./src/Module/Events/Seasonal.ts
 var Seasonal_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -18790,11 +18797,11 @@ class SeasonalEvent {
             const rankTimer = Number(convertTimeToInt($(rankTimerRequest).text()));
             return rankTimer;
         }
-        logHHAuto('ERROR: can\'t get seasonal rank timer, default to maxCollectionDelay');
+        LogUtils_logHHAuto('ERROR: can\'t get seasonal rank timer, default to maxCollectionDelay');
         return ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
     }
     static displayRemainingTime() {
-        logHHAuto('Not implemented');
+        LogUtils_logHHAuto('Not implemented');
     }
     static getSeasonalNotClaimedRewards() {
         const arrayz = $(SeasonalEvent.SEASONAL_REWARD_PATH);
@@ -18826,12 +18833,12 @@ class SeasonalEvent {
                 const megaSeasonalPaidSlotQuery = ".pass-slot.paid-unclaimed .slot";
                 if (needToCollect || needToCollectAllBeforeEnd || manualCollectAll) {
                     if (needToCollect)
-                        logHHAuto("Checking SeasonalEvent for collectable rewards.");
+                        LogUtils_logHHAuto("Checking SeasonalEvent for collectable rewards.");
                     if (needToCollectAllBeforeEnd)
-                        logHHAuto("Going to collect all SeasonalEvent rewards.");
+                        LogUtils_logHHAuto("Going to collect all SeasonalEvent rewards.");
                     if (manualCollectAll)
-                        logHHAuto("Going to collect all SeasonalEvent rewards after collect all button usage.");
-                    logHHAuto("setting autoloop to false");
+                        LogUtils_logHHAuto("Going to collect all SeasonalEvent rewards after collect all button usage.");
+                    LogUtils_logHHAuto("setting autoloop to false");
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                     const buttonsToCollect = [];
                     const listSeasonalEventTiersToClaim = isMegaSeasonalEvent ? $(megaSeasonalTierQuery) : $(seasonalTierQuery);
@@ -18849,15 +18856,15 @@ class SeasonalEvent {
                                 const paidSlotType = RewardHelper.getRewardTypeBySlot($(paidSlotQuery, listSeasonalEventTiersToClaim[currentTier])[0]);
                                 if (rewardsToCollect.includes(paidSlotType) || needToCollectAllBeforeEnd || manualCollectAll) {
                                     buttonsToCollect.push(currentButton);
-                                    logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
+                                    LogUtils_logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
                                 }
                                 else {
-                                    logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
+                                    LogUtils_logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
                                 }
                             }
                             else {
                                 buttonsToCollect.push(currentButton);
-                                logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
+                                LogUtils_logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
                             }
                         }
                     }
@@ -18868,13 +18875,13 @@ class SeasonalEvent {
                         }
                         function collectSeasonalEventRewards() {
                             if (buttonsToCollect.length > 0) {
-                                logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
+                                LogUtils_logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
                                 buttonsToCollect[0].click();
                                 buttonsToCollect.shift();
                                 setTimeout(closeRewardAndCollectagain, randomInterval(300, 500));
                             }
                             else {
-                                logHHAuto("SeasonalEvent collection finished.");
+                                LogUtils_logHHAuto("SeasonalEvent collection finished.");
                                 setTimer('nextSeasonalEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                                 if (!manualCollectAll) {
                                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
@@ -18886,7 +18893,7 @@ class SeasonalEvent {
                         return true;
                     }
                     else {
-                        logHHAuto("No SeasonalEvent reward to collect.");
+                        LogUtils_logHHAuto("No SeasonalEvent reward to collect.");
                         setTimer('nextSeasonalEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                         setTimer('nextSeasonalEventCollectAllTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                         if (!manualCollectAll) {
@@ -18900,18 +18907,18 @@ class SeasonalEvent {
             catch (err) {
                 const message = err instanceof Error ? err.message : String(err);
                 const errName = err instanceof Error ? err.name : 'Error';
-                logHHAuto(`ERROR: Can't collect rewards retry later: ${errName}, ${message}`);
+                LogUtils_logHHAuto(`ERROR: Can't collect rewards retry later: ${errName}, ${message}`);
                 setTimer('nextSeasonalEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
             }
             return false;
         }
         else if (SeasonalEvent.isActiveEvent()) {
-            logHHAuto("Switching to SeasonalEvent screen.");
+            LogUtils_logHHAuto("Switching to SeasonalEvent screen.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeasonalEvent"));
             return true;
         }
         else {
-            logHHAuto("No SeasonalEvent active.");
+            LogUtils_logHHAuto("No SeasonalEvent active.");
             setTimer('nextSeasonalEventCollectTime', 604800); // 1 week delay
             setTimer('nextSeasonalEventCollectAllTime', 604800); // 1 week delay
             return false;
@@ -19008,7 +19015,7 @@ class SeasonalEvent {
             return;
         const $playerPoints = $('.player-shards .mega-event-currency');
         if ($playerPoints.length === 0) {
-            logHHAuto("ERROR: Can't find player points");
+            LogUtils_logHHAuto("ERROR: Can't find player points");
         }
         const playerPoints = $playerPoints.length ? Number($playerPoints.text()) : 0;
         const girlContainer = $('.girls-reward-container');
@@ -19036,7 +19043,7 @@ class SeasonalEvent {
         try {
             if ($('#' + hhRewardId).length <= 0) {
                 const rewardCountByType = isMegaSeasonalEvent ? SeasonalEvent.getMegaSeasonalNotClaimedRewards() : SeasonalEvent.getSeasonalNotClaimedRewards();
-                logHHAuto("Rewards seasonal event:", JSON.stringify(rewardCountByType));
+                LogUtils_logHHAuto("Rewards seasonal event:", JSON.stringify(rewardCountByType));
                 if (rewardCountByType['all'] > 0) {
                     // GM_addStyle('.seasonal-event-panel .seasonal-event-container .tabs-section #home_tab_container .middle-container .event-resource-location .buttons-container { height: 5rem; margin-top: 0;}'); 
                     // GM_addStyle('.seasonal-event-panel .seasonal-event-container .tabs-section #home_tab_container .middle-container .event-resource-location .buttons-container a { height: 2rem;}'); 
@@ -19053,7 +19060,7 @@ class SeasonalEvent {
             }
         }
         catch (err) {
-            logHHAuto("ERROR:", err.message);
+            LogUtils_logHHAuto("ERROR:", err.message);
             target.append($('<div id=' + hhRewardId + ' style="display:none;"></div>'));
         }
     }
@@ -19064,14 +19071,14 @@ class SeasonalEvent {
                 const topRank = $('#mega-event-tabs #top_ranking_tab');
                 const eventRank = $('#mega-event-tabs #event_ranking_tab');
                 if (!isMegaSeasonalEvent && topRank.length === 0 && eventRank.length === 0) {
-                    logHHAuto('Not Mega Event');
+                    LogUtils_logHHAuto('Not Mega Event');
                     setTimer('nextMegaEventRankCollectTime', 604800); // 1 week delay
                     return Promise.resolve(false);
                 }
                 else if (topRank.length > 0 || eventRank.length > 0) {
-                    logHHAuto('Not Mega Event but rank tab exist');
+                    LogUtils_logHHAuto('Not Mega Event but rank tab exist');
                 }
-                logHHAuto('Collect Mega Event Rank Rewards');
+                LogUtils_logHHAuto('Collect Mega Event Rank Rewards');
                 // switch tabs
                 if (topRank.length > 0)
                     topRank.trigger("click");
@@ -19084,12 +19091,12 @@ class SeasonalEvent {
                 setTimer('nextMegaEventRankCollectTime', SeasonalEvent.getGlobalRankRemainingTime() + randomInterval(3600, 4000));
             }
             else if (SeasonalEvent.isActiveEvent()) {
-                logHHAuto("Switching to SeasonalEvent screen.");
+                LogUtils_logHHAuto("Switching to SeasonalEvent screen.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeasonalEvent"));
                 return Promise.resolve(true);
             }
             else {
-                logHHAuto("No SeasonalEvent active.");
+                LogUtils_logHHAuto("No SeasonalEvent active.");
                 setTimer('nextMegaEventRankCollectTime', 604800); // 1 week delay
             }
             return Promise.resolve(false);
@@ -19099,14 +19106,14 @@ class SeasonalEvent {
         return Seasonal_awaiter(this, void 0, void 0, function* () {
             var cardsOwned = getHHVars('mega_event_data.cards');
             if (cardsOwned && cardsOwned.indexOf('1') >= 0) {
-                logHHAuto(`Free cards already collected (${cardsOwned}), wait for next seasonal event`);
+                LogUtils_logHHAuto(`Free cards already collected (${cardsOwned}), wait for next seasonal event`);
                 setTimer('nextSeasonalCardCollectTime', getSecondsLeft("SeasonalEventRemainingTime") + randomInterval(3600, 4000));
             }
             else {
                 if (getPage() === ConfigHelper.getHHScriptVars("pagesIDSeasonalEvent")) {
                     const cardTabs = $('#mega-event-tabs #cards_tab');
                     if (cardTabs.length > 0) {
-                        logHHAuto('Collect free cards from Seasonal Event');
+                        LogUtils_logHHAuto('Collect free cards from Seasonal Event');
                         // switch tabs
                         cardTabs.trigger("click");
                         yield TimeHelper.sleep(randomInterval(400, 600));
@@ -19118,7 +19125,7 @@ class SeasonalEvent {
                         yield TimeHelper.sleep(randomInterval(400, 600));
                         RewardHelper.closeRewardPopupIfAny(); // Close card reward popup
                         if (freeCardClaimButton.length > 1) {
-                            logHHAuto('There is still free cards to collect, try again');
+                            LogUtils_logHHAuto('There is still free cards to collect, try again');
                             freeCardClaimButton.trigger("click");
                             yield TimeHelper.sleep(randomInterval(400, 600));
                             RewardHelper.closeRewardPopupIfAny();
@@ -19127,12 +19134,12 @@ class SeasonalEvent {
                     setTimer('nextSeasonalCardCollectTime', getSecondsLeft("SeasonalEventRemainingTime") + randomInterval(3600, 4000));
                 }
                 else if (SeasonalEvent.isActiveEvent()) {
-                    logHHAuto("Switching to SeasonalEvent screen.");
+                    LogUtils_logHHAuto("Switching to SeasonalEvent screen.");
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeasonalEvent"));
                     return Promise.resolve(true);
                 }
                 else {
-                    logHHAuto("No SeasonalEvent active.");
+                    LogUtils_logHHAuto("No SeasonalEvent active.");
                     setTimer('nextSeasonalCardCollectTime', 604800); // 1 week delay
                 }
             }
@@ -19143,7 +19150,7 @@ class SeasonalEvent {
 SeasonalEvent.SEASONAL_REWARD_PATH = '.mega-tier.unclaimed';
 SeasonalEvent.SEASONAL_REWARD_MEGA_PATH = '.mega-tier-container:has(.free-slot button.mega-claim-reward)';
 
-;// ./src/Module/Pachinko.ts
+;// CONCATENATED MODULE: ./src/Module/Pachinko.ts
 var Pachinko_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -19203,14 +19210,14 @@ class Pachinko {
             }
             try {
                 if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDPachinko")) {
-                    logHHAuto("Navigating to Pachinko window.");
+                    LogUtils_logHHAuto("Navigating to Pachinko window.");
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDPachinko"));
                     return true;
                 }
                 else {
-                    logHHAuto("Detected Pachinko Screen. Fetching Pachinko, setting autoloop to false");
+                    LogUtils_logHHAuto("Detected Pachinko Screen. Fetching Pachinko, setting autoloop to false");
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                    logHHAuto('switch to ' + pachinkoType);
+                    LogUtils_logHHAuto('switch to ' + pachinkoType);
                     const equipementSection = '#pachinko_whole .playing-zone';
                     const freeButtonQuery = '#playzone-replace-info button[data-free="true"].blue_button_L';
                     function selectPachinko(pachinkoType) {
@@ -19221,11 +19228,11 @@ class Pachinko {
                     }
                     yield selectPachinko(pachinkoType);
                     if ($(equipementSection).attr('type-panel') !== pachinkoType) {
-                        logHHAuto(`Error pachinko ${pachinkoType} not loaded after click, retry`);
+                        LogUtils_logHHAuto(`Error pachinko ${pachinkoType} not loaded after click, retry`);
                         yield selectPachinko(pachinkoType);
                     }
                     if ($(freeButtonQuery).length === 0) {
-                        logHHAuto('Not ready yet');
+                        LogUtils_logHHAuto('Not ready yet');
                     }
                     else {
                         $(freeButtonQuery).trigger('click');
@@ -19236,13 +19243,13 @@ class Pachinko {
                         setTimer(pachinkoTimer, Number(convertTimeToInt(npach)) + randomInterval(1, 5));
                     }
                     else {
-                        logHHAuto("Unable to find " + pachinkoType + " Pachinko time, wait 4h.");
+                        LogUtils_logHHAuto("Unable to find " + pachinkoType + " Pachinko time, wait 4h.");
                         setTimer(pachinkoTimer, ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(1, 10));
                     }
                     setTimeout(function () {
                         RewardHelper.closeRewardPopupIfAny();
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-                        logHHAuto("setting autoloop to true");
+                        LogUtils_logHHAuto("setting autoloop to true");
                         if (Pachinko_autoLoopKick)
                             setTimeout(Pachinko_autoLoopKick, randomInterval(500, 800));
                     }, randomInterval(300, 600));
@@ -19250,7 +19257,7 @@ class Pachinko {
                 return true;
             }
             catch (ex) {
-                logHHAuto("Catched error : Could not collect " + pachinkoType + " Pachinko... " + ex);
+                LogUtils_logHHAuto("Catched error : Could not collect " + pachinkoType + " Pachinko... " + ex);
                 setTimer(pachinkoTimer, ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(1, 10));
                 return false;
             }
@@ -19264,7 +19271,7 @@ class Pachinko {
                 numberOfGirlsToWin = safeJsonParse(girlsRewards.attr("data-rewards"), []).length;
             }
             catch (exp) {
-                logHHAuto('Could not count pachinko girls to win: ' + exp);
+                LogUtils_logHHAuto('Could not count pachinko girls to win: ' + exp);
             }
         }
         return numberOfGirlsToWin;
@@ -19276,7 +19283,7 @@ class Pachinko {
         }
         if (isNaN(orbsLeft)) {
             orbsLeft = 0;
-            logHHAuto("ERROR getting orbs left");
+            LogUtils_logHHAuto("ERROR getting orbs left");
         }
         return orbsLeft;
     }
@@ -19385,7 +19392,7 @@ class Pachinko {
     }
     static pachinkoPlayXTimes() {
         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-        logHHAuto("setting autoloop to false");
+        LogUtils_logHHAuto("setting autoloop to false");
         Pachinko.pachinkoSelector = document.getElementById("PachinkoSelector");
         Pachinko.ByPassNoGirlChecked = document.getElementById("PachinkoByPassNoGirls").checked;
         Pachinko.stopFirstGirlChecked = document.getElementById("PachinkoStopFirstGirl").checked;
@@ -19394,12 +19401,12 @@ class Pachinko {
         Pachinko.orbsToGo = Number(document.getElementById("PachinkoXTimes").value);
         Pachinko.orbLeftOnAutoStart = Pachinko.getNumberOfOrbsLeft(buttonSelector);
         if (Pachinko.orbLeftOnAutoStart <= 0) {
-            logHHAuto('No Orbs left for : ' + selectedOption.text);
+            LogUtils_logHHAuto('No Orbs left for : ' + selectedOption.text);
             $("#PachinkoError").text(getTextForUI("PachinkoSelectorNoButtons", "elementText"));
             return;
         }
         if (Number.isNaN(Number(Pachinko.orbsToGo)) || Pachinko.orbsToGo < 1 || Pachinko.orbsToGo > Pachinko.orbLeftOnAutoStart) {
-            logHHAuto('Invalid orbs number ' + Pachinko.orbsToGo);
+            LogUtils_logHHAuto('Invalid orbs number ' + Pachinko.orbsToGo);
             $("#PachinkoError").text(getTextForUI("PachinkoInvalidOrbsNb", "elementText") + " : " + Pachinko.orbsToGo);
             return;
         }
@@ -19417,7 +19424,7 @@ class Pachinko {
         // from a previous run, and a fresh retry budget.
         Pachinko.serverOrbsLeft = undefined;
         Pachinko.retry = 0;
-        logHHAuto(`Pachinko run starting: ${selectedOption.text}, target ${Pachinko.orbsToGo}, available ${Pachinko.orbLeftOnAutoStart}.`);
+        LogUtils_logHHAuto(`Pachinko run starting: ${selectedOption.text}, target ${Pachinko.orbsToGo}, available ${Pachinko.orbLeftOnAutoStart}.`);
         Pachinko.autoPachinkoRunning = true;
         setTimeout(Pachinko.playXPachinko_func, randomInterval(500, 1500));
     }
@@ -19430,29 +19437,29 @@ class Pachinko {
     // StartService page-load reset). Restore autoLoop here directly.
     static cancelXPachinkoRun() {
         maskHHPopUp();
-        logHHAuto("Cancel clicked, closing popUp.");
+        LogUtils_logHHAuto("Cancel clicked, closing popUp.");
         Pachinko.autoPachinkoRunning = false;
         if (Pachinko.failureTimeoutId)
             clearTimeout(Pachinko.failureTimeoutId); // cancel safe mode
         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-        logHHAuto("setting autoloop to true");
+        LogUtils_logHHAuto("setting autoloop to true");
         if (Pachinko_autoLoopKick)
             setTimeout(Pachinko_autoLoopKick, randomInterval(500, 800));
     }
     static stopXPachinkoNoGirl() {
-        logHHAuto("No more girl on Pachinko, cancelling.");
+        LogUtils_logHHAuto("No more girl on Pachinko, cancelling.");
         maskHHPopUp();
         Pachinko.buildPachinkoSelectPopUp();
         $("#PachinkoError").text(getTextForUI("PachinkoNoGirls", "elementText"));
     }
     static stopXPachinkoFailure() {
         if (Pachinko.retry <= 2) {
-            logHHAuto("Pachinko failure, retry once.");
+            LogUtils_logHHAuto("Pachinko failure, retry once.");
             Pachinko.retry++;
             setTimeout(Pachinko.playXPachinko_func, randomInterval(100, 300));
         }
         else {
-            logHHAuto("Pachinko failure, cancelling.");
+            LogUtils_logHHAuto("Pachinko failure, cancelling.");
             maskHHPopUp();
             Pachinko.buildPachinkoSelectPopUp();
             $("#PachinkoError").text(getTextForUI("PachinkoFailure", "elementText"));
@@ -19465,7 +19472,7 @@ class Pachinko {
             const buttonContinueSelector = '.popup_buttons #play_again:visible';
             if (!isDisplayedHHPopUp()) {
                 Pachinko.autoPachinkoRunning = false;
-                logHHAuto("PopUp closed, cancelling interval, restart autoloop.");
+                LogUtils_logHHAuto("PopUp closed, cancelling interval, restart autoloop.");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
                 if (Pachinko_autoLoopKick)
                     setTimeout(Pachinko_autoLoopKick, Number(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili)));
@@ -19475,7 +19482,7 @@ class Pachinko {
             if (confirmPachinko !== null) {
                 if (Pachinko.ByPassNoGirlChecked && confirmPachinko.querySelector("#popup_confirm.blue_button_L") !== null) {
                     confirmPachinko.querySelector("#popup_confirm.blue_button_L").click();
-                    logHHAuto('By pass no girl popup closed');
+                    LogUtils_logHHAuto('By pass no girl popup closed');
                 }
                 else {
                     Pachinko.stopXPachinkoNoGirl();
@@ -19489,9 +19496,9 @@ class Pachinko {
             const currentOrbsLeft = Pachinko.resolveStopOrbsLeft(Pachinko.serverOrbsLeft, domOrbsLeft);
             const spendedOrbs = Number(Pachinko.orbLeftOnAutoStart - currentOrbsLeft);
             if (Pachinko.debugEnabled)
-                logHHAuto(`Pachinko progress: spent ${spendedOrbs}/${Pachinko.orbsToGo} (orbsLeft server=${(_a = Pachinko.serverOrbsLeft) !== null && _a !== void 0 ? _a : 'n/a'} dom=${domOrbsLeft}).`);
+                LogUtils_logHHAuto(`Pachinko progress: spent ${spendedOrbs}/${Pachinko.orbsToGo} (orbsLeft server=${(_a = Pachinko.serverOrbsLeft) !== null && _a !== void 0 ? _a : 'n/a'} dom=${domOrbsLeft}).`);
             if (Pachinko.stopFirstGirlChecked && $('#rewards_popup #reward_holder .shards_wrapper:visible').length > 0) {
-                logHHAuto("Girl in reward, stopping...");
+                LogUtils_logHHAuto("Girl in reward, stopping...");
                 maskHHPopUp();
                 Pachinko.buildPachinkoSelectPopUp(spendedOrbs);
                 return;
@@ -19513,7 +19520,7 @@ class Pachinko {
                     pachinkoSelectedButton.click();
                     Pachinko.failureTimeoutId = setTimeout(() => {
                         // Safe mode
-                        logHHAuto("ERROR: No reply from server after more than 5s.");
+                        LogUtils_logHHAuto("ERROR: No reply from server after more than 5s.");
                         Pachinko.stopXPachinkoFailure();
                     }, randomInterval(5000, 8000));
                     // Nothing to do here, will be done by ajaxComplete handler above.
@@ -19521,7 +19528,7 @@ class Pachinko {
             }
             else {
                 RewardHelper.closeRewardPopupIfAny(false);
-                logHHAuto(`Pachinko run finished: spent ${spendedOrbs}/${Pachinko.orbsToGo} orbs, ${currentOrbsLeft} left.`);
+                LogUtils_logHHAuto(`Pachinko run finished: spent ${spendedOrbs}/${Pachinko.orbsToGo} orbs, ${currentOrbsLeft} left.`);
                 maskHHPopUp();
                 Pachinko.buildPachinkoSelectPopUp(spendedOrbs);
                 // The played-games grid on the pachinko page can fall out of sync with
@@ -19554,7 +19561,7 @@ class Pachinko {
                 const response = safeJsonParse(xhr.responseText, null);
                 if (!response || !response.success) {
                     if (Pachinko.debugEnabled)
-                        logHHAuto("Not response success");
+                        LogUtils_logHHAuto("Not response success");
                     Pachinko.stopXPachinkoFailure();
                     return;
                 }
@@ -19574,7 +19581,7 @@ class Pachinko {
                         setTimeout(Pachinko.playXPachinko_func, randomInterval(200, 500));
                     }
                     else if (Pachinko.debugEnabled) {
-                        logHHAuto('Ajax catched, do nothing');
+                        LogUtils_logHHAuto('Ajax catched, do nothing');
                     }
                 }
                 else
@@ -19677,7 +19684,7 @@ Pachinko.retry = 0;
 // fast runs and cause over-consumption past the requested amount (issue 1745).
 Pachinko.serverOrbsLeft = undefined;
 
-;// ./src/Module/Shop.ts
+;// CONCATENATED MODULE: ./src/Module/Shop.ts
 // Shop.ts -- Automates the equipment shop: buys and sells equipment, manages
 // inventory.
 //
@@ -19709,12 +19716,12 @@ class Shop {
     }
     static updateShop() {
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDShop")) {
-            logHHAuto("Navigating to Market window.");
+            LogUtils_logHHAuto("Navigating to Market window.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
             return true;
         }
         else {
-            logHHAuto("Detected Market Screen. Fetching Assortment");
+            LogUtils_logHHAuto("Detected Market Screen. Fetching Assortment");
             var assA = [];
             var assB = [];
             var assG = [];
@@ -19765,12 +19772,12 @@ class Shop {
             setStoredValue(HHStoredVarPrefixKey + TK.haveExp, HaveExp);
             setStoredValue(HHStoredVarPrefixKey + TK.haveBooster, JSON.stringify(HaveBooster));
             setStoredValue(HHStoredVarPrefixKey + TK.boosterIdMap, JSON.stringify(BoosterIdMap));
-            logHHAuto('counted ' + getStoredValue(HHStoredVarPrefixKey + TK.haveAff) + ' Aff, ' + getStoredValue(HHStoredVarPrefixKey + TK.haveExp) + ' Exp, Booster: ' + JSON.stringify(HaveBooster));
+            LogUtils_logHHAuto('counted ' + getStoredValue(HHStoredVarPrefixKey + TK.haveAff) + ' Aff, ' + getStoredValue(HHStoredVarPrefixKey + TK.haveExp) + ' Exp, Booster: ' + JSON.stringify(HaveBooster));
             // Debug: log each booster found in player inventory with id_item and quantity
             for (const [identifier, data] of Object.entries(BoosterIdMap)) {
                 const qty = HaveBooster[identifier] || 0;
                 const entry = data;
-                logHHAuto(`  Booster inventory: ${entry.name} [${identifier}] id_item=${entry.id_item} rarity=${entry.rarity} qty=${qty}`);
+                LogUtils_logHHAuto(`  Booster inventory: ${entry.name} [${identifier}] id_item=${entry.id_item} rarity=${entry.rarity} qty=${qty}`);
             }
             setStoredValue(HHStoredVarPrefixKey + TK.storeContents, JSON.stringify([assA, assB, assG, assP]));
             setStoredValue(HHStoredVarPrefixKey + TK.charLevel, HeroHelper.getLevel());
@@ -19787,7 +19794,7 @@ class Shop {
             if (isJSON(getStoredValue(HHStoredVarPrefixKey + TK.LastPageCalled))
                 && getPage() === getStoredJSON(HHStoredVarPrefixKey + TK.LastPageCalled, { page: '' }).page) {
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
-                logHHAuto("Go to Home after Shopping");
+                LogUtils_logHHAuto("Go to Home after Shopping");
             }
         }
         return false;
@@ -20032,7 +20039,7 @@ class Shop {
                         $("#" + menuID).remove();
                     }
                     catch (e) {
-                        logHHAuto("Catched error : Couldn't remove " + menuID + " menu : " + e);
+                        LogUtils_logHHAuto("Catched error : Couldn't remove " + menuID + " menu : " + e);
                     }
                 }
                 return;
@@ -20101,7 +20108,7 @@ class Shop {
                 });
                 $("#menuSellButton").on("click", function () {
                     if (Number(document.getElementById("menuSellNumber").value) > 0) {
-                        logHHAuto("Starting selling " + Number(document.getElementById("menuSellNumber").value) + " items.");
+                        LogUtils_logHHAuto("Starting selling " + Number(document.getElementById("menuSellNumber").value) + " items.");
                         sellArmorItems();
                     }
                 });
@@ -20110,13 +20117,13 @@ class Shop {
                 const SellDialog = document.getElementById("SellDialog");
                 if (typeof SellDialog.showModal !== "function") {
                     alert("The <dialog> API is not supported by this browser");
-                    logHHAuto("The <dialog> API is not supported by this browser");
+                    LogUtils_logHHAuto("The <dialog> API is not supported by this browser");
                     return;
                 }
                 menuSellMaxItems = Number(window.prompt("Max amount of inventory to load (all for no limit)", menuSellMaxItems + ''));
                 if (menuSellMaxItems !== null) {
                     menuSellMaxItems = isNaN(menuSellMaxItems) ? Number.MAX_VALUE : menuSellMaxItems;
-                    logHHAuto(`Going to load ${menuSellMaxItems} items`);
+                    LogUtils_logHHAuto(`Going to load ${menuSellMaxItems} items`);
                     $("menuSellStop").css("display", "block");
                     menuSellStop = false;
                     fetchStarted = true;
@@ -20166,10 +20173,10 @@ class Shop {
                 const oldCount = $(itemsQuery).length;
                 $("#menuSellCurrentCount").html(oldCount + '');
                 if (allLoaded) {
-                    logHHAuto(`No more items to load, currently: ${oldCount}/${menuSellMaxItems}`);
+                    LogUtils_logHHAuto(`No more items to load, currently: ${oldCount}/${menuSellMaxItems}`);
                 }
                 else {
-                    logHHAuto(`Loading items, currently: ${oldCount}/${menuSellMaxItems}`);
+                    LogUtils_logHHAuto(`Loading items, currently: ${oldCount}/${menuSellMaxItems}`);
                 }
                 const scroll = $("#player-inventory.armor")[0];
                 const SellDialog = document.getElementById("SellDialog");
@@ -20184,14 +20191,14 @@ class Shop {
                         menuSellListItems();
                     }
                     else {
-                        logHHAuto('Sell Dialog closed, stopping');
+                        LogUtils_logHHAuto('Sell Dialog closed, stopping');
                     }
                     return;
                 }
                 scroll.scrollTop = scroll.scrollHeight - scroll.offsetHeight;
             }
             catch (err) {
-                logHHAuto('Error during armor item fetch, restoring animations: ' + err);
+                LogUtils_logHHAuto('Error during armor item fetch, restoring animations: ' + err);
                 unsafeWindow.shared.animations.loadingAnimation.start = loadingAnimationStart;
                 unsafeWindow.shared.animations.loadingAnimation.stop = loadingAnimationStop;
                 fetchStarted = false;
@@ -20213,8 +20220,8 @@ class Shop {
         }
         function sellArmorItems() {
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("setting autoloop to false");
-            logHHAuto('start selling common, rare and epic stuff');
+            LogUtils_logHHAuto("setting autoloop to false");
+            LogUtils_logHHAuto('start selling common, rare and epic stuff');
             $("#menuSellHide").css("display", "none");
             $("#menuSoldHide").css("display", "block");
             // Scroll to top
@@ -20232,30 +20239,30 @@ class Shop {
             function selling_func() {
                 const SellDialog = document.getElementById("SellDialog");
                 if ($('#player-inventory.armor').length === 0) {
-                    logHHAuto('Wrong tab');
+                    LogUtils_logHHAuto('Wrong tab');
                     sellArmorEnded();
                     return;
                 }
                 else if (!SellDialog.open) {
-                    logHHAuto('Sell Dialog closed, stopping');
+                    LogUtils_logHHAuto('Sell Dialog closed, stopping');
                     sellArmorEnded();
                     return;
                 }
                 const availebleItems = $(itemsQuery);
                 const currentNumberOfItems = availebleItems.length;
                 if (currentNumberOfItems === 0) {
-                    logHHAuto('no more items for sale');
+                    LogUtils_logHHAuto('no more items for sale');
                     sellingEnd(getTextForUI("menuSoldMessageNoMore", "elementText"));
                     return;
                 }
                 if (initialNumberOfItems < currentNumberOfItems) {
-                    logHHAuto('Some items was loaded in the background, can\'t continue');
+                    LogUtils_logHHAuto('Some items was loaded in the background, can\'t continue');
                     sellingEnd(getTextForUI("menuSoldMessageErrorLoaded", "elementText"));
                     return;
                 }
                 //console.log(initialNumberOfItems,currentNumberOfItems);
                 if ((initialNumberOfItems - currentNumberOfItems) >= itemsToSell) {
-                    logHHAuto('Reach wanted sold items.');
+                    LogUtils_logHHAuto('Reach wanted sold items.');
                     sellingEnd(getTextForUI("menuSoldMessageReachNB", "elementText"));
                     return;
                 }
@@ -20266,7 +20273,7 @@ class Shop {
                     if (availebleItems.filter('.selected').filter(':not(.legendary),[canBeSold]').length > 0) {
                         can_sell = true;
                     }
-                    logHHAuto('can be sold ' + can_sell + ' : ' + availebleItems.filter('.selected')[0].getAttribute('data-d'));
+                    LogUtils_logHHAuto('can be sold ' + can_sell + ' : ' + availebleItems.filter('.selected')[0].getAttribute('data-d'));
                     if (can_sell) {
                         $('#shops .menu-switch-tab-content.active button.green_text_button[rel=sell]').click();
                         const currSellNumber = Number((initialNumberOfItems - currentNumberOfItems) + 1);
@@ -20321,7 +20328,7 @@ class Shop {
                         }
                     }
                     if ($('#player-inventory.armor [canBeSold]:not([menuSellLocked]):not(.mythic)').length === 0) {
-                        logHHAuto('no more items for sale');
+                        LogUtils_logHHAuto('no more items for sale');
                         sellingEnd(getTextForUI("menuSoldMessageReachNB", "elementText"));
                         return;
                     }
@@ -20333,7 +20340,7 @@ class Shop {
     }
 }
 
-;// ./src/Service/TeamScoringService.ts
+;// CONCATENATED MODULE: ./src/Service/TeamScoringService.ts
 // TeamScoringService.ts -- Pure scoring helpers for the Spec-driven team builder.
 //
 // Public surface (everything else is gone after the v7.35.39 refactor):
@@ -20504,7 +20511,7 @@ class TeamScoringService {
     }
 }
 
-;// ./src/Service/TeamBuilderService.ts
+;// CONCATENATED MODULE: ./src/Service/TeamBuilderService.ts
 // TeamBuilderService.ts -- Spec-driven team builder.
 //
 // Implements docs-internal/REVIEW_TeamSelection.md.
@@ -21212,7 +21219,7 @@ class TeamBuilderService {
     }
 }
 
-;// ./src/Service/TraitMappings.ts
+;// CONCATENATED MODULE: ./src/Service/TraitMappings.ts
 // TraitMappings.ts -- Maps internal hex / image / unicode codes to
 // human-readable trait names.
 //
@@ -21349,7 +21356,7 @@ class TraitMappings {
     }
 }
 
-;// ./src/model/TeamData.ts
+;// CONCATENATED MODULE: ./src/model/TeamData.ts
 // Model representing the player's team composition and scroll inventory.
 // Contains the list of team girls and counts for each scroll rarity tier.
 class TeamData {
@@ -21359,7 +21366,7 @@ class TeamData {
     }
 }
 
-;// ./src/Module/TeamModule.ts
+;// CONCATENATED MODULE: ./src/Module/TeamModule.ts
 // TeamModule.ts -- Team management: auto-selects optimal teams for different
 // battle modes.
 //
@@ -21432,11 +21439,11 @@ class TeamModule {
     }
     static unequipAllGirls(callback = null) {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDEditTeam") || getPage() === ConfigHelper.getHHScriptVars("pagesIDBattleTeams")) {
-            logHHAuto('Unequip from edit team');
+            LogUtils_logHHAuto('Unequip from edit team');
             $("#UnequipAll").attr('disabled', 'disabled');
             const girlId = TeamModule.getFirstSelectedGirlId();
             if (isNaN(girlId) || girlId < 0) {
-                logHHAuto('Error: can\'t get mandatory girl id, cancel action');
+                LogUtils_logHHAuto('Error: can\'t get mandatory girl id, cancel action');
                 return;
             }
             const currentPage = window.location.pathname + window.location.search;
@@ -21508,7 +21515,7 @@ class TeamModule {
             team.scrolls_common = neededCommonScrolls;
             scrollTooltipDetail += `<span class="scrolls_common_icn" style="width: 25px;height: 25px;"></span> Common: ${neededCommonScrolls}/${heroCurrencies.scrolls_common} <br/>`;
         }
-        logHHAuto(`Needed ${neededMythicScrolls} mythic scrolls, ${neededLegendaryScrolls} legendary scrolls, ${neededEpicScrolls} epic scrolls, ${neededRareScrolls} rare scrolls and ${neededCommonScrolls} common scrolls for the current team`);
+        LogUtils_logHHAuto(`Needed ${neededMythicScrolls} mythic scrolls, ${neededLegendaryScrolls} legendary scrolls, ${neededEpicScrolls} epic scrolls, ${neededRareScrolls} rare scrolls and ${neededCommonScrolls} common scrolls for the current team`);
         const scrollTooltip = $('<div class="hhScrollTooltip"><span class="scrolls_common_icn" style="width: 25px;height: 25px;"></span></div>');
         scrollTooltip.css('position', 'absolute').css('top', '110px').css('right', '30px');
         scrollTooltip.attr('tooltip', `<div style="max-width: 290px;">${getTextForUI("skillPointTooltipTitle", "elementText")}<br />
@@ -21575,7 +21582,7 @@ class TeamModule {
         document.getElementById("StuffTeamEquipment").checked = true;
         document.getElementById("StuffTeamSkills").checked = true;
         $("#stuffTeamSubmit").on("click", function () {
-            logHHAuto('Stuff from edit team');
+            LogUtils_logHHAuto('Stuff from edit team');
             //$("#StuffTeam").attr('disabled', 'disabled');
             const saveAndGo = function () {
                 const teamSettings = {
@@ -21586,7 +21593,7 @@ class TeamModule {
                     resetRareGirls: document.getElementById("stuffTeamResetRareGirls").checked,
                     resetCommonGirls: document.getElementById("stuffTeamResetCommonGirls").checked,
                 };
-                logHHAuto('Team settings: ' + JSON.stringify(teamSettings));
+                LogUtils_logHHAuto('Team settings: ' + JSON.stringify(teamSettings));
                 setStoredValue(HHStoredVarPrefixKey + TK.haremTeam, JSON.stringify(team));
                 setStoredValue(HHStoredVarPrefixKey + TK.haremGirlActions, HaremGirl.SKILLS_TYPE + '_' + HaremGirl.EQUIPMENT_TYPE);
                 setStoredValue(HHStoredVarPrefixKey + TK.haremGirlMode, 'team');
@@ -21596,7 +21603,7 @@ class TeamModule {
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDWaifu"));
                 }
                 else {
-                    logHHAuto('No skill to reset, going to harem.');
+                    LogUtils_logHHAuto('No skill to reset, going to harem.');
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHarem"));
                 }
             };
@@ -21613,7 +21620,7 @@ class TeamModule {
     static getSkillNeededScrolls(mainGirl, teamGirls, rarity, nbGrades) {
         const girls = teamGirls.filter(girl => girl.girl && girl.girl.rarity === rarity && girl.girl.nb_grades == nbGrades);
         if (girls.length > 0)
-            logHHAuto(`Found ${girls.length} ${rarity} girls with ${nbGrades} grades in the team.`);
+            LogUtils_logHHAuto(`Found ${girls.length} ${rarity} girls with ${nbGrades} grades in the team.`);
         let usedScrolls = 0;
         for (const girl of girls) {
             const skills = Object.values(girl.skill_tiers_info);
@@ -21626,14 +21633,14 @@ class TeamModule {
             usedScrolls += Number(skills.reduce((accumulator, skill) => accumulator + (skill.skill_points_used || 0), 0));
         }
         if (girls.length > 0)
-            logHHAuto(`Total skill points used by ${rarity}_${nbGrades} girls in the team: ${usedScrolls}/${fullNeededScrolls}`);
+            LogUtils_logHHAuto(`Total skill points used by ${rarity}_${nbGrades} girls in the team: ${usedScrolls}/${fullNeededScrolls}`);
         return Math.max(0, fullNeededScrolls - usedScrolls);
     }
     static equipAllGirls() {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDBattleTeams")) {
             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-            logHHAuto("Setting autoloop to false to let the equip action complete without interruptions.");
-            logHHAuto('Equip team');
+            LogUtils_logHHAuto("Setting autoloop to false to let the equip action complete without interruptions.");
+            LogUtils_logHHAuto('Equip team');
             $("#EquipAll").attr('disabled', 'disabled');
             const girlIds = TeamModule.getSelectedGirlsId();
             if (girlIds.length == 0) {
@@ -21642,7 +21649,7 @@ class TeamModule {
             const currentPage = window.location.pathname + window.location.search;
             let index = 0;
             const equipGirl = (girlId) => {
-                logHHAuto(`Performing equip action for girl ${girlId} (${index + 1}/${girlIds.length})`);
+                LogUtils_logHHAuto(`Performing equip action for girl ${girlId} (${index + 1}/${girlIds.length})`);
                 $(`.team-member-container[data-girl-id="${girlId}"]`).addClass('selected');
                 // change referer
                 //logHHAuto('change referer to ' + '/characters/' + girlId);
@@ -21654,10 +21661,10 @@ class TeamModule {
                 getHHAjax()(params1, function (data) {
                     $('.team-member-container').removeClass('selected');
                     if (data && data.success) {
-                        logHHAuto(`Successfully equip girl ${girlId}`);
+                        LogUtils_logHHAuto(`Successfully equip girl ${girlId}`);
                     }
                     else
-                        logHHAuto(`Failed to equip girl ${girlId}`);
+                        LogUtils_logHHAuto(`Failed to equip girl ${girlId}`);
                     index++;
                     if (index <= (girlIds.length - 1)) {
                         setTimeout(function () { equipGirl(girlIds[index]); }, randomInterval(800, 1000));
@@ -21687,34 +21694,34 @@ class TeamModule {
     static getSelectedGirlsId() {
         const selectedTeam = $('.team-slot-container.selected-team').attr('data-team-index');
         if (isNaN(Number(selectedTeam))) {
-            logHHAuto('Error: can\'t get selected team index, cancel action');
+            LogUtils_logHHAuto('Error: can\'t get selected team index, cancel action');
             return [];
         }
         const girlIds = [...unsafeWindow.teams_data[selectedTeam].girls_ids];
         if (girlIds.length != 7) {
-            logHHAuto('Error: can\'t get all team members, cancel action');
+            LogUtils_logHHAuto('Error: can\'t get all team members, cancel action');
             return [];
         }
-        logHHAuto('Selected team: ' + selectedTeam + ', Team members to equip: ' + girlIds.join(', '));
+        LogUtils_logHHAuto('Selected team: ' + selectedTeam + ', Team members to equip: ' + girlIds.join(', '));
         return girlIds;
     }
     static getSelectedGirls() {
         const selectedTeam = $('.team-slot-container.selected-team').attr('data-team-index');
         if (isNaN(Number(selectedTeam))) {
-            logHHAuto('Error: can\'t get selected team index, cancel action');
+            LogUtils_logHHAuto('Error: can\'t get selected team index, cancel action');
             return [];
         }
         const girls = [...unsafeWindow.teams_data[selectedTeam].girls];
         if (girls.length != 7) {
-            logHHAuto('Error: can\'t get all team members, cancel action');
+            LogUtils_logHHAuto('Error: can\'t get all team members, cancel action');
             return [];
         }
-        logHHAuto('Selected team: ' + selectedTeam + ', Team members to equip: ' + girls.map(girl => girl.girl.name).join(', '));
+        LogUtils_logHHAuto('Selected team: ' + selectedTeam + ', Team members to equip: ' + girls.map(girl => girl.girl.name).join(', '));
         return girls;
     }
     static assignTopTeam() {
         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-        logHHAuto("setting autoloop to false");
+        LogUtils_logHHAuto("setting autoloop to false");
         function selectFromHaremBest(i, best) {
             let girlToSelect = best ? i : i + 7;
             //console.log(i,girlToSelect,best);
@@ -21752,7 +21759,7 @@ class TeamModule {
             TeamModule.setTopTeamV2(sumFormulaType, availableGirls);
         }
         else {
-            logHHAuto('availableGirls not found, falling back to legacy team selection');
+            LogUtils_logHHAuto('availableGirls not found, falling back to legacy team selection');
             TeamModule.setTopTeamLegacy(sumFormulaType);
         }
     }
@@ -21793,7 +21800,7 @@ class TeamModule {
         const resultMode2 = TeamBuilderService.buildTeam(girls, 2, playerLevel, playerClass);
         const result = mode === 1 ? resultMode1 : resultMode2;
         if (!result) {
-            logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
+            LogUtils_logHHAuto('Not enough girls for team selection v2 (mode ' + mode + '), falling back to legacy');
             TeamModule.setTopTeamLegacy(mode);
             return;
         }
@@ -21843,7 +21850,7 @@ class TeamModule {
             ? `ProjSum=${result.projectedSum.toLocaleString()}, MainSum=${result.mainSum.toLocaleString()}`
             : `MainSum=${result.mainSum.toLocaleString()}, ProjSum=${result.projectedSum.toLocaleString()}`;
         const fbStr = result.poolUsed === 'fallback' ? `, FALLBACK=${result.fallbackReason || 'short pool'}` : '';
-        logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), Pool=${result.poolUsed}, ${sumLabel}, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${result.girls[0].rarity}, ${inClusterStr})${leaderReasonStr}, Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/${result.girls.length}), Elements: ${distStr}, ${psStr}, Blessings: ${blessStr}${fbStr}${identStr}`);
+        LogUtils_logHHAuto(`Team v2 [${modeName}]: Class=${playerClassNameLog} (${mainCaracLabel}), Pool=${result.poolUsed}, ${sumLabel}, Tier3=${(result.tier3Bonus * 100).toFixed(1)}%, Leader=${result.girls[0].name} (${result.leaderTier5.name}, ${result.girls[0].rarity}, ${inClusterStr})${leaderReasonStr}, Trait: ${result.traitCategory}=${result.traitValue} (${result.traitMatchCount}/${result.girls.length}), Elements: ${distStr}, ${psStr}, Blessings: ${blessStr}${fbStr}${identStr}`);
         // Per-slot detail line for diagnosis: tells the issue reporter
         // exactly which 7 girls were picked, with level/awakening/grades/score
         // and any active blessing percent. Cross-checks against the game UI
@@ -21856,7 +21863,7 @@ class TeamModule {
                 const cl = s.inCluster ? '*' : '';
                 return `[${i + 1}${cl}] ${s.name} (${s.rarity}/${s.element} lvl${s.level} aw${(_a = s.awakening_level) !== null && _a !== void 0 ? _a : '?'} ${s.graded}/${s.nb_grades}${tvStr}${blStr} score=${Math.round(s.score)})`;
             }).join(' | ');
-            logHHAuto(`Team v2 [${modeName}] slots: ${slotsStr}`);
+            LogUtils_logHHAuto(`Team v2 [${modeName}] slots: ${slotsStr}`);
         }
         // UI update: same approach as legacy — hide non-selected, show + number selected
         TeamModule.updateTeamUI(deckID, result);
@@ -21877,7 +21884,7 @@ class TeamModule {
             let gID = Number($(arr[i]).attr('id_girl'));
             const tooltipData = $('.girl_img', $(arr[i])).attr(ConfigHelper.getHHScriptVars('girlToolTipData')) || '';
             if (tooltipData == '') {
-                logHHAuto('ERROR, no girl information found');
+                LogUtils_logHHAuto('ERROR, no girl information found');
                 return;
             }
             let obj = JSON.parse(tooltipData);
@@ -21933,7 +21940,7 @@ class TeamModule {
             TeamModule.ensureAssignTopTeamButton();
         }
         catch (err) {
-            logHHAuto('Failed to render AssignTopTeam button: ' + err);
+            LogUtils_logHHAuto('Failed to render AssignTopTeam button: ' + err);
         }
         for (let i = arr.length - 1; i > -1; i--) {
             const gID = Number($(arr[i]).attr('id_girl'));
@@ -21985,7 +21992,7 @@ class TeamModule {
             TeamModule.renderTeamInfoPanel(teamResult);
         }
         catch (err) {
-            logHHAuto('Failed to render team info panel: ' + err);
+            LogUtils_logHHAuto('Failed to render team info panel: ' + err);
         }
     }
     /**
@@ -22142,7 +22149,7 @@ TeamModule.PLAYER_CLASS_NAME = {
  */
 TeamModule.lastMainSum = {};
 
-;// ./src/Service/AdsService.ts
+;// CONCATENATED MODULE: ./src/Service/AdsService.ts
 // AdsService.ts
 //
 // Manages in-game advertisements that can interfere with automation.
@@ -22376,7 +22383,7 @@ class AdsService {
             // must not be auto-confirmed.
             const pending = findConfirmButton();
             if (pending && AdsService.hasRecentAdClick()) {
-                logHHAuto("Ads: confirming pending reward (OK).");
+                LogUtils_logHHAuto("Ads: confirming pending reward (OK).");
                 pending.click();
                 setTimer("nextAdsTime", randomInterval(...AD_COOLDOWN_RECHECK));
                 AdsService.reloadForNextAd();
@@ -22384,7 +22391,7 @@ class AdsService {
             }
             const buttons = findAdButtons();
             if (buttons.length === 0) {
-                logHHAuto("Ads: no reward ad on the page.");
+                LogUtils_logHHAuto("Ads: no reward ad on the page.");
                 setTimer("nextAdsTime", randomInterval(...AD_COOLDOWN_RECHECK));
                 return false;
             }
@@ -22400,7 +22407,7 @@ class AdsService {
                     adName += " -> " + new URL(adMatch[2]).host;
             }
             catch ( /* keep the plain id when the URL does not parse */_a) { /* keep the plain id when the URL does not parse */ }
-            logHHAuto("Ads: clicking reward ad ('Try it now', id " + adName + "). "
+            LogUtils_logHHAuto("Ads: clicking reward ad ('Try it now', id " + adName + "). "
                 + (buttons.length - 1) + " more waiting.");
             AdsService.lastAdClickAt = Date.now();
             const handle = yield captureOpenedWindow(unsafeWindow, () => {
@@ -22412,29 +22419,29 @@ class AdsService {
                     handle.close();
                 }
                 catch (err) {
-                    logHHAuto("Ads: could not close ad tab: " + String(err));
+                    LogUtils_logHHAuto("Ads: could not close ad tab: " + String(err));
                 }
             }
             else {
                 // The tab may still have opened through a path the wrapper cannot
                 // see (or a popup blocker stopped it) -- wait for the confirm
                 // before deciding which of the two it was.
-                logHHAuto("Ads: no ad-tab handle captured, waiting for the reward confirm anyway.");
+                LogUtils_logHHAuto("Ads: no ad-tab handle captured, waiting for the reward confirm anyway.");
             }
             const confirmBtn = yield AdsService.waitForConfirmButton();
             if (!handle && !confirmBtn) {
                 // Neither a tab we control nor a reward confirm: popup blocker.
                 // Do NOT retry in a loop -- log and back off for a long cooldown.
-                logHHAuto("Ads: no ad tab and no reward confirm (popup blocker?). Backing off.");
+                LogUtils_logHHAuto("Ads: no ad tab and no reward confirm (popup blocker?). Backing off.");
                 setTimer("nextAdsTime", randomInterval(...AD_COOLDOWN_BLOCKED));
                 return false;
             }
             if (confirmBtn) {
-                logHHAuto("Ads: reward available, confirming (OK).");
+                LogUtils_logHHAuto("Ads: reward available, confirming (OK).");
                 confirmBtn.click();
             }
             else {
-                logHHAuto("Ads: reward confirm (OK) not visible yet, will retry shortly.");
+                LogUtils_logHHAuto("Ads: reward confirm (OK) not visible yet, will retry shortly.");
             }
             // Come back soon: for the next ad, for a late OK (the pending-confirm
             // check at the top of the next step catches it), or to spot a newly
@@ -22455,7 +22462,7 @@ class AdsService {
      * issue #1598).
      */
     static reloadForNextAd() {
-        logHHAuto("Ads: reloading the page so the next reward ad can appear.");
+        LogUtils_logHHAuto("Ads: reloading the page so the next reward ad can appear.");
         safeReload();
     }
 }
@@ -22470,7 +22477,7 @@ AdsService.lastAdClickAt = 0;
  *  popup on screen belongs to something else and must not be clicked. */
 AdsService.PENDING_CONFIRM_WINDOW_MS = 10 * 60 * 1000;
 
-;// ./src/Service/AutoLoopPageHandlers.ts
+;// CONCATENATED MODULE: ./src/Service/AutoLoopPageHandlers.ts
 // AutoLoopPageHandlers.ts
 //
 // Handles page-specific UI enhancements that run on every loop
@@ -22779,7 +22786,7 @@ function handlePageSpecific(ctx) {
     });
 }
 
-;// ./src/Service/AutoLoop.ts
+;// CONCATENATED MODULE: ./src/Service/AutoLoop.ts
 var AutoLoop_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -22880,19 +22887,19 @@ function CheckSpentPoints() {
         }
         setStoredValue(HHStoredVarPrefixKey + TK.CheckSpentPoints, JSON.stringify(newValues));
         if (ConfigHelper.getHHScriptVars('isEnabledLeagues', false) && newValues['challenge'] > (oldValues['challenge'] + 1)) {
-            logHHAuto("Seems league point bought, resetting timer.");
+            LogUtils_logHHAuto("Seems league point bought, resetting timer.");
             clearTimer('nextLeaguesTime');
         }
         if (ConfigHelper.getHHScriptVars('isEnabledSeason', false) && newValues['kiss'] > (oldValues['kiss'] + 1)) {
-            logHHAuto("Seems season point bought, resetting timer.");
+            LogUtils_logHHAuto("Seems season point bought, resetting timer.");
             clearTimer('nextSeasonTime');
         }
         if (ConfigHelper.getHHScriptVars('isEnabledPantheon', false) && newValues['worship'] > (oldValues['worship'] + 1)) {
-            logHHAuto("Seems Pantheon point bought, resetting timer.");
+            LogUtils_logHHAuto("Seems Pantheon point bought, resetting timer.");
             clearTimer('nextPantheonTime');
         }
         if (ConfigHelper.getHHScriptVars('isEnabledPentaDrill', false) && newValues['drill'] > (oldValues['drill'] + 1)) {
-            logHHAuto("Seems Penta Drill point bought, resetting timer.");
+            LogUtils_logHHAuto("Seems Penta Drill point bought, resetting timer.");
             clearTimer('nextPentaDrillTime');
         }
     }
@@ -22941,7 +22948,7 @@ function autoLoop() {
         const userPaused = isUserPauseActive();
         if (burst && userPaused && Date.now() - lastMousePauseLog >= 2000) {
             lastMousePauseLog = Date.now();
-            logHHAuto("Mouse pause active, holding automation.");
+            LogUtils_logHHAuto("Mouse pause active, holding automation.");
         }
         if (burst && !userPaused /*|| checkTimer('nextMissionTime')*/) {
             if (!checkTimer("paranoiaSwitch")) {
@@ -22965,7 +22972,7 @@ function autoLoop() {
             // (issue #1598 follow-up: an earlier patch gated the whole
             // autoLoop tick and starved the menu UI).
             if (isPostInFlight()) {
-                logHHAuto('AutoLoop: POST in flight, deferring action handlers this tick');
+                LogUtils_logHHAuto('AutoLoop: POST in flight, deferring action handlers this tick');
             }
             else {
                 // --- Action Handlers (executed in order, each checks ctx.busy) ---
@@ -23005,23 +23012,23 @@ function autoLoop() {
             // logHHAuto("no action performed in this loop, rest lastActionPerformed");
         }
         if (ctx.lastActionPerformed !== getStoredValue(HHStoredVarPrefixKey + TK.lastActionPerformed)) {
-            logHHAuto("lastActionPerformed changed to " + ctx.lastActionPerformed);
+            LogUtils_logHHAuto("lastActionPerformed changed to " + ctx.lastActionPerformed);
         }
         setStoredValue(HHStoredVarPrefixKey + TK.lastActionPerformed, ctx.lastActionPerformed);
         if (isNaN(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili))) {
-            logHHAuto("AutoLoopTimeMili is not a number.");
+            LogUtils_logHHAuto("AutoLoopTimeMili is not a number.");
             StartService_setDefaults(true);
         }
         else if (isAutoLoopActive()) {
             setTimeout(autoLoop, Number(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili)));
         }
         else {
-            logHHAuto("autoLoop Disabled");
+            LogUtils_logHHAuto("autoLoop Disabled");
         }
     });
 }
 
-;// ./src/Module/Events/DoublePenetration.ts
+;// CONCATENATED MODULE: ./src/Module/Events/DoublePenetration.ts
 // DoublePenetration.ts -- Double Penetration event: fight tracking and rewards.
 //
 // Double Penetration is a time-limited competitive event with its own fight
@@ -23077,8 +23084,8 @@ class DoublePenetration {
             const dPPaidSlotQuery = ".paid-slot .slot,.paid-slot .slot_girl_shards";
             const isPassPaid = $("#nc-poa-tape-blocker button.unlock-poa-bonus-rewards:visible").length <= 0;
             if (needToCollect || needToCollectAll || manualCollectAll) {
-                logHHAuto("Checking double penetration event for collectable rewards.");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("Checking double penetration event for collectable rewards.");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 let buttonsToCollect = [];
                 const listDpEventTiersToClaim = $(dPTierQuery);
@@ -23087,11 +23094,11 @@ class DoublePenetration {
                     const currentTierNb = currentButton.getAttribute("tier");
                     //console.log("checking tier : "+currentTierNb);
                     if (needToCollectAll) {
-                        logHHAuto("Adding for collection tier before end of event: " + currentTierNb);
+                        LogUtils_logHHAuto("Adding for collection tier before end of event: " + currentTierNb);
                         buttonsToCollect.push(currentButton);
                     }
                     else if (manualCollectAll) {
-                        logHHAuto("Adding for collection tier from manual collect all: " + currentTierNb);
+                        LogUtils_logHHAuto("Adding for collection tier from manual collect all: " + currentTierNb);
                         buttonsToCollect.push(currentButton);
                     }
                     else {
@@ -23102,15 +23109,15 @@ class DoublePenetration {
                                 const paidSlotType = RewardHelper.getRewardTypeBySlot($(dPPaidSlotQuery, listDpEventTiersToClaim[currentTier])[0]);
                                 if (rewardsToCollect.includes(paidSlotType)) {
                                     buttonsToCollect.push(currentButton);
-                                    logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
+                                    LogUtils_logHHAuto("Adding for collection tier (free + paid) : " + currentTierNb);
                                 }
                                 else {
-                                    logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
+                                    LogUtils_logHHAuto("Can't add tier " + currentTierNb + " as paid reward isn't to be colled");
                                 }
                             }
                             else {
                                 buttonsToCollect.push(currentButton);
-                                logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
+                                LogUtils_logHHAuto("Adding for collection tier (only free) : " + currentTierNb);
                             }
                         }
                     }
@@ -23118,14 +23125,14 @@ class DoublePenetration {
                 if (buttonsToCollect.length > 0) {
                     function collectDpEventRewards() {
                         if (buttonsToCollect.length > 0) {
-                            logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
+                            LogUtils_logHHAuto("Collecting tier : " + buttonsToCollect[0].getAttribute('tier'));
                             buttonsToCollect[0].click();
                             buttonsToCollect.shift();
                             setTimeout(RewardHelper.closeRewardPopupIfAny, randomInterval(300, 500));
                             setTimeout(collectDpEventRewards, randomInterval(500, 800));
                         }
                         else {
-                            logHHAuto("Double penetration collection finished.");
+                            LogUtils_logHHAuto("Double penetration collection finished.");
                             setTimer('nextDpEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                             //gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                             setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
@@ -23136,7 +23143,7 @@ class DoublePenetration {
                     return true;
                 }
                 else {
-                    logHHAuto("No double penetration reward to collect.");
+                    LogUtils_logHHAuto("No double penetration reward to collect.");
                     setTimer('nextDpEventCollectTime', ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180));
                     //gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
@@ -23148,13 +23155,13 @@ class DoublePenetration {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            logHHAuto(`ERROR during collect DP rewards: ${message}`);
+            LogUtils_logHHAuto(`ERROR during collect DP rewards: ${message}`);
         }
         return false;
     }
     static run() {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDEvent") && window.location.search.includes("tab=" + ConfigHelper.getHHScriptVars('doublePenetrationEventIDReg'))) {
-            logHHAuto("On Double penetration event.");
+            LogUtils_logHHAuto("On Double penetration event.");
             if (getStoredValue(HHStoredVarPrefixKey + SK.showClubButtonInPoa) === "true" && ConfigHelper.getHHScriptVars("isEnabledClubChamp", false)) {
                 GM_addStyle('#dp-content .left-container .objectives-container .hard-objective .nc-sub-panel div.buttons .redirect-buttons {flex-direction: column;}');
                 if ($(".hard-objective .hh-club-poa").length <= 0) {
@@ -23186,7 +23193,7 @@ class DoublePenetration {
         }
         catch (err) {
             const message = err instanceof Error ? err.message : String(err);
-            logHHAuto(`ERROR in display DP rewards: ${message}`);
+            LogUtils_logHHAuto(`ERROR in display DP rewards: ${message}`);
         }
     }
     static getNotClaimedRewards() {
@@ -23212,7 +23219,7 @@ class DoublePenetration {
     }
 }
 
-;// ./src/Module/Events/KinkyCumpetition.ts
+;// CONCATENATED MODULE: ./src/Module/Events/KinkyCumpetition.ts
 // KinkyCumpetition.ts -- Kinky Cumpetition event handling.
 //
 // Kinky Cumpetition is a periodic competitive event. This module parses event
@@ -23250,7 +23257,7 @@ class KinkyCumpetition {
     }
 }
 
-;// ./src/model/EventGirl.ts
+;// CONCATENATED MODULE: ./src/model/EventGirl.ts
 // Model representing a girl obtainable during an in-game event.
 // Wraps the raw KKEventGirl API data and extracts the girl ID, troll/champion
 // association, shard count, event timing, and mythic status.
@@ -23302,7 +23309,7 @@ class EventGirl {
                     let parsedURL = new URL(girlData.source.anchor_source.url, window.location.origin);
                     this.troll_id = Number(queryStringGetParam(parsedURL.search, 'id_opponent'));
                     if (girlData.source.anchor_source.disabled) {
-                        logHHAuto(`Troll ${this.troll_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
+                        LogUtils_logHHAuto(`Troll ${this.troll_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
                         this.troll_id = undefined;
                     }
                 }
@@ -23311,12 +23318,12 @@ class EventGirl {
                         let parsedURL = new URL(girlData.source.anchor_win_from[0].url, window.location.origin);
                         this.troll_id = Number(queryStringGetParam(parsedURL.search, 'id_opponent'));
                         if (girlData.source.anchor_win_from.disabled) {
-                            logHHAuto(`Troll ${this.troll_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
+                            LogUtils_logHHAuto(`Troll ${this.troll_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
                             this.troll_id = undefined;
                         }
                     }
                     catch (error) {
-                        logHHAuto(`Can't get troll from girl ${this.name} (${this.girl_id})`);
+                        LogUtils_logHHAuto(`Can't get troll from girl ${this.name} (${this.girl_id})`);
                     }
                 }
             }
@@ -23324,7 +23331,7 @@ class EventGirl {
                 try {
                     this.champ_id = Number(girlData.source.anchor_source.url.split('/champions/')[1]);
                     if (girlData.source.anchor_source.disabled) {
-                        logHHAuto(`Champion ${this.champ_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
+                        LogUtils_logHHAuto(`Champion ${this.champ_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
                         this.champ_id = undefined;
                     }
                 }
@@ -23332,12 +23339,12 @@ class EventGirl {
                     try {
                         this.champ_id = Number(girlData.source.anchor_win_from[0].url.split('/champions/')[1]);
                         if (girlData.source.anchor_win_from.disabled) {
-                            logHHAuto(`Champion ${this.champ_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
+                            LogUtils_logHHAuto(`Champion ${this.champ_id} is not available for ${this.is_mythic ? 'mythic ' : ''}girl ${this.name} (${this.girl_id}) ignoring`);
                             this.champ_id = undefined;
                         }
                     }
                     catch (error) {
-                        logHHAuto(`Can't get champion from girl ${this.name} (${this.girl_id})`);
+                        LogUtils_logHHAuto(`Can't get champion from girl ${this.name} (${this.girl_id})`);
                     }
                 }
             }
@@ -23348,13 +23355,13 @@ class EventGirl {
                 // pachinko event girl
             }
             else {
-                logHHAuto(`Other source found ${girlData.source.name}`);
+                LogUtils_logHHAuto(`Other source found ${girlData.source.name}`);
             }
         }
     }
 }
 
-;// ./src/Module/Events/MythicEvent.ts
+;// CONCATENATED MODULE: ./src/Module/Events/MythicEvent.ts
 // MythicEvent.ts -- Mythic event: wave tracking and troll fight coordination.
 //
 // Mythic events feature special troll bosses with wave-based progression and
@@ -23410,7 +23417,7 @@ class MythicEvent {
                     const eventGirl = new EventGirl(girlData, eventID, eventList[eventID]["seconds_before_end"], true);
                     if (remShards !== 0) {
                         if (eventGirl.isOnTroll()) {
-                            logHHAuto(`Event girl : ${eventGirl.toString()} with priority : ${Priority.indexOf('' + eventGirl.troll_id)}`, eventGirl);
+                            LogUtils_logHHAuto(`Event girl : ${eventGirl.toString()} with priority : ${Priority.indexOf('' + eventGirl.troll_id)}`, eventGirl);
                             eventsGirlz.push(eventGirl);
                         }
                     }
@@ -23430,7 +23437,7 @@ class MythicEvent {
     }
 }
 
-;// ./src/Module/Events/PlusEvents.ts
+;// CONCATENATED MODULE: ./src/Module/Events/PlusEvents.ts
 // PlusEvents.ts -- Plus Events: parsing and display for event overlay info.
 //
 // Plus Events are a category of events that overlay additional information
@@ -23473,11 +23480,11 @@ class PlusEvent {
                 eventList[eventID]["isCompleted"] = false;
                 const eventGirl = new EventGirl(girlData, eventID, eventList[eventID]["seconds_before_end"]);
                 if (eventGirl.isOnTroll()) {
-                    logHHAuto(`Event girl : ${eventGirl.toString()} with priority : ${Priority.indexOf('' + eventGirl.troll_id)}`, eventGirl);
+                    LogUtils_logHHAuto(`Event girl : ${eventGirl.toString()} with priority : ${Priority.indexOf('' + eventGirl.troll_id)}`, eventGirl);
                     eventsGirlz.push(eventGirl);
                 }
                 if (eventGirl.isOnChampion()) {
-                    logHHAuto(`Event girl : ${eventGirl.toString()}`, eventGirl);
+                    LogUtils_logHHAuto(`Event girl : ${eventGirl.toString()}`, eventGirl);
                     eventChamps.push(eventGirl);
                 }
             }
@@ -23488,7 +23495,7 @@ class PlusEvent {
     }
 }
 
-;// ./src/Module/Events/SultryMysteries.ts
+;// CONCATENATED MODULE: ./src/Module/Events/SultryMysteries.ts
 // SultryMysteries.ts -- Sultry Mysteries event: shop refresh and auto-buying.
 //
 // Sultry Mysteries is a time-limited event featuring a special event shop.
@@ -23524,7 +23531,7 @@ class SultryMysteries {
         eventList[eventID]["next_refresh"] = new Date().getTime() + refreshTimer * 1000;
         eventList[eventID]["isCompleted"] = false;
         if (checkTimer("eventSultryMysteryShopRefresh")) {
-            logHHAuto("Refresh sultry mysteries shop content.");
+            LogUtils_logHHAuto("Refresh sultry mysteries shop content.");
             const shopButton = $('#shop_tab');
             const gridButton = $('#grid_tab');
             shopButton.trigger('click');
@@ -23538,7 +23545,7 @@ class SultryMysteries {
     }
 }
 
-;// ./src/Module/Events/EventModule.ts
+;// CONCATENATED MODULE: ./src/Module/Events/EventModule.ts
 var EventModule_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -23671,7 +23678,7 @@ class EventModule {
     static getDisplayedIdEventPage(logging = true) {
         const eventHref = $("#contains_all #events .events-list .event-title.active").attr("href") || '';
         if (!eventHref && logging) {
-            logHHAuto('Error href not found for current event');
+            LogUtils_logHHAuto('Error href not found for current event');
         }
         if (eventHref) {
             const parsedURL = new URL(eventHref, window.location.origin);
@@ -23712,12 +23719,12 @@ class EventModule {
                 const eventID = EventModule.getDisplayedIdEventPage();
                 if (inTab !== "global" && inTab !== eventID) {
                     if (eventID === '') {
-                        logHHAuto("ERROR: No event Id found in current page, clear event data and go to home");
+                        LogUtils_logHHAuto("ERROR: No event Id found in current page, clear event data and go to home");
                         EventModule.clearEventData(inTab);
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                     }
                     else {
-                        logHHAuto("Wrong event opened, need to change event page");
+                        LogUtils_logHHAuto("Wrong event opened, need to change event page");
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDEvent"), { tab: inTab });
                     }
                     return true;
@@ -23725,7 +23732,7 @@ class EventModule {
                 const hhEvent = EventModule.getEvent(eventID);
                 if (!hhEvent.eventTypeKnown) {
                     if (queryEventTabCheck.attr('parsed') === undefined) {
-                        logHHAuto("Not parsable event");
+                        LogUtils_logHHAuto("Not parsable event");
                         queryEventTabCheck[0].setAttribute('parsed', 'true');
                     }
                     return false;
@@ -23741,7 +23748,7 @@ class EventModule {
                 // functions have always received it as-is, so keep the historic
                 // non-optional type at the call sites (WART-001).
                 const hhEventData = (unsafeWindow.event_data || unsafeWindow.current_event);
-                logHHAuto(`On event page : ${eventID} (${(hhEventData === null || hhEventData === void 0 ? void 0 : hhEventData.event_name) || ''})`);
+                LogUtils_logHHAuto(`On event page : ${eventID} (${(hhEventData === null || hhEventData === void 0 ? void 0 : hhEventData.event_name) || ''})`);
                 EventModule.clearEventData(eventID);
                 //let eventsGirlz=[];
                 const eventList = getStoredJSON(HHStoredVarPrefixKey + TK.eventsList, {});
@@ -23749,42 +23756,42 @@ class EventModule {
                 const eventChamps = getStoredJSON(HHStoredVarPrefixKey + TK.autoChampsEventGirls, []);
                 const Priority = (getStoredValue(HHStoredVarPrefixKey + SK.eventTrollOrder) || '').split(";");
                 if ((hhEvent.isPlusEvent || hhEvent.isPlusEventMythic) && !hhEventData) {
-                    logHHAuto("Error getting current event Data from HH.");
+                    LogUtils_logHHAuto("Error getting current event Data from HH.");
                 }
                 if (hhEvent.isPlusEvent) {
-                    logHHAuto("On going event, parsing...");
+                    LogUtils_logHHAuto("On going event, parsing...");
                     PlusEvent.parse(hhEvent, eventList, hhEventData, eventsGirlz, eventChamps);
                 }
                 if (hhEvent.isPlusEventMythic) {
-                    logHHAuto("On going mythic event, parsing...");
+                    LogUtils_logHHAuto("On going mythic event, parsing...");
                     MythicEvent.parse(hhEvent, eventList, hhEventData, eventsGirlz, eventChamps);
                 }
                 if (hhEvent.isBossBangEvent) {
-                    logHHAuto("On going bossBang event, parsing...");
+                    LogUtils_logHHAuto("On going bossBang event, parsing...");
                     BossBang.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isSultryMysteriesEvent) {
-                    logHHAuto("On going sultry mysteries event.");
+                    LogUtils_logHHAuto("On going sultry mysteries event.");
                     SultryMysteries.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isLivelyScene) {
-                    logHHAuto("On going lively scene event.");
+                    LogUtils_logHHAuto("On going lively scene event.");
                     LivelyScene.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isDPEvent) {
-                    logHHAuto("On going double penetration event.");
+                    LogUtils_logHHAuto("On going double penetration event.");
                     DoublePenetration.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isPoa) {
-                    logHHAuto("On going path of Attraction event.");
+                    LogUtils_logHHAuto("On going path of Attraction event.");
                     PathOfAttraction.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isCumback) {
-                    logHHAuto("On going cumback contest event.");
+                    LogUtils_logHHAuto("On going cumback contest event.");
                     CumbackContests.parse(hhEvent, eventList, hhEventData);
                 }
                 if (hhEvent.isKinky) {
-                    logHHAuto("On going kinky cumpetition event.");
+                    LogUtils_logHHAuto("On going kinky cumpetition event.");
                     KinkyCumpetition.parse(hhEvent, eventList, hhEventData);
                 }
                 if (Object.keys(eventList).length > 0) {
@@ -23855,7 +23862,7 @@ class EventModule {
                         const ev = evList[inTab];
                         const end = Number(ev === null || ev === void 0 ? void 0 : ev.seconds_before_end);
                         if (Number.isFinite(end) && end <= Date.now()) {
-                            logHHAuto(`Skipping navigation to expired event ${inTab}, dropping stale registry entry.`);
+                            LogUtils_logHHAuto(`Skipping navigation to expired event ${inTab}, dropping stale registry entry.`);
                             EventModule.clearEventData(inTab);
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                             return true;
@@ -23873,7 +23880,7 @@ class EventModule {
     }
     static saveEventGirl(eventGirlz) {
         var chosenTroll = Number(eventGirlz.troll_id);
-        logHHAuto("ET: " + chosenTroll);
+        LogUtils_logHHAuto("ET: " + chosenTroll);
         if (!eventGirlz.is_mythic) {
             setStoredValue(HHStoredVarPrefixKey + TK.eventGirl, JSON.stringify(eventGirlz));
         }
@@ -24136,7 +24143,7 @@ class EventModule {
         if (getStoredValue(HHStoredVarPrefixKey + SK.collectEventChest) === "true") {
             const eventChestId = "#extra-rewards-claim-btn:not([disabled])";
             if ($(eventChestId).length > 0) {
-                logHHAuto("Collect event chest");
+                LogUtils_logHHAuto("Collect event chest");
                 $(eventChestId).click();
             }
         }
@@ -24166,7 +24173,7 @@ class EventModule {
                 eventId = queryStringGetParam(parsedURL.search, 'tab') || '';
                 const eventName = $(queryResults[index]).children().first().text();
                 if (!eventName || eventName === '') {
-                    logHHAuto(`Error: No name displayed for event ${eventId}, ignoring it.`);
+                    LogUtils_logHHAuto(`Error: No name displayed for event ${eventId}, ignoring it.`);
                     continue;
                 }
                 if (eventId !== '' && EventModule.checkEvent(eventId)) {
@@ -24208,18 +24215,18 @@ class EventModule {
             }
             parseForEventId(dpEventQuery, eventIDs);
             if (getStoredValue(HHStoredVarPrefixKey + SK.autodpEventCollect) === "true" && $(dpEventQuery).length === 0) {
-                logHHAuto("No double penetration event found, deactivate collect.");
+                LogUtils_logHHAuto("No double penetration event found, deactivate collect.");
                 setStoredValue(HHStoredVarPrefixKey + SK.autodpEventCollect, "false");
             }
             // LivelyScene
             parseForEventId(livelySceneEventQuery, eventIDs);
             if (getStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect) === "true" && $(livelySceneEventQuery).length === 0) {
-                logHHAuto("No Lively Scene event found, deactivate collect.");
+                LogUtils_logHHAuto("No Lively Scene event found, deactivate collect.");
                 setStoredValue(HHStoredVarPrefixKey + SK.autoLivelySceneEventCollect, "false");
             }
             const queryResults = $(seasonalEventQuery);
             if ((getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonalEventCollect) === "true" || getStoredValue(HHStoredVarPrefixKey + SK.autoSeasonalEventCollectAll) === "true") && queryResults.length === 0) {
-                logHHAuto("No seasonal event found, deactivate collect.");
+                LogUtils_logHHAuto("No seasonal event found, deactivate collect.");
                 setStoredValue(HHStoredVarPrefixKey + SK.autoSeasonalEventCollect, "false");
                 setStoredValue(HHStoredVarPrefixKey + SK.autoSeasonalEventCollectAll, "false");
             }
@@ -24245,7 +24252,7 @@ class EventModule {
     }
 }
 
-;// ./src/Helper/RewardHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/RewardHelper.ts
 // RewardHelper.ts
 //
 // Detects, classifies, and renders in-game reward slots. The game
@@ -24373,7 +24380,7 @@ class RewardHelper {
             case 'mythic': return 1;
             case 'avatar': return 1;
             default:
-                logHHAuto('Error: reward type unknown ' + rewardType);
+                LogUtils_logHHAuto('Error: reward type unknown ' + rewardType);
                 return 0;
         }
     }
@@ -24516,7 +24523,7 @@ class RewardHelper {
             }
         }
         catch (err) {
-            logHHAuto("ERROR:", err.message);
+            LogUtils_logHHAuto("ERROR:", err.message);
             target.append(emptyRewardDiv);
         }
     }
@@ -24532,11 +24539,11 @@ class RewardHelper {
         let rewardQuery = `div#${popupId != '' ? popupId : 'rewards_popup'} button.blue_button_L:not([disabled]):visible`;
         if ($(rewardQuery).length > 0) {
             if ($(rewardQuery).attr('id') === 'redirect-to-harem') {
-                logHHAuto("Redirect to harem button detected.");
+                LogUtils_logHHAuto("Redirect to harem button detected.");
                 return RewardHelper.closeGirlRewardPopupIfAny(logging, popupId);
             }
             if (logging)
-                logHHAuto(`Close reward popup ${popupId != '' ? popupId : 'rewards_popup'}.`);
+                LogUtils_logHHAuto(`Close reward popup ${popupId != '' ? popupId : 'rewards_popup'}.`);
             $(rewardQuery).trigger('click');
             return true;
         }
@@ -24546,7 +24553,7 @@ class RewardHelper {
         let rewardQuery = `div#${popupId != '' ? popupId : 'rewards_popup'} button.purple_button_L:not([disabled]):visible`;
         if ($(rewardQuery).length > 0) {
             if (logging)
-                logHHAuto(`Close girl reward popup ${popupId != '' ? popupId : 'rewards_popup'}.`);
+                LogUtils_logHHAuto(`Close girl reward popup ${popupId != '' ? popupId : 'rewards_popup'}.`);
             $(rewardQuery).trigger('click');
             return true;
         }
@@ -24566,13 +24573,13 @@ class RewardHelper {
             const loveRaid = LoveRaidManager.getAllRaids();
             const foughtTrollFromLoveRaid = loveRaid.find(raid => raid.trollId === foughtTrollId);
             if (eventMythicGirl.troll_id && foughtTrollId != eventMythicGirl.troll_id && eventGirl.troll_id && foughtTrollId != eventGirl.troll_id && !foughtTrollFromLoveRaid) {
-                logHHAuto(`Troll from mythic event (${eventMythicGirl.troll_id}) or from event (${eventGirl.troll_id}) or from LoveRaid not fought, was (${foughtTrollId}) instead.
+                LogUtils_logHHAuto(`Troll from mythic event (${eventMythicGirl.troll_id}) or from event (${eventGirl.troll_id}) or from LoveRaid not fought, was (${foughtTrollId}) instead.
                 Can be issue in event variable (mythic event finished: ${EventModule.isEventActive(eventMythicGirl.event_id)},  event finished: ${EventModule.isEventActive(eventGirl.event_id)})`);
                 // TTF = foughtTrollId;
             }
             if ($('#rewards_popup #reward_holder .shards_wrapper').length === 0) {
                 clearTimeout(inCaseTimer);
-                logHHAuto("No girl in reward going back to Troll");
+                LogUtils_logHHAuto("No girl in reward going back to Troll");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: foughtTrollId });
                 return;
             }
@@ -24580,14 +24587,14 @@ class RewardHelper {
             let needLoveRaidUpdate = false;
             let loveRaidGirlWon = false;
             let girlShardsWon = $('.shards_wrapper .slot_girl_shards');
-            logHHAuto("Detected girl shard reward");
+            LogUtils_logHHAuto("Detected girl shard reward");
             for (var currGirl = 0; currGirl <= girlShardsWon.length; currGirl++) {
                 let girlIdSrc = $("img", girlShardsWon[currGirl]).attr("src") || '';
                 let girlId = Number(girlIdSrc.split('/')[5]);
                 const previousGirlShards = Math.min(Number($('.shards[shards]', girlShardsWon[currGirl]).attr('shards')), 100);
                 let wonShards = Number($('.shards[shards]', girlShardsWon[currGirl]).text().replace(/^\D+/g, ''));
                 if (!(wonShards > 0)) {
-                    logHHAuto('ERROR: Unable to gate number of shards won, default 1 shard.');
+                    LogUtils_logHHAuto('ERROR: Unable to gate number of shards won, default 1 shard.');
                     wonShards = 1;
                 }
                 const girlShards = Math.min(previousGirlShards + wonShards, 100);
@@ -24599,7 +24606,7 @@ class RewardHelper {
                             renewEvent = eventsGirlz[girlIndex].event_id;
                         }
                         if (wonShards > 0) {
-                            logHHAuto("Won " + wonShards + " event shards for " + eventsGirlz[girlIndex].name);
+                            LogUtils_logHHAuto("Won " + wonShards + " event shards for " + eventsGirlz[girlIndex].name);
                         }
                     }
                 }
@@ -24637,7 +24644,7 @@ class RewardHelper {
                 || (eventGirl === null || eventGirl === void 0 ? void 0 : eventGirl.girl_id) && EventModule.checkEvent(eventGirl.event_id)
                 || (eventMythicGirl === null || eventMythicGirl === void 0 ? void 0 : eventMythicGirl.girl_id) && EventModule.checkEvent(eventMythicGirl.event_id)) {
                 clearTimeout(inCaseTimer);
-                logHHAuto(`Need to check back event page: '${renewEvent}' or '${(_a = eventGirl === null || eventGirl === void 0 ? void 0 : eventGirl.event_id) !== null && _a !== void 0 ? _a : ''}' or '${(_b = eventMythicGirl === null || eventMythicGirl === void 0 ? void 0 : eventMythicGirl.event_id) !== null && _b !== void 0 ? _b : ''}' `);
+                LogUtils_logHHAuto(`Need to check back event page: '${renewEvent}' or '${(_a = eventGirl === null || eventGirl === void 0 ? void 0 : eventGirl.event_id) !== null && _a !== void 0 ? _a : ''}' or '${(_b = eventMythicGirl === null || eventMythicGirl === void 0 ? void 0 : eventMythicGirl.event_id) !== null && _b !== void 0 ? _b : ''}' `);
                 if (renewEvent !== "") {
                     EventModule.parseEventPage(renewEvent);
                 }
@@ -24651,13 +24658,13 @@ class RewardHelper {
             }
             else if (loveRaidGirlWon) {
                 clearTimeout(inCaseTimer);
-                logHHAuto("Parse again love Raid.");
+                LogUtils_logHHAuto("Parse again love Raid.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDLoveRaid"));
                 return;
             }
             else {
                 clearTimeout(inCaseTimer);
-                logHHAuto("Go back to troll after troll fight.");
+                LogUtils_logHHAuto("Go back to troll after troll fight.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: foughtTrollId });
                 return;
             }
@@ -24668,7 +24675,7 @@ class RewardHelper {
         if ($('#rewards_popup').length > 0) {
             if ($('#rewards_popup')[0].style.display !== "block" && $('#rewards_popup')[0].style.display !== "") {
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false to wait for troll rewards");
+                LogUtils_logHHAuto("setting autoloop to false to wait for troll rewards");
                 observerReward.observe($('#rewards_popup')[0], {
                     childList: false,
                     subtree: false,
@@ -24691,7 +24698,7 @@ class RewardHelper {
                     //replaceCheatClick();
                     setTimeout(function () {
                         $(querySkip)[0].click();
-                        logHHAuto("Clicking on pass battle.");
+                        LogUtils_logHHAuto("Clicking on pass battle.");
                     }, randomInterval(800, 1200));
                 }
             });
@@ -24705,7 +24712,7 @@ class RewardHelper {
     }
 }
 
-;// ./src/Module/Troll.ts
+;// CONCATENATED MODULE: ./src/Module/Troll.ts
 var Troll_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -24817,7 +24824,7 @@ class Troll {
             id_world = Number(getHHVars('Hero.infos.questing.id_world'));
         }
         else if (id_world <= 0) {
-            logHHAuto(`id_world given ${id_world} must be wrong, default to current world`);
+            LogUtils_logHHAuto(`id_world given ${id_world} must be wrong, default to current world`);
             id_world = Number(getHHVars('Hero.infos.questing.id_world'));
         }
         let trollIdMapping = [];
@@ -24828,17 +24835,17 @@ class Troll {
                     return trollIdMapping[id_world]; // PSH parallel adventures
                 }
                 if (logging)
-                    logHHAuto(`Error Troll ID mapping need to be updated with world ${id_world}`);
+                    LogUtils_logHHAuto(`Error Troll ID mapping need to be updated with world ${id_world}`);
             }
         }
         else {
             if (logging)
-                logHHAuto(`Side adventure detected with world ${id_world}`);
+                LogUtils_logHHAuto(`Side adventure detected with world ${id_world}`);
             trollIdMapping = ConfigHelper.getHHScriptVars("sideTrollIdMapping");
         }
         if (Object.keys(trollIdMapping).length > 0 && trollIdMapping.hasOwnProperty(id_world)) {
             if (logging)
-                logHHAuto(`Troll ID mapping (${trollIdMapping[id_world]}) found for world ${id_world}`);
+                LogUtils_logHHAuto(`Troll ID mapping (${trollIdMapping[id_world]}) found for world ${id_world}`);
             return trollIdMapping[id_world];
         }
         return id_world - 1;
@@ -24850,7 +24857,7 @@ class Troll {
         else {
             if (eventGirl)
                 EventModule.clearEventData(eventGirl.event_id);
-            logHHAuto("Event troll completed, clear event and get new troll ID");
+            LogUtils_logHHAuto("Event troll completed, clear event and get new troll ID");
             return Troll.getTrollIdToFight();
         }
     }
@@ -24877,18 +24884,18 @@ class Troll {
         // +Raid: user-selected girl bypasses grade filter, auto-mode ("first") respects it
         const loveRaids = LoveRaidManager.isActivated() ? allTrollRaids : [];
         if (debugEnabled && logging) {
-            logHHAuto('eventGirl', eventGirl);
-            logHHAuto('eventMythicGirl', eventMythicGirl);
-            logHHAuto('loveRaids', loveRaids);
+            LogUtils_logHHAuto('eventGirl', eventGirl);
+            LogUtils_logHHAuto('eventMythicGirl', eventMythicGirl);
+            LogUtils_logHHAuto('loveRaids', loveRaids);
         }
         if (getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true" && !checkTimer("eventMythicGoing") && eventMythicGirl.girl_id && eventMythicGirl.is_mythic) {
             if (logging)
-                logHHAuto("Mythic Event troll fight");
+                LogUtils_logHHAuto("Mythic Event troll fight");
             TTF = Troll.getTrollIdFromEvent(eventMythicGirl);
         }
         else if (raidStarsRaids.length > 0) {
             if (logging)
-                logHHAuto("Raid Stars troll fight (selection " + LoveRaidManager.getRaidStarsSelection() + ")");
+                LogUtils_logHHAuto("Raid Stars troll fight (selection " + LoveRaidManager.getRaidStarsSelection() + ")");
             const loveRaid = LoveRaidManager.getRaidStarsRaidToFight(raidStarsRaids, logging);
             if (loveRaid) {
                 TTF = loveRaid.trollId;
@@ -24896,17 +24903,17 @@ class Troll {
         }
         else if (getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true" && !checkTimer("eventGoing") && eventGirl.girl_id && !eventGirl.is_mythic) {
             if (logging)
-                logHHAuto("Event troll fight");
+                LogUtils_logHHAuto("Event troll fight");
             TTF = Troll.getTrollIdFromEvent(eventGirl);
         }
         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true" && (autoTrollSelectedIndex === 98 || autoTrollSelectedIndex === 99)) {
             if (trollWithGirls === undefined || trollWithGirls.length === 0) {
                 if (logging)
-                    logHHAuto("No troll with girls from storage, parsing game info ...");
+                    LogUtils_logHHAuto("No troll with girls from storage, parsing game info ...");
                 trollWithGirls = Troll.getTrollWithGirls();
                 if (trollWithGirls.length === 0) {
                     if (logging)
-                        logHHAuto("Need girls list, going to Waifu page to get them");
+                        LogUtils_logHHAuto("Need girls list, going to Waifu page to get them");
                     if (!allowSideEffects)
                         return 0;
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
@@ -24919,17 +24926,17 @@ class Troll {
             if (trollWithGirls !== undefined && trollWithGirls.length > 0) {
                 if (autoTrollSelectedIndex === 98) {
                     if (debugEnabled && logging)
-                        logHHAuto("First troll with girls from storage");
+                        LogUtils_logHHAuto("First troll with girls from storage");
                     TTF = trollWithGirls.findIndex((troll) => troll > 0) + 1;
                     if (TTF > lastTrollIdAvailable) {
                         if (logging)
-                            logHHAuto(`First troll with girls (${TTF}) is beyond last available (${lastTrollIdAvailable}), no valid troll target.`);
+                            LogUtils_logHHAuto(`First troll with girls (${TTF}) is beyond last available (${lastTrollIdAvailable}), no valid troll target.`);
                         TTF = 0;
                     }
                 }
                 else if (autoTrollSelectedIndex === 99) {
                     if (debugEnabled && logging)
-                        logHHAuto("Last troll with girls from storage");
+                        LogUtils_logHHAuto("Last troll with girls from storage");
                     TTF = trollWithGirls.findLastIndex((troll) => troll > 0) + 1;
                     if (TTF > lastTrollIdAvailable) {
                         // Find the last troll with girls that is actually unlocked
@@ -24943,36 +24950,36 @@ class Troll {
                         }
                         if (!found) {
                             if (logging)
-                                logHHAuto(`No unlocked troll has girls (last available: ${lastTrollIdAvailable}), no valid troll target.`);
+                                LogUtils_logHHAuto(`No unlocked troll has girls (last available: ${lastTrollIdAvailable}), no valid troll target.`);
                             TTF = 0;
                         }
                         else {
                             if (logging)
-                                logHHAuto(`Last troll with girls capped to ${TTF} (last available: ${lastTrollIdAvailable}).`);
+                                LogUtils_logHHAuto(`Last troll with girls capped to ${TTF} (last available: ${lastTrollIdAvailable}).`);
                         }
                     }
                 }
             }
             else if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDHome")) {
                 if (logging)
-                    logHHAuto("Can't get troll with girls, going to home page to get girl list.");
+                    LogUtils_logHHAuto("Can't get troll with girls, going to home page to get girl list.");
                 if (allowSideEffects)
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
             }
             else {
                 if (logging)
-                    logHHAuto("Can't get troll with girls, going to last troll.");
+                    LogUtils_logHHAuto("Can't get troll with girls, going to last troll.");
                 TTF = lastTrollIdAvailable;
             }
             // No troll with girls found - fall through to love raids before giving up
             if (TTF <= 0 && LoveRaidManager.isActivated() && loveRaids.length > 0) {
                 if (logging)
-                    logHHAuto("No troll with girls, checking love raids as fallback.");
+                    LogUtils_logHHAuto("No troll with girls, checking love raids as fallback.");
                 const loveRaid = LoveRaidManager.getRaidToFight(loveRaids, logging);
                 if (loveRaid) {
                     TTF = loveRaid.trollId;
                     if (logging)
-                        logHHAuto(`Love raid fallback: fighting troll ${TTF} for raid girl ${loveRaid.id_girl}.`);
+                        LogUtils_logHHAuto(`Love raid fallback: fighting troll ${TTF} for raid girl ${loveRaid.id_girl}.`);
                 }
             }
         }
@@ -24985,18 +24992,18 @@ class Troll {
         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true" && autoTrollSelectedIndex > 0 && autoTrollSelectedIndex < 98) {
             TTF = autoTrollSelectedIndex;
             if (logging)
-                logHHAuto("Custom troll fight.");
+                LogUtils_logHHAuto("Custom troll fight.");
         }
         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
             TTF = lastTrollIdAvailable;
             if (logging)
-                logHHAuto("Last troll fight: " + TTF);
+                LogUtils_logHHAuto("Last troll fight: " + TTF);
         }
         if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true"
             && getStoredValue(HHStoredVarPrefixKey + TK.autoTrollBattleSaveQuest) === "true") {
             TTF = lastTrollIdAvailable;
             if (logging)
-                logHHAuto("Last troll fight for quest item: " + TTF);
+                LogUtils_logHHAuto("Last troll fight for quest item: " + TTF);
             if (allowSideEffects)
                 setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "none");
         }
@@ -25005,7 +25012,7 @@ class Troll {
         // Check if selected troll is actually unlocked (love raid girls can be on locked trolls)
         if (TTF > 0 && TTF > lastTrollIdAvailable) {
             if (logging)
-                logHHAuto(`Troll ${TTF} (${trollz[Number(TTF)]}) not unlocked (last available: ${lastTrollIdAvailable}), resetting raid selector to "Choose a girl".`);
+                LogUtils_logHHAuto(`Troll ${TTF} (${trollz[Number(TTF)]}) not unlocked (last available: ${lastTrollIdAvailable}), resetting raid selector to "Choose a girl".`);
             if (allowSideEffects)
                 setStoredValue(HHStoredVarPrefixKey + SK.autoLoveRaidSelectedIndex, "0");
             TTF = 0;
@@ -25016,18 +25023,18 @@ class Troll {
                 // Only fallback to last troll when not using first/last troll with girls mode
                 TTF = lastTrollIdAvailable > 0 ? lastTrollIdAvailable : 1;
                 if (logging)
-                    logHHAuto(`Error: wrong troll target found. Backup to ${TTF}`);
+                    LogUtils_logHHAuto(`Error: wrong troll target found. Backup to ${TTF}`);
             }
             else {
                 // First/last troll with girls found no valid target, or events/raids only mode
                 if (logging)
-                    logHHAuto("No valid troll target found, skipping.");
+                    LogUtils_logHHAuto("No valid troll target found, skipping.");
                 return 0;
             }
         }
         if (TTF > 0 && !trollz.hasOwnProperty(TTF) && !sideTrollz.hasOwnProperty(TTF)) {
             if (logging)
-                logHHAuto("Error: New troll implemented '" + TTF + "' (List to be updated) or wrong troll target found");
+                LogUtils_logHHAuto("Error: New troll implemented '" + TTF + "' (List to be updated) or wrong troll target found");
             if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true") {
                 TTF = 1;
             }
@@ -25073,18 +25080,18 @@ class Troll {
                     && autoTrollSelectedIndex !== 98 && autoTrollSelectedIndex !== 99) {
                     // Fixed troll or "last troll" mode: retry once, then fallback to troll 1
                     if (getStoredValue(HHStoredVarPrefixKey + TK.TrollInvalid) === "true") {
-                        logHHAuto(`ERROR: Invalid troll N°${TTF}, again, going to first troll`);
+                        LogUtils_logHHAuto(`ERROR: Invalid troll N°${TTF}, again, going to first troll`);
                         TTF = 1;
                     }
                     else {
-                        logHHAuto(`ERROR: Invalid troll N°${TTF}, do not fight, retry...`);
+                        LogUtils_logHHAuto(`ERROR: Invalid troll N°${TTF}, do not fight, retry...`);
                         setStoredValue(HHStoredVarPrefixKey + TK.TrollInvalid, "true");
                         return true;
                     }
                 }
                 else {
                     // First/last troll with girls found no valid target, or events/raids only mode
-                    logHHAuto("No troll target found, skipping fight.");
+                    LogUtils_logHHAuto("No troll target found, skipping fight.");
                     return false;
                 }
             }
@@ -25096,7 +25103,7 @@ class Troll {
             const needSW = Booster.needSandalWoodEquipped(TTF);
             if (needSW) {
                 if (currentPage !== ConfigHelper.getHHScriptVars("pagesIDShop")) {
-                    logHHAuto('Sandalwood needed: going to Shop page to update booster status');
+                    LogUtils_logHHAuto('Sandalwood needed: going to Shop page to update booster status');
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDShop"));
                     return true;
                 }
@@ -25108,7 +25115,7 @@ class Troll {
                     }
                 }
             }
-            logHHAuto(`Fighting troll N°${TTF}, ${trollz[Number(TTF)]}`);
+            LogUtils_logHHAuto(`Fighting troll N°${TTF}, ${trollz[Number(TTF)]}`);
             // Battles the latest boss.
             // Navigate to latest boss.
             //console.log(getPage());
@@ -25118,9 +25125,9 @@ class Troll {
                 return true;
             }
             else {
-                logHHAuto("Navigating to chosen Troll.");
+                LogUtils_logHHAuto("Navigating to chosen Troll.");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("setting autoloop to false");
                 //week 28 new battle modification
                 //location.href = "/battle.html?id_troll=" + TTF;
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: TTF });
@@ -25133,7 +25140,7 @@ class Troll {
         return Troll_awaiter(this, void 0, void 0, function* () {
             if (getPage() === ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle")) {
                 // On battle page.
-                logHHAuto("On Pre battle page.");
+                LogUtils_logHHAuto("On Pre battle page.");
                 const TTF = Number(queryStringGetParam(window.location.search, 'id_opponent'));
                 const trollz = ConfigHelper.getHHScriptVars("trollzList");
                 const battleButton = $('#pre-battle .battle-buttons .green_button_L.battle-action-button');
@@ -25149,7 +25156,7 @@ class Troll {
                     // The goal of this function is to detect slow server response to avoid loop without fight
                     if (previousPower > 0 && previousPower === currentPower) {
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                        logHHAuto("Server seems slow to reply, setting autoloop to false to wait for troll page to load");
+                        LogUtils_logHHAuto("Server seems slow to reply, setting autoloop to false to wait for troll page to load");
                     }
                 };
                 //check if girl still available at troll in case of event
@@ -25164,7 +25171,7 @@ class Troll {
                     if (eventMythicGirl.girl_id && TTF === eventMythicGirl.troll_id && eventMythicGirl.is_mythic && getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true") {
                         eventTrollGirl = eventMythicGirl;
                         if (rewardGirlz.length === 0 || !trollGirlRewards.includes('"id_girl":' + eventMythicGirl.girl_id)) {
-                            logHHAuto(`Seems ${eventMythicGirl.name} is no more available at troll ${trollz[Number(TTF)]}. Going to event page.`);
+                            LogUtils_logHHAuto(`Seems ${eventMythicGirl.name} is no more available at troll ${trollz[Number(TTF)]}. Going to event page.`);
                             EventModule.parseEventPage(eventMythicGirl.event_id);
                             return true;
                         }
@@ -25172,13 +25179,13 @@ class Troll {
                     if (eventGirl.girl_id && TTF === eventGirl.troll_id && !eventGirl.is_mythic && getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true") {
                         eventTrollGirl = eventGirl;
                         if (rewardGirlz.length === 0 || !trollGirlRewards.includes('"id_girl":' + eventGirl.girl_id)) {
-                            logHHAuto(`Seems ${eventGirl.name} is no more available at troll ${trollz[Number(TTF)]}. Going to event page.`);
+                            LogUtils_logHHAuto(`Seems ${eventGirl.name} is no more available at troll ${trollz[Number(TTF)]}. Going to event page.`);
                             EventModule.parseEventPage(eventGirl.event_id);
                             return true;
                         }
                     }
                     if (rewardGirlz.length === 0 && (autoTrollSelectedIndex === 98 || autoTrollSelectedIndex === 99)) {
-                        logHHAuto(`Seems no more girls available at troll ${trollz[Number(TTF)]}, looking for next troll.`);
+                        LogUtils_logHHAuto(`Seems no more girls available at troll ${trollz[Number(TTF)]}, looking for next troll.`);
                         const trollWithGirls = getStoredJSON(HHStoredVarPrefixKey + TK.trollWithGirls, []);
                         trollWithGirls[TTF - 1] = 0;
                         setStoredValue(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify(trollWithGirls));
@@ -25188,7 +25195,7 @@ class Troll {
                             return true;
                         }
                         else {
-                            logHHAuto(`Same troll found and no girls available, stopping troll fight.`);
+                            LogUtils_logHHAuto(`Same troll found and no girls available, stopping troll fight.`);
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                             return;
                         }
@@ -25217,7 +25224,7 @@ class Troll {
                         const trollRaids = LoveRaidManager.getTrollRaids();
                         loveRaid = trollRaids.find(raid => raid.trollId === TTF);
                         if (loveRaid && (rewardGirlz.length === 0 || !trollGirlRewards.includes('"id_girl":' + loveRaid.id_girl))) {
-                            logHHAuto(`Seems girl ${loveRaid.id_girl} is no more available at troll ${trollz[Number(TTF)]}. Going to love Raid.`);
+                            LogUtils_logHHAuto(`Seems girl ${loveRaid.id_girl} is no more available at troll ${trollz[Number(TTF)]}. Going to love Raid.`);
                             clearTimer('nextLoveRaidTime');
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDLoveRaid"));
                             return true;
@@ -25262,9 +25269,9 @@ class Troll {
                             && (currentPower >= (Number(getStoredValue(HHStoredVarPrefixKey + SK.autoTrollThreshold)) + 50)
                                 || bypassThreshold)
                             && ((eventTrollGirl === null || eventTrollGirl === void 0 ? void 0 : eventTrollGirl.is_mythic) || getStoredValue(HHStoredVarPrefixKey + SK.useX50FightsAllowNormalEvent) === "true")) {
-                            logHHAuto("Going to crush 50 times: " + trollz[Number(TTF)] + ' for ' + battleButtonX50Price + ' kobans.');
+                            LogUtils_logHHAuto("Going to crush 50 times: " + trollz[Number(TTF)] + ' for ' + battleButtonX50Price + ' kobans.');
                             if (!acquirePostMutex('troll:battleX50')) {
-                                logHHAuto('Troll: another POST in flight, deferring x50 battle');
+                                LogUtils_logHHAuto('Troll: another POST in flight, deferring x50 battle');
                                 return;
                             }
                             const x50Start = Date.now();
@@ -25272,25 +25279,25 @@ class Troll {
                             Booster.resetBattleResponseFlag();
                             battleButtonX50[0].click();
                             setHHVars('Hero.infos.hc_confirm', hcConfirmValue);
-                            logHHAuto(`Crushed 50 times: ${trollz[Number(TTF)]} for ${battleButtonX50Price} kobans.`);
+                            LogUtils_logHHAuto(`Crushed 50 times: ${trollz[Number(TTF)]} for ${battleButtonX50Price} kobans.`);
                             if (getStoredValue(HHStoredVarPrefixKey + TK.questRequirement) === "battle") {
                                 // Battle Done.
                                 setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "none");
                             }
                             RewardHelper.ObserveAndGetGirlRewards();
                             yield Booster.waitForBattleResponse();
-                            const x50Idle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                            const x50Idle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                             const x50Duration = Date.now() - x50Start;
                             releasePostMutex();
                             if (x50Idle)
                                 yield awaitServerSettleAfterPost(x50Duration);
                             else
-                                logHHAuto('Troll: x50 AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                                LogUtils_logHHAuto('Troll: x50 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                             return;
                         }
                         else {
                             if (getStoredValue(HHStoredVarPrefixKey + SK.useX50Fights) === "true") {
-                                logHHAuto(`Unable to use x50 for ${battleButtonX50Price} kobans,fights : ${Troll.getEnergy()}/50, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX50)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
+                                LogUtils_logHHAuto(`Unable to use x50 for ${battleButtonX50Price} kobans,fights : ${Troll.getEnergy()}/50, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX50)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
                             }
                         }
                         const minShardsX10 = getStoredValue(HHStoredVarPrefixKey + SK.minShardsX10);
@@ -25301,9 +25308,9 @@ class Troll {
                             && (currentPower >= (Number(getStoredValue(HHStoredVarPrefixKey + SK.autoTrollThreshold)) + 10)
                                 || bypassThreshold)
                             && ((eventTrollGirl === null || eventTrollGirl === void 0 ? void 0 : eventTrollGirl.is_mythic) || getStoredValue(HHStoredVarPrefixKey + SK.useX10FightsAllowNormalEvent) === "true")) {
-                            logHHAuto(`Going to crush 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
+                            LogUtils_logHHAuto(`Going to crush 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
                             if (!acquirePostMutex('troll:battleX10')) {
-                                logHHAuto('Troll: another POST in flight, deferring x10 battle');
+                                LogUtils_logHHAuto('Troll: another POST in flight, deferring x10 battle');
                                 return;
                             }
                             const x10Start = Date.now();
@@ -25311,70 +25318,70 @@ class Troll {
                             Booster.resetBattleResponseFlag();
                             battleButtonX10[0].click();
                             setHHVars('Hero.infos.hc_confirm', hcConfirmValue);
-                            logHHAuto(`Crushed 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
+                            LogUtils_logHHAuto(`Crushed 10 times: ${trollz[Number(TTF)]} for ${battleButtonX10Price} kobans.`);
                             if (getStoredValue(HHStoredVarPrefixKey + TK.questRequirement) === "battle") {
                                 // Battle Done.
                                 setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "none");
                             }
                             RewardHelper.ObserveAndGetGirlRewards();
                             yield Booster.waitForBattleResponse();
-                            const x10Idle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                            const x10Idle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                             const x10Duration = Date.now() - x10Start;
                             releasePostMutex();
                             if (x10Idle)
                                 yield awaitServerSettleAfterPost(x10Duration);
                             else
-                                logHHAuto('Troll: x10 AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                                LogUtils_logHHAuto('Troll: x10 AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                             return;
                         }
                         else {
                             if (getStoredValue(HHStoredVarPrefixKey + SK.useX10Fights) === "true") {
-                                logHHAuto(`Unable to use x10 for ${battleButtonX10Price} kobans,fights : ${Troll.getEnergy()}/10, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX10)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
+                                LogUtils_logHHAuto(`Unable to use x10 for ${battleButtonX10Price} kobans,fights : ${Troll.getEnergy()}/10, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX10)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
                             }
                         }
                     }
                     //Crushing one by one
                     if (currentPower > 0) {
                         if ($('#pre-battle div.battle-buttons a.single-battle-button[disabled]').length > 0) {
-                            logHHAuto("Battle Button seems disabled, force reload of page.");
+                            LogUtils_logHHAuto("Battle Button seems disabled, force reload of page.");
                             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                             return;
                         }
                         if (battleButton === undefined || battleButton.length === 0) {
-                            logHHAuto("Battle Button was undefined. Disabling all auto-battle.");
+                            LogUtils_logHHAuto("Battle Button was undefined. Disabling all auto-battle.");
                             document.getElementById("autoTrollBattle").checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle, "false");
                             //document.getElementById("autoArenaCheckbox").checked = false;
                             if (getStoredValue(HHStoredVarPrefixKey + TK.questRequirement) === "battle") {
                                 document.getElementById("autoQuest").checked = false;
                                 setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, "false");
-                                logHHAuto("Auto-quest disabled since it requires battle and auto-battle has errors.");
+                                LogUtils_logHHAuto("Auto-quest disabled since it requires battle and auto-battle has errors.");
                             }
                             return;
                         }
-                        logHHAuto("Crushing: " + trollz[Number(TTF)]);
+                        LogUtils_logHHAuto("Crushing: " + trollz[Number(TTF)]);
                         //console.log(battleButton);
                         //replaceCheatClick();
                         checkPreviousFightDone();
                         setStoredValue(HHStoredVarPrefixKey + TK.trollPoints, currentPower);
                         if (!acquirePostMutex('troll:battle')) {
-                            logHHAuto('Troll: another POST in flight, deferring single battle');
+                            LogUtils_logHHAuto('Troll: another POST in flight, deferring single battle');
                             return;
                         }
                         const battleStart = Date.now();
                         battleButton[0].click();
-                        const battleIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                        const battleIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                         const battleDuration = Date.now() - battleStart;
                         releasePostMutex();
                         if (battleIdle)
                             yield awaitServerSettleAfterPost(battleDuration);
                         else
-                            logHHAuto('Troll: battle AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                            LogUtils_logHHAuto('Troll: battle AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                     }
                     else {
                         // We need more power.
                         const battle_price = 1; // TODO what is the expected value here ?
-                        logHHAuto(`Battle requires ${battle_price} power, having ${currentPower}.`);
+                        LogUtils_logHHAuto(`Battle requires ${battle_price} power, having ${currentPower}.`);
                         setStoredValue(HHStoredVarPrefixKey + TK.battlePowerRequired, battle_price);
                         if (getStoredValue(HHStoredVarPrefixKey + TK.questRequirement) === "battle") {
                             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, "P" + battle_price);
@@ -25388,22 +25395,22 @@ class Troll {
                     setStoredValue(HHStoredVarPrefixKey + TK.trollPoints, currentPower);
                     //replaceCheatClick();
                     if (!acquirePostMutex('troll:battleNoEvent')) {
-                        logHHAuto('Troll: another POST in flight, deferring single battle (no event)');
+                        LogUtils_logHHAuto('Troll: another POST in flight, deferring single battle (no event)');
                         return;
                     }
                     const battleNoEventStart = Date.now();
                     battleButton[0].click();
-                    const battleNoEventIdle = yield waitForAjaxIdle((/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000), (/* inlined export .AJAX_IDLE_SETTLE_MS */250));
+                    const battleNoEventIdle = yield waitForAjaxIdle(AJAX_IDLE_TIMEOUT_MS, AJAX_IDLE_SETTLE_MS);
                     const battleNoEventDuration = Date.now() - battleNoEventStart;
                     releasePostMutex();
                     if (battleNoEventIdle)
                         yield awaitServerSettleAfterPost(battleNoEventDuration);
                     else
-                        logHHAuto('Troll: battle (no event) AJAX still busy after ' + (/* inlined export .AJAX_IDLE_TIMEOUT_MS */15000) + 'ms, skipping settle');
+                        LogUtils_logHHAuto('Troll: battle (no event) AJAX still busy after ' + AJAX_IDLE_TIMEOUT_MS + 'ms, skipping settle');
                 }
             }
             else {
-                logHHAuto('Unable to identify page.');
+                LogUtils_logHHAuto('Unable to identify page.');
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                 return;
             }
@@ -25414,7 +25421,7 @@ class Troll {
         const Hero = getHero();
         //let canBuyResult = Troll.canBuyFight(eventTrollGirl);
         if (canBuyResult.canBuy) {
-            logHHAuto('Recharging ' + canBuyResult.toBuy + ' fights for ' + canBuyResult.price + ' kobans.');
+            LogUtils_logHHAuto('Recharging ' + canBuyResult.toBuy + ' fights for ' + canBuyResult.price + ' kobans.');
             const hcConfirmValue = getHHVars('Hero.infos.hc_confirm');
             setHHVars('Hero.infos.hc_confirm', true);
             // We have the power.
@@ -25422,7 +25429,7 @@ class Troll {
             //console.log($("plus[type='energy_fight']"), canBuyResult.price,canBuyResult.type, canBuyResult.max);
             Hero.recharge($("button.orange_text_button.manual-recharge"), canBuyResult.type, canBuyResult.toBuy, canBuyResult.price);
             setHHVars('Hero.infos.hc_confirm', hcConfirmValue);
-            logHHAuto('Recharged up to ' + canBuyResult.max + ' fights for ' + canBuyResult.price + ' kobans.');
+            LogUtils_logHHAuto('Recharged up to ' + canBuyResult.max + ' fights for ' + canBuyResult.price + ' kobans.');
         }
     }
     /**
@@ -25456,7 +25463,7 @@ class Troll {
             }
             else {
                 if (p.logging && getStoredValue(HHStoredVarPrefixKey + SK.useX50Fights) === "true") {
-                    logHHAuto(`Unable to recharge up to ${p.maxx50} for ${p.pricePerFight * p.maxx50} kobans : current energy : ${p.currentFight}, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX50)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
+                    LogUtils_logHHAuto(`Unable to recharge up to ${p.maxx50} for ${p.pricePerFight * p.maxx50} kobans : current energy : ${p.currentFight}, remaining shards : ${remainingShards}/${getStoredValue(HHStoredVarPrefixKey + SK.minShardsX50)}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
                 }
                 if (HeroHelper.getKoban() >= (p.pricePerFight * p.x20BuyAmount) + Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))) {
                     result.max = p.maxx20;
@@ -25465,7 +25472,7 @@ class Troll {
                     result.toBuy = p.x20BuyAmount;
                 }
                 else if (p.logging) {
-                    logHHAuto(`Unable to recharge up to ${p.x20BuyAmount} for ${p.pricePerFight * p.x20BuyAmount} kobans : current energy : ${p.currentFight}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
+                    LogUtils_logHHAuto(`Unable to recharge up to ${p.x20BuyAmount} for ${p.pricePerFight * p.x20BuyAmount} kobans : current energy : ${p.currentFight}, kobans : ${HeroHelper.getKoban()}/${Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank))}`);
                 }
             }
         }
@@ -25538,7 +25545,7 @@ class Troll {
     }
 }
 
-;// ./src/Helper/menu/MenuWidgets.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuWidgets.ts
 // MenuWidgets.ts
 //
 // Options rendering: small, reusable HTML builders that turn a text/input id
@@ -25626,7 +25633,7 @@ function hhMenuInputWithImg(textKeyAndInputId, inputPattern, inputStyle, imgPath
     return htmlRet;
 }
 
-;// ./src/Helper/menu/MenuColumnLeft.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuColumnLeft.ts
 // MenuColumnLeft.ts
 //
 // DOM construction (layout): the left column of the #sMenu panel — script
@@ -25773,7 +25780,7 @@ function buildLeftColumn() {
         + `</div>`;
 }
 
-;// ./src/Helper/menu/MenuColumnMiddle.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuColumnMiddle.ts
 // MenuColumnMiddle.ts
 //
 // DOM construction (layout): the middle column of the #sMenu panel — missions,
@@ -26034,7 +26041,7 @@ function buildMiddleColumn(debugEnabled) {
         + `</div>`;
 }
 
-;// ./src/Helper/menu/MenuColumnRight.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuColumnRight.ts
 // MenuColumnRight.ts
 //
 // DOM construction (layout): the right column of the #sMenu panel — champions
@@ -26203,7 +26210,7 @@ function buildRightColumn() {
         + `</div>`;
 }
 
-;// ./src/Helper/menu/MenuTemplate.ts
+;// CONCATENATED MODULE: ./src/Helper/menu/MenuTemplate.ts
 // MenuTemplate.ts
 //
 // DOM construction (layout): assembles the full settings panel (div#sMenu) from
@@ -26233,7 +26240,7 @@ function getMenu() {
         + `</div>`;
 }
 
-;// ./src/Helper/HHMenuHelper.ts
+;// CONCATENATED MODULE: ./src/Helper/HHMenuHelper.ts
 // HHMenuHelper.ts
 //
 // The HHAuto settings menu. Historically one ~1000-line class; split by
@@ -26360,7 +26367,7 @@ class HHMenu {
         }
         catch ({ errName, message }) {
             trollOptions.add(this._createHtmlSeparator('Error!'));
-            logHHAuto(`Error filling trolls: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`Error filling trolls: ${errName}, ${message}`);
         }
         trollOptions.add(this._createHtmlSeparator(getTextForUI("otherTrollOption", "elementText")));
         trollOptions.add(this._createHtmlOption('98', getTextForUI("firstTrollWithGirls", "elementText")));
@@ -26382,7 +26389,7 @@ class HHMenu {
         }
         catch ({ errName, message }) {
             loveRaidOptions.add(this._createHtmlSeparator('Error!'));
-            logHHAuto(`Error filling love raids: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`Error filling love raids: ${errName}, ${message}`);
         }
     }
     fillLeagueSelectMenu() {
@@ -26396,7 +26403,7 @@ class HHMenu {
         }
         catch ({ errName, message }) {
             leaguesOptions.add(this._createHtmlOption('0', 'Error!'));
-            logHHAuto(`Error filling leagues: ${errName}, ${message}`);
+            LogUtils_logHHAuto(`Error filling leagues: ${errName}, ${message}`);
         }
     }
     fillLeaguSortMenu() {
@@ -26457,7 +26464,7 @@ function switchHHMenuButton(isActive) {
     }
 }
 
-;// ./src/Module/Market.ts
+;// CONCATENATED MODULE: ./src/Module/Market.ts
 // Market.ts -- Auto-buys items from the in-game market using soft currency.
 //
 // Periodically checks the market shop for available items and purchases them
@@ -26487,7 +26494,7 @@ class Market {
             var kobans = HeroHelper.getKoban();
             if (getStoredValue(HHStoredVarPrefixKey + TK.storeContents) === undefined) {
                 if (!isJSON(getStoredValue(HHStoredVarPrefixKey + TK.storeContents))) {
-                    logHHAuto("Catched error : Could not parse store content.");
+                    LogUtils_logHHAuto("Catched error : Could not parse store content.");
                 }
                 setStoredValue(HHStoredVarPrefixKey + TK.charLevel, 0);
                 return;
@@ -26519,9 +26526,9 @@ class Market {
                     let boosterOwned = HaveBooster.hasOwnProperty(boost) ? Number(HaveBooster[boost]) : 0;
                     for (var n1 = shop[1].length - 1; n1 >= 0; n1--) {
                         if (kobans >= Number(getStoredValue(HHStoredVarPrefixKey + SK.kobanBank)) + Number(shop[1][n1].price_buy) && shop[1][n1].item.currency == "hc" && shop[1][n1].item.identifier == boost && (shop[1][n1].item.rarity == 'legendary' || shop[1][n1].item.rarity == 'mythic') && boosterOwned < MaxBooster) {
-                            logHHAuto({ log: 'wanna buy ', object: shop[1][n1], owning: boosterOwned });
+                            LogUtils_logHHAuto({ log: 'wanna buy ', object: shop[1][n1], owning: boosterOwned });
                             if (kobans >= Number(shop[1][n1].price_buy)) {
-                                logHHAuto({ log: 'Buying : ', object: shop[1][n1] });
+                                LogUtils_logHHAuto({ log: 'Buying : ', object: shop[1][n1] });
                                 // change referer
                                 window.history.replaceState(null, '', addNutakuSession('/shop.html'));
                                 kobans -= Number(shop[1][n1].price_buy);
@@ -26566,7 +26573,7 @@ class Market {
                     }
                 }
                 if (allGiftsPriceSc > 0 && money >= Exp + allGiftsPriceSc) {
-                    logHHAuto('Buy all gifts for price:' + allGiftsPriceSc);
+                    LogUtils_logHHAuto('Buy all gifts for price:' + allGiftsPriceSc);
                     // change referer
                     window.history.replaceState(null, '', addNutakuSession('/shop.html'));
                     money -= allGiftsPriceSc;
@@ -26595,7 +26602,7 @@ class Market {
                         //logHHAuto({log:'wanna buy ',Object:shop[2][n2]});
                         if (money >= Aff + Number(shop[2][n2].price_buy) && money >= Number(shop[2][n2].price_buy) && shop[2][n2].item.currency == "sc") // "sc" for soft currency = money, "hc" for hard currency = kobans
                          {
-                            logHHAuto({ log: 'Buying : ', Object: shop[2][n2] });
+                            LogUtils_logHHAuto({ log: 'Buying : ', Object: shop[2][n2] });
                             // change referer
                             window.history.replaceState(null, '', addNutakuSession('/shop.html'));
                             money -= Number(shop[2][n2].price_buy);
@@ -26635,7 +26642,7 @@ class Market {
                     }
                 }
                 if (allPotionPriceSc > 0 && money >= Exp + allPotionPriceSc) {
-                    logHHAuto('Buy all books for price:' + allPotionPriceSc);
+                    LogUtils_logHHAuto('Buy all books for price:' + allPotionPriceSc);
                     // change referer
                     window.history.replaceState(null, '', addNutakuSession('/shop.html'));
                     money -= allPotionPriceSc;
@@ -26664,7 +26671,7 @@ class Market {
                         //logHHAuto('wanna buy ',shop[3][n3]);
                         if (money >= Exp + Number(shop[3][n3].price_buy) && money >= Number(shop[3][n3].price_buy) && shop[3][n3].item.currency == "sc") // "sc" for soft currency = money, "hc" for hard currency = kobans
                          {
-                            logHHAuto({ log: 'Buying : ', Object: shop[3][n3] });
+                            LogUtils_logHHAuto({ log: 'Buying : ', Object: shop[3][n3] });
                             // change referer
                             window.history.replaceState(null, '', addNutakuSession('/shop.html'));
                             money -= Number(shop[3][n3].price);
@@ -26698,13 +26705,13 @@ class Market {
             //Hero.update("soft_currency", money, false);
         }
         catch (ex) {
-            logHHAuto("Catched error : Could not buy : " + ex);
+            LogUtils_logHHAuto("Catched error : Could not buy : " + ex);
             setStoredValue(HHStoredVarPrefixKey + TK.charLevel, 0);
         }
     }
 }
 
-;// ./src/model/Mission.ts
+;// CONCATENATED MODULE: ./src/model/Mission.ts
 // Models for in-game missions and their rewards.
 // Mission holds the cost, duration, remaining time, completion state,
 // and a reference to the DOM element. MissionRewards describes each reward entry.
@@ -26719,7 +26726,7 @@ class MissionRewards {
     }
 }
 
-;// ./src/Module/Missions.ts
+;// CONCATENATED MODULE: ./src/Module/Missions.ts
 // Missions.ts -- Automates missions: collects completed missions and starts new ones.
 //
 // Missions are time-based tasks that yield rewards. This module checks for
@@ -26770,7 +26777,7 @@ class Missions {
             }
         }
         catch (error) {
-            logHHAuto("Something went wrong, starting first mission in the list ", error);
+            LogUtils_logHHAuto("Something went wrong, starting first mission in the list ", error);
             msn = missionsList[0];
         }
         return msn;
@@ -26778,7 +26785,7 @@ class Missions {
     static run() {
         // returns boolean to set busy
         if (getPage() !== ConfigHelper.getHHScriptVars("pagesIDMissions")) {
-            logHHAuto("Navigating to missions page.");
+            LogUtils_logHHAuto("Navigating to missions page.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDMissions"));
             // return busy
             return true;
@@ -26786,26 +26793,26 @@ class Missions {
         else {
             try {
                 const debugEnabled = getStoredValue(HHStoredVarPrefixKey + TK.Debug) === 'true';
-                logHHAuto("On missions page.");
+                LogUtils_logHHAuto("On missions page.");
                 if (RewardHelper.closeRewardPopupIfAny()) {
                     return true;
                 }
                 let canCollect = getStoredValue(HHStoredVarPrefixKey + SK.autoMissionCollect) === "true" && $(".mission_button button:visible[rel='claim']").length > 0 && TimeHelper.canCollectCompetitionActive();
                 var { allGood, missions, missionOngoing } = Missions.parseMissions(canCollect);
                 if (debugEnabled)
-                    logHHAuto("Missions parsed, mission list is:", missions);
+                    LogUtils_logHHAuto("Missions parsed, mission list is:", missions);
                 if (debugEnabled && missionOngoing != null)
-                    logHHAuto("Mission missionOngoing:", missionOngoing);
+                    LogUtils_logHHAuto("Mission missionOngoing:", missionOngoing);
                 if (!allGood && checkTimer('nextMissionTime')) {
-                    logHHAuto("Something went wrong, need to retry in 15secs.");
+                    LogUtils_logHHAuto("Something went wrong, need to retry in 15secs.");
                     setTimer('nextMissionTime', randomInterval(15, 30));
                     return true;
                 }
                 if (missions.length > 0 && missionOngoing == null) {
                     var mission = Missions.getSuitableMission(missions);
-                    logHHAuto(`Selected mission to be started (duration: ${mission.duration}sec):`);
+                    LogUtils_logHHAuto(`Selected mission to be started (duration: ${mission.duration}sec):`);
                     if (debugEnabled)
-                        logHHAuto(mission);
+                        LogUtils_logHHAuto(mission);
                     var missionButton = $(mission.missionObject).find("button:visible[rel='mission_start']").first();
                     if (missionButton.length > 0) {
                         missionButton.trigger('click');
@@ -26813,34 +26820,34 @@ class Missions {
                         missionOngoing.remaining_time = Number(mission.duration);
                     }
                     else {
-                        logHHAuto("Something went wrong, no start button");
+                        LogUtils_logHHAuto("Something went wrong, no start button");
                         setTimer('nextMissionTime', randomInterval(15, 30));
                         return true;
                     }
                 }
                 if (canCollect) {
-                    logHHAuto("Collecting finished mission's reward.");
+                    LogUtils_logHHAuto("Collecting finished mission's reward.");
                     $(".mission_button button:visible[rel='claim']").first().trigger('click');
                     return true;
                 }
                 if (missionOngoing != null) {
-                    logHHAuto("Mission ongoing waiting it ends.");
+                    LogUtils_logHHAuto("Mission ongoing waiting it ends.");
                     if (checkTimer('nextMissionTime'))
                         setTimer('nextMissionTime', missionOngoing.remaining_time + randomInterval(10, 20));
                     return true;
                 }
                 if (missions.length == 0 && missionOngoing == null) {
-                    logHHAuto("No missions detected...!");
+                    LogUtils_logHHAuto("No missions detected...!");
                     // get gift
                     const isAfterGift = $("#missions .end_gift:visible").length > 0;
                     if (isAfterGift) {
                         const buttonAfterGift = $("#missions .end_gift button:visible");
                         if (buttonAfterGift.length > 0) {
-                            logHHAuto("Collecting gift.");
+                            LogUtils_logHHAuto("Collecting gift.");
                             buttonAfterGift.trigger('click');
                         }
                         else {
-                            logHHAuto("Refreshing to collect gift...");
+                            LogUtils_logHHAuto("Refreshing to collect gift...");
                             // C1: safeReload waits for any in-flight game
                             // AJAX before the reload, so an open POST is
                             // not cancelled (issue #1598).
@@ -26850,7 +26857,7 @@ class Missions {
                     }
                     let time = $('.end-gift-timer span[rel="expires"],.after_gift .new-missions-timer span[rel="expires"]').first().text();
                     if (time === undefined || time === null || time.length === 0) {
-                        logHHAuto("New mission time was undefined... Setting it manually to 10min.");
+                        LogUtils_logHHAuto("New mission time was undefined... Setting it manually to 10min.");
                         setTimer('nextMissionTime', randomInterval(10 * 60, 12 * 60));
                     }
                     else
@@ -26858,7 +26865,7 @@ class Missions {
                 }
             }
             catch ({ errName, message }) {
-                logHHAuto(`ERROR during mission run: ${message}, retry in 10min`);
+                LogUtils_logHHAuto(`ERROR during mission run: ${message}, retry in 10min`);
                 setTimer('nextMissionTime', randomInterval(10 * 60, 12 * 60));
             }
             // not busy
@@ -26872,7 +26879,7 @@ class Missions {
         var allGood = true;
         // parse missions
         const allMissions = $(".mission_object");
-        logHHAuto("Found " + allMissions.length + " missions to be parsed.");
+        LogUtils_logHHAuto("Found " + allMissions.length + " missions to be parsed.");
         try {
             allMissions.each((idx, missionObject) => {
                 var data = $.data(missionObject).d;
@@ -26884,7 +26891,7 @@ class Missions {
                     if (data.remaining_time > 0) {
                         // allGood = false;
                         if ($('.finish_in_bar[style*="display:none;"], .finish_in_bar[style*="display: none;"]', missionObject).length === 0) {
-                            logHHAuto("Unfinished mission detected...(" + data.remaining_time + "sec. remaining)");
+                            LogUtils_logHHAuto("Unfinished mission detected...(" + data.remaining_time + "sec. remaining)");
                             missionOngoing = data;
                             data.finished = false;
                         }
@@ -26913,8 +26920,8 @@ class Missions {
             });
         }
         catch (error) {
-            logHHAuto("Catched error : Couldn't parse missions (try again in 15min) : " + error);
-            logHHAuto("Last mission parsed : " + JSON.stringify(lastMissionData));
+            LogUtils_logHHAuto("Catched error : Couldn't parse missions (try again in 15min) : " + error);
+            LogUtils_logHHAuto("Last mission parsed : " + JSON.stringify(lastMissionData));
             setTimer('nextMissionTime', randomInterval(15 * 60, 20 * 60));
             allGood = false;
         }
@@ -26947,8 +26954,8 @@ class Missions {
                         reward.data = Number(slotDiv.innerHTML.replace(/<.*?>/g, '').replace(/\D/g, ''));
                     }
                     catch (e) {
-                        logHHAuto("Catched error : Couldn't parse xp/money data : " + e);
-                        logHHAuto(slotDiv);
+                        LogUtils_logHHAuto("Catched error : Couldn't parse xp/money data : " + e);
+                        LogUtils_logHHAuto(slotDiv);
                     }
                 }
                 // set item details if item
@@ -26957,8 +26964,8 @@ class Missions {
                         reward.data = $.data(slotDiv).d;
                     }
                     catch (e) {
-                        logHHAuto("Catched error : Couldn't parse item reward slot details : " + e);
-                        logHHAuto(slotDiv);
+                        LogUtils_logHHAuto("Catched error : Couldn't parse item reward slot details : " + e);
+                        LogUtils_logHHAuto(slotDiv);
                         reward.type = "unknown";
                     }
                 }
@@ -26966,7 +26973,7 @@ class Missions {
             });
         }
         catch (error) {
-            logHHAuto("Catched error : Couldn't parse rewards for missions : " + error);
+            LogUtils_logHHAuto("Catched error : Couldn't parse rewards for missions : " + error);
         }
         return rewards;
     }
@@ -27028,7 +27035,7 @@ class Missions {
     }
 }
 
-;// ./src/Module/MonthlyCard.ts
+;// CONCATENATED MODULE: ./src/Module/MonthlyCard.ts
 // MonthlyCard.ts -- Updates input validation patterns for monthly card features
 // based on available energy types.
 //
@@ -27146,12 +27153,12 @@ class MonthlyCards {
             }
         }
         catch (e) {
-            logHHAuto("Catched error : Couldn't parse card info, input patern kept as default : " + e);
+            LogUtils_logHHAuto("Catched error : Couldn't parse card info, input patern kept as default : " + e);
         }
     }
 }
 
-;// ./src/Service/FeaturePopupService.ts
+;// CONCATENATED MODULE: ./src/Service/FeaturePopupService.ts
 // FeaturePopupService.ts
 //
 // Version-gated "What's New" popup to inform users about important changes
@@ -27227,9 +27234,8 @@ class FeaturePopupService {
      * Dismiss counters reset automatically when activated for a new version.
      */
     static shouldShowPopup() {
-        if (false)
-            // removed by dead control flow
-{}
+        if (FEATURE_POPUP_VERSION === "0")
+            return false;
         const currentVersion = GM.info.script.version;
         if (currentVersion !== FEATURE_POPUP_VERSION)
             return false;
@@ -27267,7 +27273,7 @@ class FeaturePopupService {
         const count = Number(getStoredValue(HHStoredVarPrefixKey + TK.featurePopupDismissCount) || "0");
         setStoredValue(HHStoredVarPrefixKey + TK.featurePopupDismissCount, String(count + 1));
         const limitDisplay = FEATURE_POPUP_MAX_REMINDERS >= Number.MAX_SAFE_INTEGER ? '∞' : String(FEATURE_POPUP_MAX_REMINDERS);
-        logHHAuto(`Feature popup postponed (${count + 1}/${limitDisplay}).`);
+        LogUtils_logHHAuto(`Feature popup postponed (${count + 1}/${limitDisplay}).`);
         maskHHPopUp();
     }
     /**
@@ -27275,7 +27281,7 @@ class FeaturePopupService {
      */
     static dismiss() {
         FeaturePopupService.markAsShown();
-        logHHAuto("Feature popup dismissed for version " + FEATURE_POPUP_VERSION + ".");
+        LogUtils_logHHAuto("Feature popup dismissed for version " + FEATURE_POPUP_VERSION + ".");
         maskHHPopUp();
     }
     // ── Private helpers ──
@@ -27306,7 +27312,7 @@ class FeaturePopupService {
     }
 }
 
-;// ./src/Service/SurveyService.ts
+;// CONCATENATED MODULE: ./src/Service/SurveyService.ts
 // SurveyService.ts
 //
 // One-time settings survey that asks users to anonymously share which
@@ -27348,25 +27354,24 @@ class SurveyService {
      * Dismiss counters reset automatically when activated for a new version.
      */
     static shouldShowSurvey() {
-        if (true)
+        if (SURVEY_ACTIVE_IN_VERSION === "0")
             return false;
-        // removed by dead control flow
-
-        // removed by dead control flow
-
+        const currentVersion = GM.info.script.version;
+        if (currentVersion !== SURVEY_ACTIVE_IN_VERSION)
+            return false;
         // Reset dismiss state when activated for a new version
-        // removed by dead control flow
-
-        // removed by dead control flow
-
-        // removed by dead control flow
-
-        // removed by dead control flow
-
-        // removed by dead control flow
-
-        // removed by dead control flow
-
+        const shownForVersion = getStoredValue(HHStoredVarPrefixKey + TK.surveyShown);
+        if (shownForVersion !== "0" && shownForVersion !== SURVEY_ACTIVE_IN_VERSION) {
+            // Different version was tracked before → reset for the new activation
+            setStoredValue(HHStoredVarPrefixKey + TK.surveyShown, "0");
+            setStoredValue(HHStoredVarPrefixKey + TK.surveyDismissCount, "0");
+        }
+        if (shownForVersion === SURVEY_ACTIVE_IN_VERSION)
+            return false;
+        const dismissCount = Number(getStoredValue(HHStoredVarPrefixKey + TK.surveyDismissCount) || "0");
+        if (dismissCount >= MAX_REMIND_COUNT)
+            return false;
+        return true;
     }
     /**
      * Show the survey popup.
@@ -27393,7 +27398,7 @@ class SurveyService {
         // Iterate all SK keys (user settings only)
         for (const keyName of Object.keys(SK)) {
             const storageKey = HHStoredVarPrefixKey + SK[keyName];
-            const varDef = HHStoredVars[storageKey];
+            const varDef = HHStoredVars_HHStoredVars[storageKey];
             if (!varDef || varDef.HHType !== "Setting")
                 continue;
             const currentValue = getStoredValue(storageKey);
@@ -27432,7 +27437,7 @@ class SurveyService {
         const hash = SurveyService.hashString(hashInput);
         const lastHash = getStoredValue(HHStoredVarPrefixKey + TK.surveyLastHash);
         if (lastHash === hash) {
-            logHHAuto("Settings survey skipped: settings unchanged since last submission.");
+            LogUtils_logHHAuto("Settings survey skipped: settings unchanged since last submission.");
             SurveyService.markAsShown();
             SurveyService.showThankYou();
             return;
@@ -27447,18 +27452,18 @@ class SurveyService {
             data: formData,
             onload: function (response) {
                 if (response.status === 200) {
-                    logHHAuto("Settings survey submitted successfully via Google Form.");
+                    LogUtils_logHHAuto("Settings survey submitted successfully via Google Form.");
                     setStoredValue(HHStoredVarPrefixKey + TK.surveyLastHash, hash);
                     SurveyService.markAsShown();
                     SurveyService.showThankYou();
                 }
                 else {
-                    logHHAuto("Settings survey submission failed: " + response.status);
+                    LogUtils_logHHAuto("Settings survey submission failed: " + response.status);
                     SurveyService.showError();
                 }
             },
             onerror: function () {
-                logHHAuto("Settings survey submission error.");
+                LogUtils_logHHAuto("Settings survey submission error.");
                 SurveyService.showError();
             }
         });
@@ -27468,7 +27473,7 @@ class SurveyService {
      */
     static copyToClipboard(data, silent = false) {
         GM_setClipboard(data, 'text');
-        logHHAuto("Settings survey data copied to clipboard.");
+        LogUtils_logHHAuto("Settings survey data copied to clipboard.");
         if (!silent) {
             SurveyService.markAsShown();
             SurveyService.showCopied();
@@ -27486,7 +27491,7 @@ class SurveyService {
     static remindLater() {
         const count = Number(getStoredValue(HHStoredVarPrefixKey + TK.surveyDismissCount) || "0");
         setStoredValue(HHStoredVarPrefixKey + TK.surveyDismissCount, String(count + 1));
-        logHHAuto(`Settings survey postponed (${count + 1}/${MAX_REMIND_COUNT}).`);
+        LogUtils_logHHAuto(`Settings survey postponed (${count + 1}/${MAX_REMIND_COUNT}).`);
         maskHHPopUp();
     }
     /**
@@ -27494,7 +27499,7 @@ class SurveyService {
      */
     static dismiss() {
         SurveyService.markAsShown();
-        logHHAuto("Settings survey permanently dismissed.");
+        LogUtils_logHHAuto("Settings survey permanently dismissed.");
         maskHHPopUp();
     }
     // ── Private helpers ──
@@ -27573,7 +27578,7 @@ class SurveyService {
     }
 }
 
-;// ./src/Service/OrderResolver.ts
+;// CONCATENATED MODULE: ./src/Service/OrderResolver.ts
 /**
  * Build the directed hard/soft edges implied by every block's constraints,
  * restricted to block ids that are actually present in `order`.
@@ -27757,7 +27762,7 @@ function resolveOrder(stored, registry, defaultOrder) {
     return { order: reconciled, warnings };
 }
 
-;// ./src/Service/PipelineOrderService.ts
+;// CONCATENATED MODULE: ./src/Service/PipelineOrderService.ts
 // PipelineOrderService.ts -- "Block Order" reorder popup (v7.37.0 pipeline-block
 // architecture, ADR-001, Roadmap step 17 task 15).
 //
@@ -27811,7 +27816,7 @@ class PipelineOrderService {
     /** Open the reorder popup with the current effective order. */
     static showPopup() {
         if (!registryProvider) {
-            logHHAuto("Block order: registry provider not wired yet.");
+            LogUtils_logHHAuto("Block order: registry provider not wired yet.");
             return;
         }
         const { registry, defaultOrder } = registryProvider();
@@ -27904,7 +27909,7 @@ class PipelineOrderService {
         $('#pipeOrderCancel').off('click').on('click', function () { maskHHPopUp(); });
         $('#pipeOrderReset').off('click').on('click', function () {
             deleteStoredValue(HHStoredVarPrefixKey + TK.pipelineOrder);
-            logHHAuto("Block order reset to default.");
+            LogUtils_logHHAuto("Block order reset to default.");
             maskHHPopUp();
             safeReload();
         });
@@ -27921,14 +27926,14 @@ class PipelineOrderService {
                 deleteStoredValue(HHStoredVarPrefixKey + TK.pipelineOrder);
             else
                 setStoredValue(HHStoredVarPrefixKey + TK.pipelineOrder, JSON.stringify(proposed));
-            logHHAuto("Block order saved.");
+            LogUtils_logHHAuto("Block order saved.");
             maskHHPopUp();
             safeReload();
         });
     }
 }
 
-;// ./src/Service/TooltipService.ts
+;// CONCATENATED MODULE: ./src/Service/TooltipService.ts
 // TooltipService.ts
 //
 // Controls the visibility of help tooltips in the HHAuto settings
@@ -27977,7 +27982,7 @@ function enableToolTipsDisplay(important = false) {
             tooltip.css({ top: tipY, left: tipX });
         }
         catch (err) {
-            logHHAuto('Error in tooltip construction');
+            LogUtils_logHHAuto('Error in tooltip construction');
         }
     });
 }
@@ -27986,7 +27991,7 @@ function disableToolTipsDisplay(important = false) {
     GM_addStyle('.tooltipHH:hover span.tooltipHHtext { display: none' + importantAddendum + '}');
 }
 
-;// ./src/Service/ForbiddenBackoff.ts
+;// CONCATENATED MODULE: ./src/Service/ForbiddenBackoff.ts
 // ForbiddenBackoff.ts
 //
 // Persistent Forbidden counter and exponential backoff calculator
@@ -28082,7 +28087,7 @@ function nextStreakCount(prevCount, prevTimestamp, now) {
  */
 function recordForbidden(storage = defaultStorage(), now = Date.now) {
     if (!storage) {
-        logHHAuto('[ForbiddenBackoff] storage unavailable, Forbidden not recorded');
+        LogUtils_logHHAuto('[ForbiddenBackoff] storage unavailable, Forbidden not recorded');
         return -1;
     }
     let prevCount = 0;
@@ -28107,10 +28112,10 @@ function recordForbidden(storage = defaultStorage(), now = Date.now) {
         storage.setItem(FORBIDDEN_LAST_AT_KEY, String(t));
     }
     catch (e) {
-        logHHAuto('[ForbiddenBackoff] storage write failed, Forbidden not persisted');
+        LogUtils_logHHAuto('[ForbiddenBackoff] storage write failed, Forbidden not persisted');
         return -1;
     }
-    logHHAuto('[ForbiddenBackoff] XHR 403 recorded (streak #' + count + ')');
+    LogUtils_logHHAuto('[ForbiddenBackoff] XHR 403 recorded (streak #' + count + ')');
     return count;
 }
 function defaultStorage() {
@@ -28122,7 +28127,7 @@ function defaultStorage() {
     return null;
 }
 
-;// ./src/Service/HeroBootRecovery.ts
+;// CONCATENATED MODULE: ./src/Service/HeroBootRecovery.ts
 // HeroBootRecovery.ts
 //
 // Self-heal for the boot path when a game page loads but never
@@ -28179,7 +28184,7 @@ function nextHeroGiveupReloadCount(prevReloadCount) {
     return sanitizeHeroGiveupReloadCount(prevReloadCount) + 1;
 }
 
-;// ./src/Service/StartService.ts
+;// CONCATENATED MODULE: ./src/Service/StartService.ts
 // StartService.ts
 //
 // One-time initialization that runs when the script first loads on a
@@ -28272,7 +28277,7 @@ class StartService {
         let previousScriptVersion = getStoredValue(HHStoredVarPrefixKey + TK.scriptversion);
         if (previousScriptVersion != GM.info.script.version) {
             // run action on new script version
-            logHHAuto(`New script version detected from ${previousScriptVersion} to ${GM.info.script.version}`);
+            LogUtils_logHHAuto(`New script version detected from ${previousScriptVersion} to ${GM.info.script.version}`);
             setStoredValue(HHStoredVarPrefixKey + TK.scriptversion, GM.info.script.version);
             // +Raid Stars migration handled below (outside version check)
             if ('7.26.0' === GM.info.script.version) {
@@ -28316,19 +28321,19 @@ class StartService {
     }
 }
 function StartService_setDefaults(force = false) {
-    for (let i of Object.keys(HHStoredVars)) {
-        if (HHStoredVars[i].storage !== undefined) {
-            let storageItem = getStorageItem(HHStoredVars[i].storage);
+    for (let i of Object.keys(HHStoredVars_HHStoredVars)) {
+        if (HHStoredVars_HHStoredVars[i].storage !== undefined) {
+            let storageItem = getStorageItem(HHStoredVars_HHStoredVars[i].storage);
             let isInvalid = false;
             //console.log(storageItem[i], storageItem[i] !== undefined);
-            if (HHStoredVars[i].isValid !== undefined && storageItem[i] !== undefined) {
-                isInvalid = !HHStoredVars[i].isValid.test(storageItem[i]);
+            if (HHStoredVars_HHStoredVars[i].isValid !== undefined && storageItem[i] !== undefined) {
+                isInvalid = !HHStoredVars_HHStoredVars[i].isValid.test(storageItem[i]);
                 if (isInvalid) {
-                    logHHAuto("HHStoredVar " + i + " is invalid, reseting.");
-                    logHHAuto("HHStoredVar " + i + " current value : " + storageItem[i]);
+                    LogUtils_logHHAuto("HHStoredVar " + i + " is invalid, reseting.");
+                    LogUtils_logHHAuto("HHStoredVar " + i + " current value : " + storageItem[i]);
                 }
             }
-            if (HHStoredVars[i].default !== undefined) {
+            if (HHStoredVars_HHStoredVars[i].default !== undefined) {
                 if (storageItem[i] === undefined || force || isInvalid) {
                     setHHStoredVarToDefault(i);
                 }
@@ -28340,7 +28345,7 @@ function StartService_setDefaults(force = false) {
             }
         }
         else {
-            logHHAuto("HHStoredVar " + i + " has no storage defined.");
+            LogUtils_logHHAuto("HHStoredVar " + i + " has no storage defined.");
         }
     }
 }
@@ -28394,7 +28399,7 @@ function hardened_start() {
                 }
                 catch (e) { }
                 const time = nextForbiddenDelaySeconds(count);
-                logHHAuto('HHAUTO WARNING: "Forbidden" detected (#' + count + '), reloading the page in ' + time + ' seconds');
+                LogUtils_logHHAuto('HHAUTO WARNING: "Forbidden" detected (#' + count + '), reloading the page in ' + time + ' seconds');
                 // C1: safeReload combines setTimeout + waitForAjaxIdle + location.reload
                 // and honors the navigation mutex, so concurrent forbidden
                 // pages cannot fire two reloads back-to-back.
@@ -28418,7 +28423,7 @@ function start() {
     // "no Hero" and gave up after ~75s, looking like a freeze. Skip init there;
     // the actual game frame (e.g. /home.html) is unaffected and runs normally.
     if (location.pathname === '/') {
-        logHHAuto('Not a game page (/), skipping init in this frame.');
+        LogUtils_logHHAuto('Not a game page (/), skipping init in this frame.');
         return;
     }
     if (((_a = unsafeWindow.shared) === null || _a === void 0 ? void 0 : _a.Hero) === undefined) {
@@ -28451,15 +28456,15 @@ function start() {
                     sessionStorage.setItem(heroGiveupReloadKey(), String(nextReloads));
                 }
                 catch (e) { /* sessionStorage unavailable */ }
-                logHHAuto('Hero object not available after ' + HERO_MAX_RETRIES + ' retries. Auto-reloading (attempt ' + nextReloads + '/' + (/* inlined export .HERO_GIVEUP_MAX_RELOADS */3) + ', page=' + location.pathname + ', elapsed=' + elapsed + 'ms).');
+                LogUtils_logHHAuto('Hero object not available after ' + HERO_MAX_RETRIES + ' retries. Auto-reloading (attempt ' + nextReloads + '/' + HERO_GIVEUP_MAX_RELOADS + ', page=' + location.pathname + ', elapsed=' + elapsed + 'ms).');
                 safeReload();
             }
             else {
-                logHHAuto('Hero object not available after ' + HERO_MAX_RETRIES + ' retries and ' + (/* inlined export .HERO_GIVEUP_MAX_RELOADS */3) + ' auto-reloads. Giving up. Try reloading the page. (page=' + location.pathname + ', elapsed=' + elapsed + 'ms)');
+                LogUtils_logHHAuto('Hero object not available after ' + HERO_MAX_RETRIES + ' retries and ' + HERO_GIVEUP_MAX_RELOADS + ' auto-reloads. Giving up. Try reloading the page. (page=' + location.pathname + ', elapsed=' + elapsed + 'ms)');
             }
             return;
         }
-        logHHAuto('???no Hero??? (attempt ' + heroRetryCount + '/' + HERO_MAX_RETRIES + ', page=' + location.pathname + ', elapsed=' + elapsed + 'ms)');
+        LogUtils_logHHAuto('???no Hero??? (attempt ' + heroRetryCount + '/' + HERO_MAX_RETRIES + ', page=' + location.pathname + ', elapsed=' + elapsed + 'ms)');
         started = false;
         heroRetryTimer = setTimeout(hardened_start, 5000);
         return;
@@ -28474,10 +28479,10 @@ function start() {
     // line so it is verifiable that shared.Hero was actually found, including
     // how long it took when there were retries.
     if (heroRetryCount > 0) {
-        logHHAuto('Hero object available after ' + heroRetryCount + ' retries (elapsed=' + (Date.now() - heroRetryFirstAt) + 'ms, page=' + location.pathname + ').');
+        LogUtils_logHHAuto('Hero object available after ' + heroRetryCount + ' retries (elapsed=' + (Date.now() - heroRetryFirstAt) + 'ms, page=' + location.pathname + ').');
     }
     else {
-        logHHAuto('Hero object available (page=' + location.pathname + ').');
+        LogUtils_logHHAuto('Hero object available (page=' + location.pathname + ').');
     }
     heroRetryCount = 0;
     heroRetryFirstAt = 0;
@@ -28488,7 +28493,7 @@ function start() {
     }
     catch (e) { /* sessionStorage unavailable */ }
     if ($("a[rel='phoenix_member_login']").length > 0) {
-        logHHAuto('Not logged in, please login first!');
+        LogUtils_logHHAuto('Not logged in, please login first!');
         return;
     }
     StartService.checkVersion();
@@ -28527,7 +28532,7 @@ function start() {
         };
         if (selectionMap[raidStarsVal] !== undefined) {
             setStoredValue(HHStoredVarPrefixKey + SK.plusLoveRaidMythic, selectionMap[raidStarsVal]);
-            logHHAuto("Migrated +Raid Stars value '" + raidStarsVal + "' → '" + selectionMap[raidStarsVal] + "'");
+            LogUtils_logHHAuto("Migrated +Raid Stars value '" + raidStarsVal + "' → '" + selectionMap[raidStarsVal] + "'");
         }
     }
     // Migrate Season focus stored value to string-based selection (runs every load).
@@ -28541,7 +28546,7 @@ function start() {
         };
         if (focusMap[seasonFocusVal] !== undefined) {
             setStoredValue(HHStoredVarPrefixKey + SK.autoSeasonFocus, focusMap[seasonFocusVal]);
-            logHHAuto("Migrated Season focus value '" + seasonFocusVal + "' → '" + focusMap[seasonFocusVal] + "'");
+            LogUtils_logHHAuto("Migrated Season focus value '" + seasonFocusVal + "' → '" + focusMap[seasonFocusVal] + "'");
         }
     }
     StartService_setDefaults();
@@ -28752,7 +28757,7 @@ function start() {
         const lastTs = typeof (last === null || last === void 0 ? void 0 : last.dateTime) === 'number' ? last.dateTime : 0;
         if (lastTs > 0 && (Date.now() - lastTs) > COLD_START_THRESHOLD_MS) {
             initialDelayMs = COLD_START_DELAY_MS;
-            logHHAuto('Cold start detected (last activity > ' + Math.round(COLD_START_THRESHOLD_MS / 1000) + 's ago), delaying first autoLoop by ' + initialDelayMs + 'ms');
+            LogUtils_logHHAuto('Cold start detected (last activity > ' + Math.round(COLD_START_THRESHOLD_MS / 1000) + 's ago), delaying first autoLoop by ' + initialDelayMs + 'ms');
         }
     }
     catch (e) { /* fall back to normal delay */ }
@@ -28769,7 +28774,7 @@ function start() {
 }
 ;
 
-;// ./src/Service/BlockScheduler.ts
+;// CONCATENATED MODULE: ./src/Service/BlockScheduler.ts
 var BlockScheduler_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -29089,7 +29094,7 @@ class BlockScheduler {
     }
 }
 
-;// ./src/Service/BlockRunStore.ts
+;// CONCATENATED MODULE: ./src/Service/BlockRunStore.ts
 // BlockRunStore.ts -- reload-safe persistence of the active BlockRun
 // (v7.37.0 pipeline-block architecture, ADR-001).
 //
@@ -29144,7 +29149,7 @@ function clearBlockRun() {
     deleteStoredValue(key());
 }
 
-;// ./src/Service/PipeLogger.ts
+;// CONCATENATED MODULE: ./src/Service/PipeLogger.ts
 // PipeLogger.ts -- structured [PIPE] logging for the block scheduler
 // (v7.37.0 pipeline-block architecture, ADR-001, task 7).
 //
@@ -29213,14 +29218,14 @@ function logEvent(fields) {
     // Per-step "done" is verbose; the run-complete "done" is lean.
     if (ev === "done" && fields.detail !== "run complete" && !isDiagnose())
         return;
-    logHHAuto(formatPipeLine(fields));
+    LogUtils_logHHAuto(formatPipeLine(fields));
 }
 /** Write/refresh the non-rotating context block (R6.16). Prepended to the export via storage. */
 function writeLogContext(ctx) {
     setStoredValue(HHStoredVarPrefixKey + TK.pipelineLogContext, JSON.stringify(ctx));
 }
 
-;// ./src/Module/Bundles.pure.ts
+;// CONCATENATED MODULE: ./src/Module/Bundles.pure.ts
 // Bundles.pure.ts -- Pure decision logic for the free-bundle collector.
 //
 // Extracted from Bundles.getExpiryTime so the 24-hour threshold check
@@ -29251,7 +29256,7 @@ function decideExpiryTime(state) {
     return state.scrapedSeconds;
 }
 
-;// ./src/Module/Bundles.ts
+;// CONCATENATED MODULE: ./src/Module/Bundles.ts
 // Bundles.ts -- Collects free daily and periodic bundles from the shop popup.
 //
 // The game periodically offers free bundle rewards in a popup. This module
@@ -29278,12 +29283,12 @@ class Bundles {
         let scrapedSeconds = null;
         if ($(timerRequest).length > 0) {
             scrapedSeconds = Number(convertTimeToInt($(timerRequest).text()));
-            logHHAuto('freeBundleTimer', scrapedSeconds);
+            LogUtils_logHHAuto('freeBundleTimer', scrapedSeconds);
         }
         const fallbackSeconds = ConfigHelper.getHHScriptVars("maxCollectionDelay") + randomInterval(60, 180);
         const decision = decideExpiryTime({ scrapedSeconds, fallbackSeconds });
         if (scrapedSeconds === null || scrapedSeconds >= 24 * 3600) {
-            logHHAuto('ERROR: can\'t get bundle expiry time, default to maxCollectionDelay');
+            LogUtils_logHHAuto('ERROR: can\'t get bundle expiry time, default to maxCollectionDelay');
         }
         return decision;
     }
@@ -29291,44 +29296,44 @@ class Bundles {
         if (getPage() === ConfigHelper.getHHScriptVars("pagesIDHome")) {
             try {
                 if (getStoredValue(HHStoredVarPrefixKey + SK.autoFreeBundlesCollect) !== "true") {
-                    logHHAuto("Error autoFreeBundlesCollect not activated.");
+                    LogUtils_logHHAuto("Error autoFreeBundlesCollect not activated.");
                     return;
                 }
                 const plusButton = $("header .currency .reversed_tooltip");
                 if (plusButton.length > 0) {
-                    logHHAuto("click button for popup.");
+                    LogUtils_logHHAuto("click button for popup.");
                     plusButton.trigger('click');
                 }
                 else {
-                    logHHAuto("No button for popup. Try again in 5h.");
+                    LogUtils_logHHAuto("No button for popup. Try again in 5h.");
                     setTimer('nextFreeBundlesCollectTime', randomInterval(4 * 60 * 60, 6 * 60 * 60));
                     return false;
                 }
-                logHHAuto("setting autoloop to false");
+                LogUtils_logHHAuto("setting autoloop to false");
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 const bundleTabsContainerQuery = "#common-popups .payments-wrapper .payment-tabs";
                 const bundleTabsListQuery = '.starter_offers, .event_bundles, .special_offers, .period_deal';
                 const subTabsQuery = "#common-popups .payments-wrapper .content-container .subtabs-container .card-container";
                 const freeButtonBundleQuery = "#common-popups .payments-wrapper .bundle .bundle-offer-price .blue_button_L:enabled[price='0.00']";
                 function collectFreeBundlesFinished(message, nextFreeBundlesCollectTime) {
-                    logHHAuto(message);
+                    LogUtils_logHHAuto(message);
                     setTimer('nextFreeBundlesCollectTime', nextFreeBundlesCollectTime);
                     $("#common-popups .close_cross").trigger('click'); // Close popup
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "true");
-                    logHHAuto("setting autoloop to true");
+                    LogUtils_logHHAuto("setting autoloop to true");
                     setTimeout(autoLoop, Number(getStoredValue(HHStoredVarPrefixKey + TK.autoLoopTimeMili)));
                 }
                 function parseAndCollectFreeBundles() {
                     const freeBundlesNumber = $(freeButtonBundleQuery).length;
                     if (freeBundlesNumber > 0) {
-                        logHHAuto("Free Bundles found: " + freeBundlesNumber);
+                        LogUtils_logHHAuto("Free Bundles found: " + freeBundlesNumber);
                         let buttonsToCollect = [];
                         for (let currentBundle = 0; currentBundle < freeBundlesNumber; currentBundle++) {
                             buttonsToCollect.push($(freeButtonBundleQuery)[currentBundle]);
                         }
                         function collectFreeBundle() {
                             if (buttonsToCollect.length > 0) {
-                                logHHAuto("Collecting bundle n°" + buttonsToCollect[0].getAttribute('product'));
+                                LogUtils_logHHAuto("Collecting bundle n°" + buttonsToCollect[0].getAttribute('product'));
                                 buttonsToCollect[0].click();
                                 buttonsToCollect.shift();
                                 setTimeout(RewardHelper.closeRewardPopupIfAny, randomInterval(500, 800));
@@ -29348,14 +29353,14 @@ class Bundles {
                         let freeBundleFound = false;
                         for (let bundleIndex = 0; bundleIndex < bundleTabs.length && !freeBundleFound; bundleIndex++) {
                             bundleTabs[bundleIndex].click();
-                            logHHAuto("Looking in tabs '" + $(bundleTabs[bundleIndex]).attr('type') + "'.");
+                            LogUtils_logHHAuto("Looking in tabs '" + $(bundleTabs[bundleIndex]).attr('type') + "'.");
                             freeBundleFound = parseAndCollectFreeBundles();
                             if (!freeBundleFound && $(subTabsQuery).length > 0) {
                                 const subTabs = $(subTabsQuery);
-                                logHHAuto("Sub tabs found, switching to next one");
+                                LogUtils_logHHAuto("Sub tabs found, switching to next one");
                                 for (let subTabIndex = 1; subTabIndex < subTabs.length && !freeBundleFound; subTabIndex++) {
                                     subTabs[subTabIndex].click();
-                                    logHHAuto("Looking in sub tabs '" + $(subTabs[subTabIndex]).attr('period_deal') + "'.");
+                                    LogUtils_logHHAuto("Looking in sub tabs '" + $(subTabs[subTabIndex]).attr('period_deal') + "'.");
                                     freeBundleFound = parseAndCollectFreeBundles();
                                 }
                             }
@@ -29373,13 +29378,13 @@ class Bundles {
                 return true;
             }
             catch ({ errName, message }) {
-                logHHAuto(`ERROR during free bundles run: ${message}, retry in 1h`);
+                LogUtils_logHHAuto(`ERROR during free bundles run: ${message}, retry in 1h`);
                 setTimer('nextFreeBundlesCollectTime', randomInterval(3600, 4000));
                 return false;
             }
         }
         else {
-            logHHAuto("Navigating to home page.");
+            LogUtils_logHHAuto("Navigating to home page.");
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
             // return busy
             return true;
@@ -29387,7 +29392,7 @@ class Bundles {
     }
 }
 
-;// ./src/Module/LabyrinthAuto.ts
+;// CONCATENATED MODULE: ./src/Module/LabyrinthAuto.ts
 var LabyrinthAuto_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -29433,7 +29438,7 @@ class LabyrinthAuto {
             // off instead of overflowing the stack. Full continuation model is
             // tracked for the step-17 multi-step scheduler.
             if (depth > 10) {
-                logHHAuto('Labyrinth: max recursion depth reached this tick, backing off.');
+                LogUtils_logHHAuto('Labyrinth: max recursion depth reached this tick, backing off.');
                 setTimer('nextLabyrinthTime', randomInterval(60, 120));
                 return false;
             }
@@ -29441,7 +29446,7 @@ class LabyrinthAuto {
             if (page === ConfigHelper.getHHScriptVars("pagesIDLabyrinthEntrance")) {
                 const difficultyButton = $('.difficulty-button:not([disabled])');
                 if (difficultyButton.length === 1) {
-                    logHHAuto(`On Labyrinth entrance page, only one difficulty available, ${difficultyButton.text().trim()}, select it.`);
+                    LogUtils_logHHAuto(`On Labyrinth entrance page, only one difficulty available, ${difficultyButton.text().trim()}, select it.`);
                     difficultyButton.trigger('click');
                     yield TimeHelper.sleep(randomInterval(200, 400));
                     $('#labyrinth_confirm_difficulty button.blue_button_L').trigger('click');
@@ -29453,7 +29458,7 @@ class LabyrinthAuto {
                     const difficultyToSelect = LabyrinthAuto.LABYRINTH_SELECTOR[parseInt(chooseDifficulty)];
                     const buttonToSelect = $(`.difficulty-button.difficulty-${difficultyToSelect}:not([disabled])`);
                     if (buttonToSelect.length === 1) {
-                        logHHAuto(`On Labyrinth entrance page, selecting ${difficultyToSelect} difficulty.`);
+                        LogUtils_logHHAuto(`On Labyrinth entrance page, selecting ${difficultyToSelect} difficulty.`);
                         buttonToSelect.trigger('click');
                         yield TimeHelper.sleep(randomInterval(200, 400));
                         $('#labyrinth_confirm_difficulty button.blue_button_L').trigger('click');
@@ -29461,28 +29466,28 @@ class LabyrinthAuto {
                         return true;
                     }
                     else {
-                        logHHAuto(`On Labyrinth entrance page, ${difficultyToSelect} difficulty not available, manual selection needed.`);
+                        LogUtils_logHHAuto(`On Labyrinth entrance page, ${difficultyToSelect} difficulty not available, manual selection needed.`);
                     }
                 }
                 setTimer('nextLabyrinthTime', randomInterval(600, 700));
                 return false;
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDLabyrinthPoolSelect")) {
-                logHHAuto("On Labyrinthpool select.");
+                LogUtils_logHHAuto("On Labyrinthpool select.");
                 $('button.blue_button_L[rel="labyrinth_auto_assign"]').trigger('click');
                 yield TimeHelper.sleep(randomInterval(200, 400));
                 $('button.blue_button_L[rel="labyrinth_team_confirmation"]').trigger('click');
                 return true;
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDLabyrinth")) {
-                logHHAuto("On Labyrinth page.");
+                LogUtils_logHHAuto("On Labyrinth page.");
                 yield TimeHelper.sleep(randomInterval(500, 800));
                 if (this.closeRewards()) {
                     if (this.debugEnabled)
-                        logHHAuto('Some rewards popup closed');
+                        LogUtils_logHHAuto('Some rewards popup closed');
                 }
                 if ($('.cleared-labyrinth-container:visible').length > 0) {
-                    logHHAuto("Labyrinth ended.");
+                    LogUtils_logHHAuto("Labyrinth ended.");
                     setTimer('nextLabyrinthTime', Labyrinth.getResetTime() + randomInterval(7200, 8000));
                     return false;
                 }
@@ -29496,28 +29501,28 @@ class LabyrinthAuto {
                     Labyrinth.sim();
                     yield TimeHelper.sleep(randomInterval(200, 400));
                     if ($('.labChosen').length <= 0) {
-                        logHHAuto("Issue to find labyrinth next step button, retry in 60secs.");
+                        LogUtils_logHHAuto("Issue to find labyrinth next step button, retry in 60secs.");
                         setTimer('nextLabyrinthTime', randomInterval(60, 70));
                         return true;
                     }
                 }
                 setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
                 if (this.debugEnabled)
-                    logHHAuto("setting autoloop to false");
+                    LogUtils_logHHAuto("setting autoloop to false");
                 const autoLabySweep = getStoredValue(HHStoredVarPrefixKey + SK.autoLabySweep) === "true";
                 const sweepFloorButton = $('#sweeping-floor:not([disabled])');
                 if (autoLabySweep && sweepFloorButton.length > 0) {
-                    logHHAuto("Auto laby sweep enabled, triggering sweep.");
+                    LogUtils_logHHAuto("Auto laby sweep enabled, triggering sweep.");
                     sweepFloorButton.trigger('click');
                     yield TimeHelper.sleep(randomInterval(1000, 1500));
                     if (this.debugEnabled)
-                        logHHAuto("Confirm sweep.");
+                        LogUtils_logHHAuto("Confirm sweep.");
                     $("#labyrinth_sweeping_preview_popup #popup_confirm.blue_button_L").trigger('click');
                     yield TimeHelper.sleep(randomInterval(1500, 2000));
                     // Close reward popup or wait until it opens
                     for (let i = 0; i < 3; i++) {
                         if (this.debugEnabled)
-                            logHHAuto("Close seep reward popup.");
+                            LogUtils_logHHAuto("Close seep reward popup.");
                         const popupOpened = this.closeRewards();
                         yield TimeHelper.sleep(randomInterval(800, 1300));
                         if (popupOpened)
@@ -29538,35 +29543,35 @@ class LabyrinthAuto {
                 return true;
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDLabyrinthPreBattle")) {
-                logHHAuto("On labyrinth-pre-battle page.");
+                LogUtils_logHHAuto("On labyrinth-pre-battle page.");
                 if (this.getNumberSelectedGirl() === 7) {
                     const templeID = queryStringGetParam(window.location.search, 'id_opponent');
-                    logHHAuto("Go and fight labyrinth :" + templeID);
+                    LogUtils_logHHAuto("Go and fight labyrinth :" + templeID);
                     const labyrinthBattleButton = $("#pre-battle .buttons-container .blue_button_L");
                     if (labyrinthBattleButton.length > 0) {
                         setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                        logHHAuto("setting autoloop to false");
+                        LogUtils_logHHAuto("setting autoloop to false");
                         labyrinthBattleButton[0].click();
                     }
                     else {
-                        logHHAuto("Issue to find labyrinth battle button retry in 60secs.");
+                        LogUtils_logHHAuto("Issue to find labyrinth battle button retry in 60secs.");
                         setTimer('nextLabyrinthTime', randomInterval(60, 70));
                     }
                 }
                 else if (this.getNumberSelectedGirl() < 7) {
-                    logHHAuto("Not enough girls, Edit team.");
+                    LogUtils_logHHAuto("Not enough girls, Edit team.");
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDEditLabyrinthTeam"));
                 }
                 else {
-                    logHHAuto("Error in parsing, disable laby.");
+                    LogUtils_logHHAuto("Error in parsing, disable laby.");
                     setStoredValue(HHStoredVarPrefixKey + SK.autoLabyrinth, "false");
                 }
                 return true;
             }
             else if (page === ConfigHelper.getHHScriptVars("pagesIDEditLabyrinthTeam")) {
-                logHHAuto("Fill team.");
+                LogUtils_logHHAuto("Fill team.");
                 const numberOfGirlsRemaining = Labyrinth.getRemainingNumberOfGirl();
-                logHHAuto(`Number of girls remaining: ${numberOfGirlsRemaining}`);
+                LogUtils_logHHAuto(`Number of girls remaining: ${numberOfGirlsRemaining}`);
                 if (numberOfGirlsRemaining >= 7) {
                     const customTeamBuilder = getStoredValue(HHStoredVarPrefixKey + SK.autoLabyCustomTeamBuilder) === "true";
                     if (customTeamBuilder) {
@@ -29587,12 +29592,12 @@ class LabyrinthAuto {
                     }
                     else {
                         if (this.debugEnabled)
-                            logHHAuto('Not enough girl selected, retry...');
+                            LogUtils_logHHAuto('Not enough girl selected, retry...');
                         return this.run(depth + 1);
                     }
                 }
                 else {
-                    logHHAuto('Not enough girl to continue. Stopping');
+                    LogUtils_logHHAuto('Not enough girl to continue. Stopping');
                     setTimer('nextLabyrinthTime', randomInterval(5 * 60 * 60, 7 * 60 * 60));
                     gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
                     return true;
@@ -29628,7 +29633,7 @@ LabyrinthAuto.NORMAL = LABY_DIFFICULTY.NORMAL;
 LabyrinthAuto.HARD = LABY_DIFFICULTY.HARD;
 LabyrinthAuto.LABYRINTH_SELECTOR = ['easy', 'normal', 'hard'];
 
-;// ./src/Module/harem/HaremSalary.ts
+;// CONCATENATED MODULE: ./src/Module/harem/HaremSalary.ts
 var HaremSalary_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -29686,26 +29691,26 @@ class HaremSalary {
                         if (enoughSalaryToCollect) {
                             const getButtonClass = salaryButton.attr("class") || '';
                             if (getButtonClass.indexOf("blue_button_L") !== -1 || getButtonClass.indexOf("round_blue_button") !== -1) {
-                                logHHAuto('Collected all salary');
+                                LogUtils_logHHAuto('Collected all salary');
                                 salaryButton.trigger('click');
                                 yield TimeHelper.sleep(randomInterval(200, 400));
                                 setTimer('nextSalaryTime', randomInterval(60, 180));
                                 return false;
                             }
                             else {
-                                logHHAuto("Unknown salary button color : " + getButtonClass);
+                                LogUtils_logHHAuto("Unknown salary button color : " + getButtonClass);
                                 setTimer('nextSalaryTime', randomInterval(60, 180));
                             }
                         }
                         else {
-                            logHHAuto("Not enough salary to collect, wait");
+                            LogUtils_logHHAuto("Not enough salary to collect, wait");
                             setTimer('nextSalaryTime', randomInterval(60, 180));
                         }
                     }
                 }
             }
             catch (ex) {
-                logHHAuto("Catched error : Could not collect salary... " + ex);
+                LogUtils_logHHAuto("Catched error : Could not collect salary... " + ex);
                 setTimer('nextSalaryTime', randomInterval(60, 180));
                 // return not busy
                 return false;
@@ -29715,7 +29720,7 @@ class HaremSalary {
     }
 }
 
-;// ./src/Module/GenericBattle.ts
+;// CONCATENATED MODULE: ./src/Module/GenericBattle.ts
 // GenericBattle.ts -- Handles the battle result page UI across all fight types.
 //
 // When a battle completes (troll, event, league, etc.), this module manages
@@ -29750,9 +29755,9 @@ class GenericBattle {
             || getPage() === ConfigHelper.getHHScriptVars("pagesIDPentaDrillBattle")
             || getPage() === ConfigHelper.getHHScriptVars("pagesIDPantheonBattle")
             || getPage() === ConfigHelper.getHHScriptVars("pagesIDLabyrinthBattle")) {
-            logHHAuto("On battle page.");
+            LogUtils_logHHAuto("On battle page.");
             if (getPage() === ConfigHelper.getHHScriptVars("pagesIDLeagueBattle") && getStoredValue(HHStoredVarPrefixKey + SK.autoLeagues) === "true") {
-                logHHAuto("Reloading after league fight.");
+                LogUtils_logHHAuto("Reloading after league fight.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDLeaderboard"), {}, randomInterval(4000, 5000));
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDTrollBattle")) {
@@ -29767,23 +29772,23 @@ class GenericBattle {
                 if (getStoredValue(HHStoredVarPrefixKey + SK.plusEvent) === "true" && (eventGirl === null || eventGirl === void 0 ? void 0 : eventGirl.girl_id) && !(eventGirl === null || eventGirl === void 0 ? void 0 : eventGirl.is_mythic)
                     ||
                         getStoredValue(HHStoredVarPrefixKey + SK.plusEventMythic) === "true" && (eventMythicGirl === null || eventMythicGirl === void 0 ? void 0 : eventMythicGirl.girl_id) && (eventMythicGirl === null || eventMythicGirl === void 0 ? void 0 : eventMythicGirl.is_mythic)) {
-                    logHHAuto("Event ongoing search for girl rewards in popup.");
+                    LogUtils_logHHAuto("Event ongoing search for girl rewards in popup.");
                     RewardHelper.ObserveAndGetGirlRewards();
                 }
                 else {
                     LoveRaidManager.getTrollRaids().forEach((raid) => {
                         if (raid.trollId === Number(troll_id)) {
-                            logHHAuto("Event ongoing search for girl rewards in popup.");
+                            LogUtils_logHHAuto("Event ongoing search for girl rewards in popup.");
                             RewardHelper.ObserveAndGetGirlRewards();
                             return true;
                         }
                     });
                     if (troll_id !== null) {
-                        logHHAuto("Go back to Troll after Troll fight.");
+                        LogUtils_logHHAuto("Go back to Troll after Troll fight.");
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDTrollPreBattle"), { id_opponent: troll_id }, randomInterval(2000, 4000));
                     }
                     else {
-                        logHHAuto("Go to home after unknown troll fight.");
+                        LogUtils_logHHAuto("Go to home after unknown troll fight.");
                         gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"), {}, randomInterval(2000, 4000));
                     }
                 }
@@ -29793,32 +29798,32 @@ class GenericBattle {
                 // pvp-arena is the new page the game shows season fights on
                 // (July 2026); handle it exactly like the old season-battle
                 // result page.
-                logHHAuto("Go back to Season arena after Season fight.");
+                LogUtils_logHHAuto("Go back to Season arena after Season fight.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDSeasonArena"), {}, randomInterval(2000, 4000));
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPentaDrillBattle") && getStoredValue(HHStoredVarPrefixKey + SK.autoPentaDrill) === "true") {
-                logHHAuto("Go back to Penta drill arena after fight.");
+                LogUtils_logHHAuto("Go back to Penta drill arena after fight.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDPentaDrillArena"), {}, PentaDrill.getActionDelayMs());
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDPantheonBattle") && (getStoredValue(HHStoredVarPrefixKey + SK.autoPantheon) === "true" || DailyGoals.isPantheonDailyGoal())) {
-                logHHAuto("Go back to Pantheon arena after Pantheon temple.");
+                LogUtils_logHHAuto("Go back to Pantheon arena after Pantheon temple.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDPantheon"), {}, randomInterval(2000, 4000));
             }
             else if (getPage() === ConfigHelper.getHHScriptVars("pagesIDLabyrinthBattle") && getStoredValue(HHStoredVarPrefixKey + SK.autoLabyrinth) === "true") {
-                logHHAuto("Go back to Labyrinth after fight.");
+                LogUtils_logHHAuto("Go back to Labyrinth after fight.");
                 gotoPage(ConfigHelper.getHHScriptVars("pagesIDLabyrinth"), {}, randomInterval(2000, 4000));
             }
             return true;
         }
         else {
-            logHHAuto('Unable to identify page.');
+            LogUtils_logHHAuto('Unable to identify page.');
             gotoPage(ConfigHelper.getHHScriptVars("pagesIDHome"));
             return;
         }
     }
 }
 
-;// ./src/Service/Pipeline.config.ts
+;// CONCATENATED MODULE: ./src/Service/Pipeline.config.ts
 var Pipeline_config_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -29943,7 +29948,7 @@ function fromDescriptor(descriptor, opts) {
                 name: descriptor.action,
                 fn: (ctx) => Pipeline_config_awaiter(this, void 0, void 0, function* () {
                     try {
-                        logHHAuto(descriptor.name);
+                        LogUtils_logHHAuto(descriptor.name);
                         const result = yield descriptor.execute();
                         ctx.busy = typeof result === 'boolean' ? result : true;
                         ctx.lastActionPerformed = descriptor.action;
@@ -30214,7 +30219,7 @@ const handleLeague = {
         },
     ],
     onFailure: (_ctx, failedStep, reason) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
-        logHHAuto('[Pipeline] handleLeague failed at ' + failedStep + ': ' + reason);
+        LogUtils_logHHAuto('[Pipeline] handleLeague failed at ' + failedStep + ': ' + reason);
     }),
     totalTimeoutMs: 30000,
 };
@@ -30274,7 +30279,7 @@ const handleShop = {
             name: 'updateShop',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to check shop.');
+                    LogUtils_logHHAuto('Time to check shop.');
                     const result = Shop.updateShop();
                     ctx.busy = result === true;
                     ctx.lastActionPerformed = 'shop';
@@ -30536,21 +30541,21 @@ const handlePlaceOfPower = {
                     let popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
                     const popToStartExist = getStoredValue(HHStoredVarPrefixKey + TK.PopToStart) ? true : false;
                     if (!popToStartExist) {
-                        logHHAuto('Go and collect pop');
+                        LogUtils_logHHAuto('Go and collect pop');
                         ctx.busy = yield PlaceOfPower.collectAndUpdate();
                     }
                     const indexes = getStoredValue(HHStoredVarPrefixKey + SK.autoPowerPlacesIndexFilter).split(';');
                     popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
                     for (const pop of popToStart) {
                         if (ctx.busy === false && !indexes.includes(String(pop))) {
-                            logHHAuto('PoP is no longer in list :' + pop + ' removing it from start list.');
+                            LogUtils_logHHAuto('PoP is no longer in list :' + pop + ' removing it from start list.');
                             PlaceOfPower.removePopFromPopToStart(pop);
                         }
                     }
                     popToStart = getStoredJSON(HHStoredVarPrefixKey + TK.PopToStart, []);
                     for (const index of indexes) {
                         if (ctx.busy === false && popToStart.includes(Number(index))) {
-                            logHHAuto('Time to do PowerPlace' + index + '.');
+                            LogUtils_logHHAuto('Time to do PowerPlace' + index + '.');
                             ctx.busy = yield PlaceOfPower.doPowerPlacesStuff(index);
                             ctx.lastActionPerformed = 'pop';
                         }
@@ -30691,7 +30696,7 @@ const handleTrollBattle = {
                                 ? (ctx.currentPower > 0 || Troll.canBuyFightForRaid(loveRaid, false).canBuy)
                                 : (energyAboveThreshold || Troll.canBuyFightForRaid(loveRaid, false).canBuy)));
                     if (shouldFight) {
-                        logHHAuto('Troll:', { threshold: threshold, runThreshold: runThreshold, TrollHumanLikeRun: humanLikeRun });
+                        LogUtils_logHHAuto('Troll:', { threshold: threshold, runThreshold: runThreshold, TrollHumanLikeRun: humanLikeRun });
                         setStoredValue(HHStoredVarPrefixKey + TK.battlePowerRequired, '0');
                         ctx.busy = true;
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) !== 'true' || getStoredValue(HHStoredVarPrefixKey + TK.questRequirement)[0] !== 'P') {
@@ -30700,7 +30705,7 @@ const handleTrollBattle = {
                                 ctx.lastActionPerformed = 'troll';
                         }
                         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === 'true') {
-                            logHHAuto('AutoBattle disabled for power collection for AutoQuest.');
+                            LogUtils_logHHAuto('AutoBattle disabled for power collection for AutoQuest.');
                             document.getElementById('autoTrollBattle').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle, 'false');
                             ctx.busy = false;
@@ -30716,7 +30721,7 @@ const handleTrollBattle = {
                             setStoredValue(HHStoredVarPrefixKey + TK.TrollHumanLikeRun, 'false');
                         }
                         if (ctx.currentPower === 0 && wouldFightWithPower(eventGirl, eventMythicGirl, raidStarsRaid, loveRaid)) {
-                            logHHAuto('Troll fight pending: waiting for energy refill.');
+                            LogUtils_logHHAuto('Troll fight pending: waiting for energy refill.');
                             setStoredValue(HHStoredVarPrefixKey + TK.trollWaitForEnergy, 'true');
                         }
                     }
@@ -30775,17 +30780,17 @@ const handlePachinko = {
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
                     if (ctx.busy === false && ConfigHelper.getHHScriptVars('isEnabledMythicPachinko', false) && checkTimer('nextPachinko2Time')) {
-                        logHHAuto('Time to fetch Mythic Pachinko.');
+                        LogUtils_logHHAuto('Time to fetch Mythic Pachinko.');
                         ctx.busy = yield Pachinko.getMythicPachinko();
                         ctx.lastActionPerformed = 'pachinko';
                     }
                     if (ctx.busy === false && ConfigHelper.getHHScriptVars('isEnabledGreatPachinko', false) && checkTimer('nextPachinkoTime')) {
-                        logHHAuto('Time to fetch Great Pachinko.');
+                        LogUtils_logHHAuto('Time to fetch Great Pachinko.');
                         ctx.busy = yield Pachinko.getGreatPachinko();
                         ctx.lastActionPerformed = 'pachinko';
                     }
                     if (ctx.busy === false && ConfigHelper.getHHScriptVars('isEnabledEquipmentPachinko', false) && checkTimer('nextPachinkoEquipTime')) {
-                        logHHAuto('Time to fetch Equipment Pachinko.');
+                        LogUtils_logHHAuto('Time to fetch Equipment Pachinko.');
                         ctx.busy = yield Pachinko.getEquipmentPachinko();
                         ctx.lastActionPerformed = 'pachinko';
                     }
@@ -30840,14 +30845,14 @@ const handleQuest = {
                     const routeHomeIfWaitingOnQuest = () => {
                         const onQuestPage = ctx.currentPage === ConfigHelper.getHHScriptVars('pagesIDQuest') || ctx.currentPage === 'side-quests';
                         if (!ctx.busy && onQuestPage) {
-                            logHHAuto('Quest waiting for resources, returning home.');
+                            LogUtils_logHHAuto('Quest waiting for resources, returning home.');
                             ctx.busy = gotoPage(ConfigHelper.getHHScriptVars('pagesIDHome'));
                         }
                     };
                     if (questRequirement === 'battle') {
                         if (ConfigHelper.getHHScriptVars('isEnabledTrollBattle', false) && getStoredValue(HHStoredVarPrefixKey + TK.autoTrollBattleSaveQuest) === 'false') {
-                            logHHAuto('Quest requires battle.');
-                            logHHAuto('prepare to save one battle for quest');
+                            LogUtils_logHHAuto('Quest requires battle.');
+                            LogUtils_logHHAuto('prepare to save one battle for quest');
                             setStoredValue(HHStoredVarPrefixKey + TK.autoTrollBattleSaveQuest, 'true');
                             if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) !== 'true') {
                                 ctx.busy = yield Troll.doBossBattle();
@@ -30856,16 +30861,16 @@ const handleQuest = {
                     }
                     else if (questRequirement[0] === '$') {
                         if (Number(questRequirement.substr(1)) < getHHVars('Hero.currencies.soft_currency')) {
-                            logHHAuto('Continuing quest, required money obtained.');
+                            LogUtils_logHHAuto('Continuing quest, required money obtained.');
                             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
                             ctx.busy = QuestHelper.run();
                         }
                         else {
                             setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
                             if (isNaN(Number(questRequirement.substr(1)))) {
-                                logHHAuto(questRequirement);
+                                LogUtils_logHHAuto(questRequirement);
                                 setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
-                                logHHAuto('Invalid money in session storage quest requirement !');
+                                LogUtils_logHHAuto('Invalid money in session storage quest requirement !');
                             }
                             ctx.busy = false;
                         }
@@ -30876,7 +30881,7 @@ const handleQuest = {
                         const energyCurrent = QuestHelper.getEnergy();
                         if (energyNeeded <= energyCurrent) {
                             if (Number(energyCurrent) > Number(getStoredValue(HHStoredVarPrefixKey + SK.autoQuestThreshold)) || ParanoiaService.checkParanoiaSpendings('quest') > 0) {
-                                logHHAuto('Continuing quest, required energy obtained.');
+                                LogUtils_logHHAuto('Continuing quest, required energy obtained.');
                                 setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
                                 ctx.busy = QuestHelper.run();
                             }
@@ -30893,12 +30898,12 @@ const handleQuest = {
                     else if (questRequirement[0] === 'P') {
                         const neededPower = Number(questRequirement.substr(1));
                         if (ctx.currentPower < neededPower) {
-                            logHHAuto('Quest requires ' + neededPower + ' Battle Power for advancement. Waiting...');
+                            LogUtils_logHHAuto('Quest requires ' + neededPower + ' Battle Power for advancement. Waiting...');
                             ctx.busy = false;
                             setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
                         }
                         else {
-                            logHHAuto('Battle Power obtained, resuming quest...');
+                            LogUtils_logHHAuto('Battle Power obtained, resuming quest...');
                             setStoredValue(HHStoredVarPrefixKey + TK.questRequirement, 'none');
                             ctx.busy = QuestHelper.run();
                         }
@@ -30907,12 +30912,12 @@ const handleQuest = {
                     else if (questRequirement === 'unknownQuestButton') {
                         setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled.HHAuto_Setting_AutoQuest cannot be performed due to unknown quest button. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled.HHAuto_Setting_AutoQuest cannot be performed due to unknown quest button. Please manually proceed the current quest screen.');
                             document.getElementById('autoQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, 'false');
                         }
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled.HHAuto_Setting_autoSideQuest cannot be performed due to unknown quest button. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled.HHAuto_Setting_autoSideQuest cannot be performed due to unknown quest button. Please manually proceed the current quest screen.');
                             document.getElementById('autoSideQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest, 'false');
                         }
@@ -30922,12 +30927,12 @@ const handleQuest = {
                     else if (questRequirement === 'errorInAutoBattle') {
                         setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled.HHAuto_Setting_AutoQuest cannot be performed due errors in AutoBattle. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled.HHAuto_Setting_AutoQuest cannot be performed due errors in AutoBattle. Please manually proceed the current quest screen.');
                             document.getElementById('autoQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, 'false');
                         }
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled.HHAuto_Setting_autoSideQuest cannot be performed due errors in AutoBattle. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled.HHAuto_Setting_autoSideQuest cannot be performed due errors in AutoBattle. Please manually proceed the current quest screen.');
                             document.getElementById('autoSideQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest, 'false');
                         }
@@ -30950,12 +30955,12 @@ const handleQuest = {
                         // to wait for quest progress.
                         setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled. The current quest step requires an outfit change. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled. The current quest step requires an outfit change. Please manually proceed the current quest screen.');
                             document.getElementById('autoQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoQuest, 'false');
                         }
                         if (getStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest) === 'true') {
-                            logHHAuto('AutoQuest disabled. The current side-quest step requires an outfit change. Please manually proceed the current quest screen.');
+                            LogUtils_logHHAuto('AutoQuest disabled. The current side-quest step requires an outfit change. Please manually proceed the current quest screen.');
                             document.getElementById('autoSideQuest').checked = false;
                             setStoredValue(HHStoredVarPrefixKey + SK.autoSideQuest, 'false');
                         }
@@ -30977,13 +30982,13 @@ const handleQuest = {
                         // the quest page, route back home so the normal loop resumes.
                         const onQuestPage = ctx.currentPage === ConfigHelper.getHHScriptVars('pagesIDQuest') || ctx.currentPage === 'side-quests';
                         if (!ctx.busy && onQuestPage) {
-                            logHHAuto('Nothing to do on quest page, returning home.');
+                            LogUtils_logHHAuto('Nothing to do on quest page, returning home.');
                             ctx.busy = gotoPage(ConfigHelper.getHHScriptVars('pagesIDHome'));
                         }
                     }
                     else {
                         setStoredValue(HHStoredVarPrefixKey + TK.paranoiaQuestBlocked, 'true');
-                        logHHAuto('Invalid quest requirement : ' + questRequirement);
+                        LogUtils_logHHAuto('Invalid quest requirement : ' + questRequirement);
                         ctx.busy = false;
                     }
                     if (ctx.busy)
@@ -31035,7 +31040,7 @@ const handleSeason = {
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
                     if (Season.isTimeToFight()) {
-                        logHHAuto('Time to fight in Season.');
+                        LogUtils_logHHAuto('Time to fight in Season.');
                         ctx.busy = yield Season.run();
                         ctx.lastActionPerformed = 'season';
                         // Slot-hold (issue #1796): a fight was launched -- keep the run so
@@ -31104,7 +31109,7 @@ const handlePentaDrill = {
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
                     if (PentaDrill.isTimeToFight()) {
-                        logHHAuto('Time to fight in PentaDrill.');
+                        LogUtils_logHHAuto('Time to fight in PentaDrill.');
                         PentaDrill.run();
                         ctx.busy = true;
                         ctx.lastActionPerformed = 'pentaDrill';
@@ -31158,7 +31163,7 @@ const handlePantheon = {
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
                     if (Pantheon.isTimeToFight()) {
-                        logHHAuto('Time to do Pantheon.');
+                        LogUtils_logHHAuto('Time to do Pantheon.');
                         Pantheon.run();
                         ctx.busy = true;
                         ctx.lastActionPerformed = 'pantheon';
@@ -31227,7 +31232,7 @@ const handleChampionTicket = {
                             currency: 'energy_quest',
                             amount: '1',
                         };
-                        logHHAuto('Buying ticket with energy');
+                        LogUtils_logHHAuto('Buying ticket with energy');
                         getHHAjax()(params, function (data) {
                             Hero.updates(data.hero_changes);
                             // Route the post-purchase reload through safeReload so any
@@ -31243,7 +31248,7 @@ const handleChampionTicket = {
                     // suppressing ticks during the reload itself. See ChampionTicket
                     // race-window discussion in REVIEW_AutoLoop_Findings.md F1.
                     setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, 'false');
-                    logHHAuto('setting autoloop to false');
+                    LogUtils_logHHAuto('setting autoloop to false');
                     ctx.busy = true;
                     setTimeout(buyTicket, randomInterval(800, 1600));
                     ctx.lastActionPerformed = 'champion';
@@ -31281,7 +31286,7 @@ const handleSeasonCollect = {
             name: 'collectSeason',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to go and check Season for collecting reward.');
+                    LogUtils_logHHAuto('Time to go and check Season for collecting reward.');
                     ctx.busy = Season.goAndCollect();
                     ctx.lastActionPerformed = 'season';
                     return { ok: true };
@@ -31318,7 +31323,7 @@ const handlePentaDrillCollect = {
             name: 'collectPentaDrill',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to go and check PentaDrill for collecting reward.');
+                    LogUtils_logHHAuto('Time to go and check PentaDrill for collecting reward.');
                     ctx.busy = PentaDrill.goAndCollect();
                     ctx.lastActionPerformed = 'pentaDrill';
                     return { ok: true };
@@ -31355,7 +31360,7 @@ const handleSeasonalEventCollect = {
             name: 'collectSeasonalEvent',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to go and check SeasonalEvent for collecting reward.');
+                    LogUtils_logHHAuto('Time to go and check SeasonalEvent for collecting reward.');
                     ctx.busy = SeasonalEvent.goAndCollect();
                     ctx.lastActionPerformed = 'seasonal';
                     return { ok: true };
@@ -31392,7 +31397,7 @@ const handlePoVCollect = {
             name: 'collectPoV',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to go and check Path of Valor for collecting reward.');
+                    LogUtils_logHHAuto('Time to go and check Path of Valor for collecting reward.');
                     ctx.busy = PathOfValue.goAndCollect();
                     ctx.lastActionPerformed = 'pov';
                     return { ok: true };
@@ -31429,7 +31434,7 @@ const handlePoGCollect = {
             name: 'collectPoG',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Time to go and check Path of Glory for collecting reward.');
+                    LogUtils_logHHAuto('Time to go and check Path of Glory for collecting reward.');
                     ctx.busy = PathOfGlory.goAndCollect();
                     ctx.lastActionPerformed = 'pog';
                     return { ok: true };
@@ -31500,7 +31505,7 @@ const handleBossBangParse = {
             name: 'parseBossBang',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Going to parse boss bang event.');
+                    LogUtils_logHHAuto('Going to parse boss bang event.');
                     ctx.busy = yield EventModule.parseEventPage(ctx.bossBangEventIDs[0]);
                     ctx.lastActionPerformed = 'event';
                     return { ok: true };
@@ -31538,7 +31543,7 @@ const handleBossBangFight = {
             name: 'fightBossBang',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Going to fight boss bang.');
+                    LogUtils_logHHAuto('Going to fight boss bang.');
                     ctx.busy = yield BossBang.goToFightPage(ctx.bossBangEventIDs[0]);
                     ctx.lastActionPerformed = 'bossBang';
                     return { ok: true };
@@ -31571,7 +31576,7 @@ const handleGoHome = {
             name: 'gotoHome',
             fn: (ctx) => Pipeline_config_awaiter(void 0, void 0, void 0, function* () {
                 try {
-                    logHHAuto('Back to home page at the end of actions');
+                    LogUtils_logHHAuto('Back to home page at the end of actions');
                     deleteStoredValue(HHStoredVarPrefixKey + TK.LastPageCalled);
                     ctx.busy = gotoPage(ConfigHelper.getHHScriptVars('pagesIDHome'));
                     return { ok: true };
@@ -31660,7 +31665,7 @@ const pipeline = [
     handleGoHome,
 ];
 
-;// ./src/Service/BlockPipeline.ts
+;// CONCATENATED MODULE: ./src/Service/BlockPipeline.ts
 var BlockPipeline_awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -31800,7 +31805,7 @@ function buildScheduler() {
     const stored = getStoredJSON(HHStoredVarPrefixKey + TK.pipelineOrder, null);
     const resolved = resolveOrder(stored, registry, defaultOrder);
     for (const w of resolved.warnings)
-        logHHAuto(`[Scheduler] order: ${w.message}`);
+        LogUtils_logHHAuto(`[Scheduler] order: ${w.message}`);
     // Refresh the non-rotating log context block (R6.16): version/platform/order/
     // disabled blocks/diagnose flag, prepended to the user debug export.
     const disabledMap = blockPorts.getAutoDisabled();
@@ -31826,7 +31831,7 @@ function getBlockScheduler() {
     return _scheduler;
 }
 
-;// ./src/index.ts
+;// CONCATENATED MODULE: ./src/index.ts
 // index.ts - HHAuto entry point
 //
 // This is the Tampermonkey userscript entry point. It augments the
@@ -31883,9 +31888,9 @@ function wireMenuPorts() {
         getStoredValue: getStoredValue,
         getStorageItem: getStorageItem,
         setStoredValue: setStoredValue,
-        HHStoredVars: HHStoredVars,
+        HHStoredVars: HHStoredVars_HHStoredVars,
         storedVarPrefix: HHStoredVarPrefixKey,
-        logHHAuto: logHHAuto,
+        logHHAuto: LogUtils_logHHAuto,
         setDefaults: StartService_setDefaults,
         isDisplayedHHPopUp: isDisplayedHHPopUp,
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.5.1",
+  "version": "8.5.2",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Helper/ConfigHelper.spec.ts
+++ b/spec/Helper/ConfigHelper.spec.ts
@@ -48,7 +48,7 @@ describe("ConfigHelper", function() {
     it("HH", function() {
         MockHelper.mockDomain('www.hentaiheroes.com');
         expect(ConfigHelper.getHHScriptVars('eventIDReg')).toBe("event_");
-        expect(ConfigHelper.getHHScriptVars('lastQuestId')).toBe(2408);
+        expect(ConfigHelper.getHHScriptVars('lastQuestId')).toBe(2412);
         expect(ConfigHelper.getHHScriptVars('isEnabledSideQuest')).toBeTruthy();
 
         expect(ConfigHelper.getHHScriptVars('UNKNOWN')).toBeNull();

--- a/src/Module/Quest.ts
+++ b/src/Module/Quest.ts
@@ -55,8 +55,16 @@ export class QuestHelper {
         const lastQuestId:number = ConfigHelper.getHHScriptVars("lastQuestId",false);
         const trollz = ConfigHelper.getHHScriptVars("trollzList");
 
-        if (id_world < (trollz.length) || lastQuestId > 0 && id_quest != lastQuestId) {
-            // Fix when KK quest url is world url
+        // Fix when KK quest url is world url: force the direct /quest/<id>
+        // URL only while the player still has a known next main quest ahead.
+        // Use `<` (not `!=`) against lastQuestId: once id_quest reaches or
+        // passes our last-known quest id, trust the game's current_url (a world
+        // url at end-of-content) instead of forcing navigation into the newest
+        // quest screen. A stale lastQuestId (game added quests we do not know
+        // about yet) otherwise force-navigates onto that end-of-content screen,
+        // where the unrecognized button trips the unknownQuestButton path and
+        // switches auto main/side quest off (regression of the issue #1773 fix).
+        if (id_world < (trollz.length) || (lastQuestId > 0 && id_quest < lastQuestId)) {
             mainQuestUrl = "/quest/" + id_quest;
         }
         return mainQuestUrl;

--- a/src/config/game/HentaiHeroesVars.ts
+++ b/src/config/game/HentaiHeroesVars.ts
@@ -6,7 +6,7 @@ export class HentaiHeroes {
     static spreadsheet = 'https://docs.google.com/spreadsheets/d/1kVZxcZZMa82lS4k-IpxTTTELAeaipjR_v1twlqW5vbI'; // zoopokemon
     static trollIdMapping = { 21: 19, 24: 22 };
     static sideTrollIdMapping = { 22: 20, 23: 21 };
-    static lastQuestId = 2408; //  TODO update when new quest comes
+    static lastQuestId = 2412; //  TODO update when new quest comes
     static getEnv() {
         return {
             "www.hentaiheroes.com": { name: "HH_prod", id: "hh_hentai" },


### PR DESCRIPTION
## Summary

Regression of the v7.37.8 fix (#1773). Reported in #1811 on v8.5.1.

`QuestHelper.getMainQuestUrl` compared the player's current quest id with the last known quest id using `!=`. Once the game added quests beyond that id (game reached 2412, script knew 2408), it force-navigated onto the newest quest's end-of-content screen. The proceed button there is unrecognized, so the `unknownQuestButton` path fired and switched **both** `autoQuest` and `autoSideQuest` off every tick, even right after the user re-enabled them.

The reporter's debug log confirms the path: `side-quests -> /quest/2412 -> "Could not identify given resume button" -> AutoQuest disabled (main) + AutoQuest disabled (side)`. No side-quest DOM navigation and no "All quests finished" log, so `/quest/2412` came from the forced main-quest URL, not the side-quest list.

## Fix

- `getMainQuestUrl`: compare with `<` instead of `!=`. The direct `/quest/<id>` URL is forced only while the player is still below the newest known quest. Once they reach or pass it, the game's own `current_url` (a world url at end-of-content) is trusted and the bot waits for new content, leaving both toggles on. This makes a stale `lastQuestId` harmless (bot waits) instead of a recurring self-disable, matching the other game variants.
- Bump `HentaiHeroesVars.lastQuestId` 2408 -> 2412 so the world-url workaround keeps covering the live quest range.
- Update the `ConfigHelper` spec assertion accordingly.

Why the id is neither dropped nor set to a high sentinel: dropping it (`-1`) disables the forced-URL workaround and the main quest stops auto-advancing near the end; a high value (e.g. 9999) would force navigation onto the end screen for everyone who finished the newest quest, reintroducing exactly this self-disable. So it stays an exact value bumped when new quests ship.

## Verification

- `npm run typecheck` clean
- `npm run build` succeeds, `HHAuto.user.js` regenerated
- `npm test`: 87 suites / 1223 tests pass

Not tested live (cannot reproduce end-of-content locally); logic-verified against the reporter's debug log.