### PR TITLE
fix(troll): rebuild the troll-with-girls snapshot instead of caching once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to HHauto are documented here. Format loosely follows
 This file replaces the in-README "Latest Updates" section as of v7.35.52.
 Older entries below were migrated 1:1 from `README.md`.
 
+### v8.5.4 - "First/last troll with girl" no longer sticks on a finished troll
+
+- With the troll target set to "First troll with girl" or "Last troll with
+  girl", the bot could keep fighting a troll whose girls you had already
+  finished, and Love Raids never got their turn. The list of which trolls still
+  have girls was built once and kept for the whole browser session, so girls you
+  completed afterwards were not taken into account. That list is now rebuilt from
+  your current harem, so a finished troll is dropped and the bot moves on.
+
 ### v8.5.3 - Boss Bang runs all fights, collects rewards, and stays off when disabled
 
 - When the bot entered the Boss Bang battle screen, another due timer could

--- a/HHAuto.user.js
+++ b/HHAuto.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         HaremHeroes Automatic++
 // @namespace    https://github.com/OldRon1977/HHauto
-// @version      8.5.3
+// @version      8.5.4
 // @description  Open the menu in HaremHeroes(topright) to toggle AutoControlls. Supports AutoSalary, AutoContest, AutoMission, AutoQuest, AutoTrollBattle, AutoArenaBattle and AutoPachinko(Free), AutoLeagues, AutoChampions and AutoStatUpgrades. Messages are printed in local console.
 // @author       JD and Dorten(a bit), Roukys, cossname, YotoTheOne, CLSchwab, deuxge, react31, PrimusVox, OldRon1977, tsokh, UncleBob800
 // @match        http*://*.haremheroes.com/*
@@ -24933,21 +24933,28 @@ class Troll {
             TTF = Troll.getTrollIdFromEvent(eventGirl);
         }
         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true" && (autoTrollSelectedIndex === 98 || autoTrollSelectedIndex === 99)) {
-            if (trollWithGirls === undefined || trollWithGirls.length === 0) {
-                if (logging)
-                    LogUtils_logHHAuto("No troll with girls from storage, parsing game info ...");
-                trollWithGirls = Troll.getTrollWithGirls();
-                if (trollWithGirls.length === 0) {
-                    if (logging)
-                        LogUtils_logHHAuto("Need girls list, going to Waifu page to get them");
-                    if (!allowSideEffects)
-                        return 0;
-                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDWaifu"));
-                    return -1;
-                }
+            // Rebuild the "troll with girls" snapshot from the current harem
+            // whenever the girl list is available, instead of caching it once for
+            // the whole browser-tab lifetime. The old code only built it when the
+            // cache was empty, so girls completed later were never reflected: a
+            // fully-farmed troll kept being selected and Love Raids never got a
+            // turn (issue #1780). getTrollWithGirls() returns a non-empty array
+            // only when the girl list is loaded; otherwise fall back to the cached
+            // snapshot, or fetch the list from the Waifu page.
+            const freshTrollWithGirls = Troll.getTrollWithGirls();
+            if (freshTrollWithGirls.length > 0) {
+                trollWithGirls = freshTrollWithGirls;
                 if (allowSideEffects)
                     setStoredValue(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify(trollWithGirls));
+            }
+            else if (trollWithGirls === undefined || trollWithGirls.length === 0) {
+                if (logging)
+                    LogUtils_logHHAuto("Need girls list, going to Waifu page to get them");
+                if (!allowSideEffects)
+                    return 0;
+                setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDWaifu"));
+                return -1;
             }
             if (trollWithGirls !== undefined && trollWithGirls.length > 0) {
                 if (autoTrollSelectedIndex === 98) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hhauto",
-  "version": "8.5.3",
+  "version": "8.5.4",
   "description": "Tampermonkey userscript automating the Harem Heroes game family",
   "main": "HHAuto.user.js",
   "scripts": {

--- a/spec/Module/Troll.spec.ts
+++ b/spec/Module/Troll.spec.ts
@@ -443,6 +443,35 @@ describe("Troll module", function () {
             expect(TTF).toBe(4);
         });
 
+        it("rebuilds trollWithGirls from the current harem, ignoring a stale cache (issue #1780)", function () {
+            localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
+            localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '99'); // last troll with girl
+            // Stale snapshot from earlier in the session: every troll still flagged
+            // as having unfinished girls.
+            sessionStorage.setItem(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify([1, 1, 1, 1, 1]));
+            // Current harem: all troll girls owned -> fresh snapshot is all zeros.
+            jest.spyOn(Troll, 'getTrollWithGirls').mockReturnValue([0, 0, 0, 0, 0]);
+
+            const TTF = Troll.getTrollIdToFight(false);
+
+            // Fresh snapshot wins over the stale cache: no troll target left, so
+            // the caller (e.g. Love Raids) gets its turn instead of re-fighting a
+            // fully-farmed troll.
+            expect(TTF).toBe(0);
+        });
+
+        it("uses the freshly rebuilt trollWithGirls to pick the last troll that still has a girl", function () {
+            localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
+            localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '99'); // last troll with girl
+            sessionStorage.setItem(HHStoredVarPrefixKey + TK.trollWithGirls, JSON.stringify([0, 0, 0, 0, 0]));
+            // Fresh harem: only troll 3 still has an unfinished girl.
+            jest.spyOn(Troll, 'getTrollWithGirls').mockReturnValue([0, 0, 1, 0, 0]);
+
+            const TTF = Troll.getTrollIdToFight(false);
+
+            expect(TTF).toBe(3);
+        });
+
         it("returns custom troll index when autoTrollSelectedIndex set (1-97)", function () {
             localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollBattle, 'true');
             localStorage.setItem(HHStoredVarPrefixKey + SK.autoTrollSelectedIndex, '3');

--- a/src/Module/Troll.ts
+++ b/src/Module/Troll.ts
@@ -201,17 +201,24 @@ export class Troll {
             TTF = Troll.getTrollIdFromEvent(eventGirl);
         }
         else if (getStoredValue(HHStoredVarPrefixKey + SK.autoTrollBattle) === "true" && (autoTrollSelectedIndex === 98 || autoTrollSelectedIndex === 99)) {
-            if (trollWithGirls === undefined || trollWithGirls.length === 0) {
-                if (logging) logHHAuto("No troll with girls from storage, parsing game info ...");
-                trollWithGirls = Troll.getTrollWithGirls();
-                if (trollWithGirls.length === 0) {
-                    if (logging) logHHAuto("Need girls list, going to Waifu page to get them");
-                    if (!allowSideEffects) return 0;
-                    setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
-                    gotoPage(ConfigHelper.getHHScriptVars("pagesIDWaifu"));
-                    return -1;
-                }
+            // Rebuild the "troll with girls" snapshot from the current harem
+            // whenever the girl list is available, instead of caching it once for
+            // the whole browser-tab lifetime. The old code only built it when the
+            // cache was empty, so girls completed later were never reflected: a
+            // fully-farmed troll kept being selected and Love Raids never got a
+            // turn (issue #1780). getTrollWithGirls() returns a non-empty array
+            // only when the girl list is loaded; otherwise fall back to the cached
+            // snapshot, or fetch the list from the Waifu page.
+            const freshTrollWithGirls = Troll.getTrollWithGirls();
+            if (freshTrollWithGirls.length > 0) {
+                trollWithGirls = freshTrollWithGirls;
                 if (allowSideEffects) setStoredValue(HHStoredVarPrefixKey+TK.trollWithGirls, JSON.stringify(trollWithGirls));
+            } else if (trollWithGirls === undefined || trollWithGirls.length === 0) {
+                if (logging) logHHAuto("Need girls list, going to Waifu page to get them");
+                if (!allowSideEffects) return 0;
+                setStoredValue(HHStoredVarPrefixKey + TK.autoLoop, "false");
+                gotoPage(ConfigHelper.getHHScriptVars("pagesIDWaifu"));
+                return -1;
             }
 
             if (trollWithGirls !== undefined && trollWithGirls.length > 0) {


### PR DESCRIPTION
## Summary

Reported in #1780. With the troll target set to **First troll with girl** / **Last troll with girl**, the bot kept fighting a troll whose girls were already finished, and Love Raids never got a turn.

`getTrollIdToFight` built the `trollWithGirls` snapshot only when the cache was empty and then kept it for the whole browser-tab lifetime (sessionStorage). Girls completed afterwards were never reflected, so a fully-farmed troll stayed flagged as "has girls", was selected every time, and the with-girl modes are evaluated before raids -- so raids were starved. This matches the maintainer's diagnosis in the issue thread (stale session snapshot).

## Fix

Rebuild the snapshot from the current harem whenever the girl list is available (`getTrollWithGirls()` returns a non-empty array only then). Fall back to the cached snapshot, or the Waifu-page fetch, only when the list is not loaded -- so no new Waifu redirect loops.

Regression tests added:
- a stale cache is overridden by the fresh harem state (finished troll -> no target -> raids get their turn);
- the freshly rebuilt snapshot drives the "last troll with girl" selection.

## Verification

- `npm run typecheck` clean
- `npm run build` succeeds, `HHAuto.user.js` regenerated (v8.5.4)
- `npm test`: 87 suites / 1225 tests pass (2 new)